### PR TITLE
Feature trim export

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @okike
+* @okikeSolutions

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "swift"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "main"
+    labels:
+      - "dependencies"
+      - "security"
+    assignees:
+      - "okikeSolutions"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,50 +1,72 @@
-# Agent instructions — Guerilla Glass
+# Repository Guidelines
 
-This project is an open-source macOS app that records displays/windows (including iOS Simulator) with optional system audio and microphone, plus cursor/click metadata when permitted, and exports “beautiful by default” videos with automatic motion design (auto-zoom, cursor smoothing, motion blur, background framing, vertical exports).
-
-**Full product and technical spec:** `docs/SPEC.md`
-
----
-
-## Platform & stack
-
-- **macOS baseline (v1):** 13.0+ (stretch: validate 12.3+ video-only)
-- **Language/UI:** Swift + SwiftUI
-- **Capture:** ScreenCaptureKit (video + system audio where supported), AVFoundation (microphone)
-- **Encoding/muxing:** AVFoundation
-- **Rendering:** Metal preferred, Core Image acceptable for MVP
+- **Spec:** `docs/SPEC.md` — source of truth for product, architecture, project format, and verification links.
+- **Licensing:** MIT or Apache-2.0 (see spec §19); third-party in `THIRD_PARTY_NOTICES.md`.
+- GitHub issues/comments/PR comments: use literal multiline strings or `-F - <<'EOF'` (or `$'...'`) for real newlines; never embed `"\\n"`.
 
 ---
 
-## Architecture modules
+## Project Structure & Module Organization
 
-1. **Capture** — CaptureEngine, DisplayCapture, WindowCapture, AudioCapture, CaptureClock
-2. **InputTracking** — InputPermissionManager, CursorTracker, ClickTracker (permission-gated)
-3. **Project** — Project, ProjectStore, ProjectMigration, Schema
-4. **Automation** — VirtualCameraPlanner, AttentionModel, ZoomConstraints
-5. **Rendering** — PreviewRenderer, ExportRenderer, Metal
-6. **Export** — ExportPipeline, Presets, AssetWriter
-7. **Diagnostics** — PerformanceMetrics
+- **App entry:** `app/` — `GuerillaglassApp.swift`, `AppDelegate.swift`, `Info.plist`, `Entitlements.entitlements`.
+- **UI:** `ui/` — `RootView.swift` and extensions (`RootView+Sidebar`, `RootView+Navigator`, `RootView+Inspector`, etc.), `editor/`, shared components.
+- **Capture:** `capture/` — CaptureEngine, DisplayCapture, WindowCapture, AudioCapture, CaptureClock.
+- **Input tracking:** `inputTracking/` — InputPermissionManager, CursorTracker, ClickTracker (permission-gated).
+- **Project:** `project/` — Project, ProjectStore, ProjectMigration, Schema.
+- **Automation:** `automation/` — VirtualCameraPlanner, AttentionModel, ZoomConstraints.
+- **Rendering:** `rendering/` — PreviewRenderer, ExportRenderer, Metal.
+- **Export:** `export/` — ExportPipeline, Presets, AssetWriter, TrimRangeCalculator.
+- **Diagnostics:** `diagnostics/` — PerformanceMetrics.
+- **Tests:** `Tests/` — `automationTests/`, `captureTests/`, `exportTests/`, `projectMigrationTests/`, `renderingDeterminismTests/`.
+- **Scripts:** `Scripts/` — `full_gate.sh`, `compile_and_run.sh`, `launch.sh`, `package_app.sh`.
+- **Docs:** `docs/` — SPEC and other project docs.
+
+When adding modules or moving code, keep the spec’s architecture (§16–17) and update `AGENTS.md` / `docs/SPEC.md` if the tree changes.
 
 ---
 
-## Project structure (from spec)
+## Build, Test, and Development Commands
 
-Code lives under `app/`, `ui/`, `capture/`, `inputTracking/`, `project/`, `automation/`, `rendering/`, `export/`, `diagnostics/`. Tests under `Tests/` with subdirs `automationTests/`, `projectMigrationTests/`, `renderingDeterminismTests/`. See `docs/SPEC.md` §17 for the full tree.
+- **Full gate (format, lint, test, build):** `Scripts/full_gate.sh`  
+  Runs: SwiftFormat → SwiftLint → `swift test` → `swift build`. Use this to verify the project after changes.
+- **Build:** `swift build`
+- **Test:** `swift test`
+- **Format:** `swiftformat .` (config: `.swiftformat`)
+- **Lint:** `swiftlint` (config: `.swiftlint.yml`)
+- **Run app:** use `Scripts/compile_and_run.sh` or `Scripts/launch.sh` as documented.
+- **Package app:** `Scripts/package_app.sh` (defaults to current arch).
 
 ---
 
-## Conventions to follow
+## Agent Task Verification
+
+**After every task completed, run `Scripts/full_gate.sh` to verify that what the agent built is actually working.**
+
+Do not consider a task done until the full gate passes. If it fails, fix the issues (format, lint, tests, or build) and run the gate again before reporting completion.
+
+---
+
+## Platform & Stack
+
+- **macOS baseline (v1):** 13.0+ (stretch: validate 12.3+ video-only).
+- **Language/UI:** Swift + SwiftUI.
+- **Capture:** ScreenCaptureKit (video + system audio where supported), AVFoundation (microphone).
+- **Encoding/muxing:** AVFoundation.
+- **Rendering:** Metal preferred, Core Image acceptable for MVP.
+
+---
+
+## Conventions to Follow
 
 - **Native macOS:** Follow Apple HIG; system typography (SF), standard controls, document-based workflow. Respect Reduce Motion, Increase Contrast, Reduce Transparency.
-- **Determinism:** Pre-encode frame buffers must be deterministic (same project + version + settings + hardware class ⇒ pixel-identical frames). Encoding bytes are not guaranteed identical. Tests hash pre-encode frames.
+- **Determinism:** Pre-encode frame buffers must be deterministic (same project + version + settings + hardware class ⇒ pixel-identical frames). Encoding bytes are not guaranteed identical. Tests hash pre-encode frames; update rendering determinism tests when changing the pipeline.
 - **Permissions:** Screen Recording required; Microphone and Input Monitoring only when those features are enabled. If Input Monitoring is denied, recording continues but auto-zoom/click highlights are disabled—UI must show degraded mode clearly.
 - **Versioning:** Project schema always migrates forward on load; never write older schema versions.
 - **Mezzanine (v1):** H.264 mezzanine, high bitrate, short GOP / frequent keyframes.
 
 ---
 
-## Phased delivery context
+## Phased Delivery Context
 
 - **Phase 1:** Display/window capture, mic audio, trim + export, project save/load + versioning.
 - **Phase 2:** Input Monitoring–gated event tracking, auto-zoom, background framing, vertical export with re-planned camera.
@@ -54,15 +76,34 @@ When adding features, align with the current phase and the capability matrix in 
 
 ---
 
-## Testing & quality
+## Testing Guidelines
 
-- Determinism validated by hashing pre-encode frames; update rendering determinism tests when changing the pipeline.
+- Determinism validated by hashing pre-encode frames; update `Tests/renderingDeterminismTests/` when changing the pipeline.
 - Baseline targets (Apple Silicon M1/M2): capture dropped frames ≤ 0.5%, avg CPU ≤ 20%; export ≤ 1.5× realtime for 1080p/60.
 - Tag issues/PRs appropriately: `bug`, `feature`, `good first issue`, `help wanted`, `design`, `performance`.
+- Run `Scripts/full_gate.sh` before pushing when you touch logic; CI runs the same gate (see `.github/workflows/full_gate.yml`).
+- Pure test additions/fixes generally do **not** need a changelog entry unless they alter user-facing behavior.
 
 ---
 
-## References
+## Commit & Pull Request Guidelines
 
-- **Spec:** `docs/SPEC.md` — source of truth for requirements, project format, auto-zoom constraints, presets, and verification links.
-- **Licensing:** MIT or Apache-2.0 (see spec §19); third-party in `THIRD_PARTY_NOTICES.md`.
+- Prefer concise, action-oriented commit messages (e.g. `Capture: add keyframe interval to mezzanine`, `UI: respect Reduce Motion in preview`).
+- Group related changes; avoid bundling unrelated refactors.
+- PRs should summarize scope, note testing performed (including full gate), and mention any user-facing changes.
+- Before merging: run `Scripts/full_gate.sh` locally; ensure CI passes.
+- Changelog: keep latest released version at top; add entries for user-facing changes and reference issues/PRs as in `CONTRIBUTING.md`.
+
+---
+
+## Agent-Specific Notes
+
+- **Vocabulary:** “Guerilla Glass” / “Guerillaglass” for the product; `guerillaglass` for bundle/binary/paths as used in the project.
+- Never edit generated or vendored artifacts outside the documented workflows; prefer project scripts and configs.
+- When working on a GitHub Issue or PR, print the full URL at the end of the task.
+- When answering questions, respond with high-confidence answers only; verify in code when possible.
+- **Full gate:** After every completed task, run `Scripts/full_gate.sh` to verify the build and tests; do not report task completion until the gate passes.
+- Lint/format churn: if changes are formatting-only, auto-resolve without asking; only ask when changes are semantic (logic/data/behavior).
+- Focus reports on your edits; when multiple agents touch the same area, continue if safe and note “other files present” only if relevant.
+- Bug investigations: read relevant source and dependencies before concluding; aim for high-confidence root cause.
+- Do not change version numbers or release artifacts without explicit approval; see `CONTRIBUTING.md` and the spec for release steps.

--- a/Package.swift
+++ b/Package.swift
@@ -81,6 +81,11 @@ let package = Package(
             name: "CaptureTests",
             dependencies: ["Capture"],
             path: "Tests/captureTests"
+        ),
+        .testTarget(
+            name: "ExportTests",
+            dependencies: ["Export"],
+            path: "Tests/exportTests"
         )
     ]
 )

--- a/Scripts/full_gate.sh
+++ b/Scripts/full_gate.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Run SwiftFormat
 echo "==> swiftformat"
 swiftformat .
 
+# Run SwiftLint
 echo "==> swiftlint"
 swiftlint
 
+# Run SwiftTest
+echo "==> swift test"
+swift test
+
+# Build the project
 echo "==> swift build"
 swift build
 

--- a/Tests/exportTests/TrimRangeCalculatorTests.swift
+++ b/Tests/exportTests/TrimRangeCalculatorTests.swift
@@ -1,0 +1,32 @@
+import AVFoundation
+@testable import Export
+import XCTest
+
+final class TrimRangeCalculatorTests: XCTestCase {
+    func testClampedDefaultsEndToDurationWhenZero() {
+        let result = TrimRangeCalculator.clamped(start: 2, end: 0, duration: 10)
+        XCTAssertEqual(result, TrimRangeValues(start: 2, end: 10))
+    }
+
+    func testClampedMovesEndForwardWhenBeforeStart() {
+        let result = TrimRangeCalculator.clamped(start: 8, end: 4, duration: 10)
+        XCTAssertEqual(result, TrimRangeValues(start: 8, end: 8))
+    }
+
+    func testTimeRangeReturnsNilWhenEndBeforeStart() {
+        let range = TrimRangeCalculator.timeRange(start: 6, end: 2, duration: 10)
+        XCTAssertNil(range)
+    }
+
+    func testTimeRangeUsesDurationWhenEndExceeds() {
+        let range = TrimRangeCalculator.timeRange(start: 1.5, end: 99, duration: 10)
+        XCTAssertNotNil(range)
+        XCTAssertEqual(range?.start.seconds ?? 0, 1.5, accuracy: 0.001)
+        XCTAssertEqual(range?.duration.seconds ?? 0, 8.5, accuracy: 0.001)
+    }
+
+    func testTimeRangeNilWhenDurationIsZero() {
+        let range = TrimRangeCalculator.timeRange(start: 0, end: 0, duration: 0)
+        XCTAssertNil(range)
+    }
+}

--- a/app/Resources/Localizable.xcstrings
+++ b/app/Resources/Localizable.xcstrings
@@ -161,6 +161,118 @@
         }
       }
     },
+    "Stop Preview": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Vorschau stoppen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop Preview"
+          }
+        }
+      }
+    },
+    "Record": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnehmen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Record"
+          }
+        }
+      }
+    },
+    "Stop": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stopp"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Stop"
+          }
+        }
+      }
+    },
+    "Frame": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frame"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Frame"
+          }
+        }
+      }
+    },
+    "In Frame": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start-Frame"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In Frame"
+          }
+        }
+      }
+    },
+    "Out Frame": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "End-Frame"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Out Frame"
+          }
+        }
+      }
+    },
+    "Playhead Frame": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abspielkopf-Frame"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playhead Frame"
+          }
+        }
+      }
+    },
     "Refresh": {
       "localizations": {
         "de": {
@@ -461,6 +573,278 @@
           "stringUnit": {
             "state": "translated",
             "value": "Trim Out"
+          }
+        }
+      }
+    },
+    "Timeline": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Zeitachse"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeline"
+          }
+        }
+      }
+    },
+    "Trim": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trimmen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trim"
+          }
+        }
+      }
+    },
+    "Trim controls are below the preview.": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trim-Steuerung befindet sich unter der Vorschau."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trim controls are below the preview."
+          }
+        }
+      }
+    },
+    "Recording Diagnostics": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme-Diagnose"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording Diagnostics"
+          }
+        }
+      }
+    },
+    "Capture running": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahme läuft"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture running"
+          }
+        }
+      }
+    },
+    "Recording duration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmedauer"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording duration"
+          }
+        }
+      }
+    },
+    "Playback duration": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wiedergabedauer"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Playback duration"
+          }
+        }
+      }
+    },
+    "Recording file": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aufnahmedatei"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording file"
+          }
+        }
+      }
+    },
+    "File exists": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Datei vorhanden"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File exists"
+          }
+        }
+      }
+    },
+    "File size": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dateigröße"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "File size"
+          }
+        }
+      }
+    },
+    "None": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Keine"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "None"
+          }
+        }
+      }
+    },
+    "Yes": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ja"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yes"
+          }
+        }
+      }
+    },
+    "No": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nein"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No"
+          }
+        }
+      }
+    },
+    "Set In at Playhead": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Start am Abspielkopf setzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set In at Playhead"
+          }
+        }
+      }
+    },
+    "Set Out at Playhead": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ende am Abspielkopf setzen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Set Out at Playhead"
+          }
+        }
+      }
+    },
+    "Play": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Abspielen"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Play"
+          }
+        }
+      }
+    },
+    "Pause": {
+      "localizations": {
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Pause"
           }
         }
       }

--- a/capture/CaptureEngine.swift
+++ b/capture/CaptureEngine.swift
@@ -34,6 +34,8 @@ public final class CaptureEngine: NSObject, ObservableObject {
         var isRecording: Bool = false
         var writer: AssetWriter?
         var outputURL: URL?
+        var videoBaseTime: CMTime?
+        var lastDurationUpdate: TimeInterval = 0
     }
 
     public func startDisplayCapture(enableMic: Bool = false) async throws {

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -352,7 +352,7 @@ Progress (current repo)
 - [x] Display capture preview (ScreenCaptureKit)
 - [x] Mic capture skeleton (permission + AVAudioEngine tap)
 - [x] Window capture UI + preview
-- [ ] Trim + export
+- [x] Trim + export
 - [ ] Project save/load + versioning
 - [x] Localization catalog exists and is wired into the app target
 - [ ] Post‑localization polish audit (UI/UX, performance, accessibility)

--- a/export/TrimRangeCalculator.swift
+++ b/export/TrimRangeCalculator.swift
@@ -1,0 +1,49 @@
+import AVFoundation
+import Foundation
+
+public struct TrimRangeValues: Equatable {
+    public let start: Double
+    public let end: Double
+
+    public init(start: Double, end: Double) {
+        self.start = start
+        self.end = end
+    }
+}
+
+public enum TrimRangeCalculator {
+    public static func clamped(
+        start: Double,
+        end: Double,
+        duration: Double
+    ) -> TrimRangeValues? {
+        guard duration > 0 else { return nil }
+        let clampedStart = min(max(0, start), duration)
+        var clampedEnd = end
+        if clampedEnd <= 0 || clampedEnd > duration {
+            clampedEnd = duration
+        }
+        clampedEnd = max(clampedEnd, clampedStart)
+        return TrimRangeValues(start: clampedStart, end: clampedEnd)
+    }
+
+    public static func timeRange(
+        start: Double,
+        end: Double,
+        duration: Double
+    ) -> CMTimeRange? {
+        guard duration > 0 else { return nil }
+        let clampedStart = min(max(0, start), duration)
+        var clampedEnd = end
+        if clampedEnd <= 0 || clampedEnd > duration {
+            clampedEnd = duration
+        }
+        if clampedEnd <= clampedStart {
+            return nil
+        }
+        return CMTimeRange(
+            start: CMTime(seconds: clampedStart, preferredTimescale: 600),
+            duration: CMTime(seconds: clampedEnd - clampedStart, preferredTimescale: 600)
+        )
+    }
+}

--- a/ui/RootView+Export.swift
+++ b/ui/RootView+Export.swift
@@ -13,7 +13,12 @@ extension RootView {
         exportStatus = nil
 
         do {
-            let trimRange = makeTrimRange(duration: captureEngine.recordingDuration)
+            let duration = playbackModel.duration > 0 ? playbackModel.duration : captureEngine.recordingDuration
+            let trimRange = TrimRangeCalculator.timeRange(
+                start: trimInSeconds,
+                end: trimOutSeconds,
+                duration: duration
+            )
             _ = try await exportPipeline.export(
                 recordingURL: recordingURL,
                 preset: selectedPreset,
@@ -39,22 +44,6 @@ extension RootView {
         let result = panel.runModal()
         guard result == .OK else { return nil }
         return panel.url
-    }
-
-    private func makeTrimRange(duration: Double) -> CMTimeRange? {
-        guard duration > 0 else { return nil }
-        let start = max(0, min(trimInSeconds, duration))
-        var end = trimOutSeconds
-        if end <= 0 || end > duration {
-            end = duration
-        }
-        if end <= start {
-            return nil
-        }
-        return CMTimeRange(
-            start: CMTime(seconds: start, preferredTimescale: 600),
-            duration: CMTime(seconds: end - start, preferredTimescale: 600)
-        )
     }
 
     private func fileType(for fileType: AVFileType) -> UTType {

--- a/ui/RootView.swift
+++ b/ui/RootView.swift
@@ -88,12 +88,6 @@ public struct RootView: View {
         .onChange(of: playbackModel.duration) { _ in
             clampTrimValues()
         }
-        .onChange(of: trimInSeconds) { _ in
-            clampTrimValues()
-        }
-        .onChange(of: trimOutSeconds) { _ in
-            clampTrimValues()
-        }
         .onChange(of: studioMode) { newValue in
             if newValue == .capture {
                 playbackModel.pause()

--- a/ui/editor/FilmstripThumbnailProvider.swift
+++ b/ui/editor/FilmstripThumbnailProvider.swift
@@ -1,0 +1,41 @@
+import AppKit
+import AVFoundation
+import Foundation
+
+final class FilmstripThumbnailProvider: ObservableObject {
+    @Published var thumbnails: [Int: NSImage] = [:]
+
+    private let queue = DispatchQueue(label: "gg.editor.filmstrip")
+    private var generator: AVAssetImageGenerator?
+    private var assetURL: URL?
+    private var maximumSize = CGSize(width: 160, height: 90)
+
+    func configure(url: URL, maximumSize: CGSize) {
+        if assetURL == url {
+            return
+        }
+        assetURL = url
+        self.maximumSize = maximumSize
+        thumbnails = [:]
+        let asset = AVAsset(url: url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = maximumSize
+        self.generator = generator
+    }
+
+    func requestThumbnail(frameIndex: Int, frameRate: Double) {
+        guard thumbnails[frameIndex] == nil else { return }
+        guard let generator, frameRate > 0 else { return }
+        queue.async { [weak self] in
+            guard let self else { return }
+            let seconds = Double(frameIndex) / frameRate
+            let time = CMTime(seconds: seconds, preferredTimescale: 600)
+            guard let cgImage = try? generator.copyCGImage(at: time, actualTime: nil) else { return }
+            let image = NSImage(cgImage: cgImage, size: .zero)
+            DispatchQueue.main.async {
+                self.thumbnails[frameIndex] = image
+            }
+        }
+    }
+}

--- a/ui/editor/PlayerView.swift
+++ b/ui/editor/PlayerView.swift
@@ -1,0 +1,18 @@
+import AVKit
+import SwiftUI
+
+struct PlayerView: NSViewRepresentable {
+    let player: AVPlayer
+
+    func makeNSView(context _: Context) -> AVPlayerView {
+        let view = AVPlayerView()
+        view.controlsStyle = .none
+        view.videoGravity = .resizeAspect
+        view.player = player
+        return view
+    }
+
+    func updateNSView(_ nsView: AVPlayerView, context _: Context) {
+        nsView.player = player
+    }
+}

--- a/ui/editor/RecordingPlaybackModel.swift
+++ b/ui/editor/RecordingPlaybackModel.swift
@@ -1,0 +1,147 @@
+import AVFoundation
+import Foundation
+
+final class RecordingPlaybackModel: ObservableObject {
+    @Published var duration: Double = 0
+    @Published var currentTime: Double = 0
+    @Published var isPlaying: Bool = false
+    @Published var frameRate: Double = 30
+    @Published var currentURL: URL?
+
+    let player = AVPlayer()
+
+    private var timeObserverToken: Any?
+    private var endObserver: NSObjectProtocol?
+    private var wasPlayingBeforeScrub = false
+    private var isScrubbing = false
+    private var loadToken = UUID()
+
+    init() {
+        player.actionAtItemEnd = .pause
+        addTimeObserver()
+    }
+
+    deinit {
+        removeTimeObserver()
+        removeEndObserver()
+    }
+
+    func load(url: URL?) {
+        loadToken = UUID()
+        player.pause()
+        isPlaying = false
+        currentTime = 0
+        duration = 0
+        currentURL = url
+        removeEndObserver()
+
+        guard let url else {
+            player.replaceCurrentItem(with: nil)
+            return
+        }
+
+        let asset = AVAsset(url: url)
+        let item = AVPlayerItem(asset: asset)
+        player.replaceCurrentItem(with: item)
+        let token = loadToken
+        endObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { [weak self] _ in
+            self?.isPlaying = false
+        }
+
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let loadedDuration = await (try? asset.load(.duration)) ?? .zero
+            let tracks = try? await asset.loadTracks(withMediaType: .video)
+            if let track = tracks?.first {
+                let nominal = await (try? track.load(.nominalFrameRate)) ?? 0
+                frameRate = nominal > 0 ? Double(nominal) : 30
+            } else {
+                frameRate = 30
+            }
+            guard loadToken == token else { return }
+            guard player.currentItem === item else { return }
+            if loadedDuration.isNumeric {
+                duration = loadedDuration.seconds
+            }
+            currentTime = 0
+            await player.seek(to: .zero, toleranceBefore: .zero, toleranceAfter: .zero)
+        }
+    }
+
+    func togglePlayPause() {
+        if isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            if duration > 0, currentTime >= max(0, duration - 0.05) {
+                seek(to: 0)
+            }
+            player.play()
+            isPlaying = true
+        }
+    }
+
+    func pause() {
+        player.pause()
+        isPlaying = false
+    }
+
+    func beginScrubbing() {
+        guard !isScrubbing else { return }
+        wasPlayingBeforeScrub = isPlaying
+        isScrubbing = true
+        player.pause()
+        isPlaying = false
+    }
+
+    func endScrubbing(at seconds: Double) {
+        seek(to: seconds)
+        isScrubbing = false
+        if wasPlayingBeforeScrub {
+            player.play()
+            isPlaying = true
+        }
+    }
+
+    func seek(to seconds: Double) {
+        let time = CMTime(seconds: max(0, seconds), preferredTimescale: 600)
+        player.currentItem?.cancelPendingSeeks()
+        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    func updateScrubbing(to seconds: Double) {
+        let clamped = max(0, seconds)
+        currentTime = clamped
+        seek(to: clamped)
+    }
+
+    private func addTimeObserver() {
+        let interval = CMTime(seconds: 0.1, preferredTimescale: 600)
+        timeObserverToken = player.addPeriodicTimeObserver(
+            forInterval: interval,
+            queue: .main
+        ) { [weak self] time in
+            guard let self else { return }
+            guard !isScrubbing else { return }
+            currentTime = max(0, time.seconds)
+        }
+    }
+
+    private func removeTimeObserver() {
+        if let timeObserverToken {
+            player.removeTimeObserver(timeObserverToken)
+            self.timeObserverToken = nil
+        }
+    }
+
+    private func removeEndObserver() {
+        if let endObserver {
+            NotificationCenter.default.removeObserver(endObserver)
+            self.endObserver = nil
+        }
+    }
+}

--- a/ui/editor/RecordingPlaybackView.swift
+++ b/ui/editor/RecordingPlaybackView.swift
@@ -1,0 +1,284 @@
+import AppKit
+import SwiftUI
+
+struct RecordingPlaybackView: View {
+    @ObservedObject var model: RecordingPlaybackModel
+    @Binding var trimInSeconds: Double
+    @Binding var trimOutSeconds: Double
+    @StateObject private var thumbnailProvider = FilmstripThumbnailProvider()
+
+    var body: some View {
+        VStack(spacing: 12) {
+            PlayerView(player: model.player)
+                .background(Color.black.opacity(0.12))
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(Color.black.opacity(0.08))
+                )
+
+            timelinePanel
+                .frame(minHeight: 120, idealHeight: 140, maxHeight: 180)
+        }
+        .padding(10)
+    }
+
+    private var frameRate: Double {
+        max(model.frameRate, 1)
+    }
+
+    private var frameStride: Int {
+        2
+    }
+
+    private var totalFrames: Int {
+        max(1, Int((model.duration * frameRate).rounded()))
+    }
+
+    private var currentFrame: Int {
+        frameIndex(from: model.currentTime)
+    }
+
+    private func frameIndex(from seconds: Double) -> Int {
+        Int((seconds * frameRate).rounded())
+    }
+
+    private func seconds(from frame: Int) -> Double {
+        Double(frame) / frameRate
+    }
+
+    private func snapFrame(_ frame: Int) -> Int {
+        let step = frameStride
+        return Int((Double(frame) / Double(step)).rounded()) * step
+    }
+
+    private var timelinePanel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(String(localized: "Timeline"))
+                .font(.headline)
+                .foregroundStyle(.secondary)
+
+            if let assetURL = model.currentURL, model.duration > 0 {
+                FilmstripTimelineView(
+                    assetURL: assetURL,
+                    duration: model.duration,
+                    frameRate: frameRate,
+                    frameStride: frameStride,
+                    trimInSeconds: trimInSeconds,
+                    trimOutSeconds: trimOutSeconds,
+                    currentTime: model.currentTime,
+                    thumbnailProvider: thumbnailProvider,
+                    onSeek: { seconds in
+                        model.updateScrubbing(to: seconds)
+                    },
+                    onBeginScrub: {
+                        model.beginScrubbing()
+                    },
+                    onEndScrub: {
+                        model.endScrubbing(at: model.currentTime)
+                    }
+                )
+            } else {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(Color.black.opacity(0.06))
+                    .frame(height: 60)
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    model.togglePlayPause()
+                } label: {
+                    Image(systemName: model.isPlaying ? "pause.fill" : "play.fill")
+                }
+                .buttonStyle(.bordered)
+                .accessibilityLabel(model.isPlaying ? Text("Pause") : Text("Play"))
+                .disabled(model.duration <= 0)
+
+                Slider(
+                    value: Binding(
+                        get: { Double(currentFrame) },
+                        set: { value in
+                            let frame = snapFrame(Int(value))
+                            model.updateScrubbing(to: seconds(from: frame))
+                        }
+                    ),
+                    in: 0 ... max(Double(totalFrames), 1),
+                    step: Double(frameStride),
+                    onEditingChanged: { isEditing in
+                        if isEditing {
+                            model.beginScrubbing()
+                        } else {
+                            model.endScrubbing(at: model.currentTime)
+                        }
+                    }
+                )
+                .disabled(model.duration <= 0)
+
+                Text("\(String(localized: "Frame")) \(currentFrame) / \(totalFrames)")
+                    .font(.system(.caption, design: .monospaced))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color.black.opacity(0.04))
+        )
+    }
+}
+
+private struct FilmstripTimelineView: View {
+    let assetURL: URL
+    let duration: Double
+    let frameRate: Double
+    let frameStride: Int
+    let trimInSeconds: Double
+    let trimOutSeconds: Double
+    let currentTime: Double
+    @ObservedObject var thumbnailProvider: FilmstripThumbnailProvider
+    let onSeek: (Double) -> Void
+    let onBeginScrub: () -> Void
+    let onEndScrub: () -> Void
+
+    private let cellWidth: CGFloat = 48
+    private let cellHeight: CGFloat = 54
+    private let spacing: CGFloat = 2
+
+    var body: some View {
+        let frames = frameIndices
+        let totalWidth = max(0, CGFloat(frames.count)) * (cellWidth + spacing) - spacing
+
+        ScrollView(.horizontal) {
+            ZStack(alignment: .leading) {
+                LazyHStack(spacing: spacing) {
+                    ForEach(frames, id: \.self) { frameIndex in
+                        thumbnailView(frameIndex: frameIndex)
+                            .onAppear {
+                                thumbnailProvider.requestThumbnail(
+                                    frameIndex: frameIndex,
+                                    frameRate: frameRate
+                                )
+                            }
+                    }
+                }
+
+                trimOverlay()
+                playheadOverlay()
+            }
+            .frame(width: totalWidth, height: cellHeight)
+            .padding(.vertical, 6)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        onBeginScrub()
+                        let seconds = seconds(at: value.location.x, totalWidth: totalWidth)
+                        onSeek(seconds)
+                    }
+                    .onEnded { value in
+                        let seconds = seconds(at: value.location.x, totalWidth: totalWidth)
+                        onSeek(seconds)
+                        onEndScrub()
+                    }
+            )
+        }
+        .frame(height: cellHeight + 12)
+        .onAppear {
+            thumbnailProvider.configure(
+                url: assetURL,
+                maximumSize: CGSize(width: cellWidth * 2, height: cellHeight * 2)
+            )
+        }
+        .onChange(of: assetURL) { newValue in
+            thumbnailProvider.configure(
+                url: newValue,
+                maximumSize: CGSize(width: cellWidth * 2, height: cellHeight * 2)
+            )
+        }
+    }
+
+    private var frameIndices: [Int] {
+        guard frameRate > 0, duration > 0 else { return [] }
+        let totalFrames = max(1, Int((duration * frameRate).rounded()))
+        return Array(stride(from: 0, through: totalFrames, by: frameStride))
+    }
+
+    private func frameIndex(from seconds: Double) -> Int {
+        Int((seconds * frameRate).rounded())
+    }
+
+    private func seconds(from frameIndex: Int) -> Double {
+        Double(frameIndex) / frameRate
+    }
+
+    private func slotIndex(for frameIndex: Int, maxIndex: Int) -> Int {
+        guard maxIndex > 0 else { return 0 }
+        return min(max(frameIndex / frameStride, 0), maxIndex)
+    }
+
+    private func position(for slotIndex: Int) -> CGFloat {
+        CGFloat(slotIndex) * (cellWidth + spacing)
+    }
+
+    private func seconds(at locationX: CGFloat, totalWidth: CGFloat) -> Double {
+        let clampedX = min(max(0, locationX), max(totalWidth, 1))
+        let slotWidth = cellWidth + spacing
+        let slot = Int((clampedX / slotWidth).rounded())
+        let frameIndex = slot * frameStride
+        return seconds(from: frameIndex)
+    }
+
+    private func thumbnailView(frameIndex: Int) -> some View {
+        ZStack {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.black.opacity(0.08))
+            if let image = thumbnailProvider.thumbnails[frameIndex] {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+                    .frame(width: cellWidth, height: cellHeight)
+                    .clipped()
+            }
+        }
+        .frame(width: cellWidth, height: cellHeight)
+        .overlay(
+            RoundedRectangle(cornerRadius: 4)
+                .strokeBorder(Color.black.opacity(0.1))
+        )
+    }
+
+    @ViewBuilder
+    private func trimOverlay() -> some View {
+        let frameCount = frameIndices.count
+        if frameCount > 0 {
+            let maxSlot = max(0, frameCount - 1)
+            let trimInFrame = frameIndex(from: trimInSeconds)
+            let trimOutFrame = frameIndex(from: trimOutSeconds)
+            let startSlot = slotIndex(for: trimInFrame, maxIndex: maxSlot)
+            let endSlot = max(startSlot, slotIndex(for: trimOutFrame, maxIndex: maxSlot))
+            let startX = position(for: startSlot)
+            let width = CGFloat(endSlot - startSlot + 1) * (cellWidth + spacing) - spacing
+
+            RoundedRectangle(cornerRadius: 4)
+                .fill(Color.accentColor.opacity(0.2))
+                .frame(width: width, height: cellHeight)
+                .offset(x: startX)
+        }
+    }
+
+    @ViewBuilder
+    private func playheadOverlay() -> some View {
+        let frameCount = frameIndices.count
+        if frameCount > 0 {
+            let maxSlot = max(0, frameCount - 1)
+            let playheadFrame = frameIndex(from: currentTime)
+            let slot = slotIndex(for: playheadFrame, maxIndex: maxSlot)
+            let playheadX = position(for: slot) + (cellWidth / 2)
+
+            Rectangle()
+                .fill(Color.accentColor)
+                .frame(width: 2, height: cellHeight)
+                .offset(x: playheadX)
+        }
+    }
+}


### PR DESCRIPTION
# Summary
- This PR implements the trim and export feature for Phase 1, adding a complete video playback editor with filmstrip timeline, trim controls, and export functionality.

## UI Changes

###  Capture Mode
<img width="1580" height="1017" alt="Bildschirmfoto 2026-01-30 um 19 18 17" src="https://github.com/user-attachments/assets/4f4956dd-756d-4493-8062-9f090a036038" />

### Edit Mode
<img width="1580" height="1017" alt="Bildschirmfoto 2026-01-30 um 19 18 36" src="https://github.com/user-attachments/assets/75add0db-b755-4ef4-8bd5-568903cb9a14" />


## Checklist
- [x] Ran `Scripts/full_gate.sh`
- [ ] Scoped to a single area (UI, capture, export, docs, tooling)
- [x] UI changes include screenshots

## Testing (optional)
- [x] swift test
