### PR TITLE
Phase2 autozoom planner

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,17 +44,17 @@ let package = Package(
         ),
         .target(
             name: "Automation",
-            dependencies: [],
+            dependencies: ["InputTracking"],
             path: "automation"
         ),
         .target(
             name: "Rendering",
-            dependencies: [],
+            dependencies: ["Automation"],
             path: "rendering"
         ),
         .target(
             name: "Export",
-            dependencies: [],
+            dependencies: ["Automation", "Rendering"],
             path: "export"
         ),
         .target(
@@ -64,7 +64,7 @@ let package = Package(
         ),
         .testTarget(
             name: "AutomationTests",
-            dependencies: ["Automation"],
+            dependencies: ["Automation", "InputTracking"],
             path: "Tests/automationTests"
         ),
         .testTarget(
@@ -89,7 +89,7 @@ let package = Package(
         ),
         .testTarget(
             name: "UITests",
-            dependencies: ["UI"],
+            dependencies: ["UI", "InputTracking", "Project"],
             path: "Tests/uiTests"
         )
     ]

--- a/Tests/automationTests/AutomationTests.swift
+++ b/Tests/automationTests/AutomationTests.swift
@@ -1,4 +1,6 @@
 @testable import Automation
+import CoreGraphics
+import InputTracking
 import XCTest
 
 final class AutomationTests: XCTestCase {
@@ -10,5 +12,79 @@ final class AutomationTests: XCTestCase {
         XCTAssertNotNil(planner)
         XCTAssertNotNil(model)
         XCTAssertNotNil(constraints)
+    }
+
+    func testAttentionModelDwellAndClickIntensity() {
+        let constraints = ZoomConstraints(
+            dwellDuration: 0.1,
+            dwellSpeedThreshold: 10,
+            velocitySmoothingAlpha: 1,
+            motionIntensity: 0.2,
+            dwellIntensity: 0.7,
+            clickIntensity: 1.0
+        )
+
+        let events: [InputEvent] = [
+            InputEvent(type: .cursorMoved, timestamp: 0.2, position: CGPoint(x: 100, y: 100)),
+            InputEvent(type: .cursorMoved, timestamp: 0.0, position: CGPoint(x: 100, y: 100)),
+            InputEvent(type: .mouseDown, timestamp: 0.25, position: CGPoint(x: 100, y: 100))
+        ]
+
+        let samples = AttentionModel().samples(from: events, constraints: constraints)
+
+        XCTAssertEqual(samples.map(\.time), samples.map(\.time).sorted())
+
+        guard let dwellSample = samples.first(where: { $0.time == 0.2 }) else {
+            XCTFail("Missing dwell sample at 0.2s")
+            return
+        }
+        XCTAssertEqual(dwellSample.isDwell, true)
+        XCTAssertEqual(dwellSample.intensity, constraints.dwellIntensity, accuracy: 0.0001)
+
+        guard let clickSample = samples.first(where: { $0.isClick }) else {
+            XCTFail("Missing click sample")
+            return
+        }
+        XCTAssertEqual(clickSample.intensity, constraints.clickIntensity, accuracy: 0.0001)
+    }
+
+    func testPlannerClampsZoomAndDuration() {
+        let planner = VirtualCameraPlanner()
+        let constraints = ZoomConstraints(
+            maxZoom: 3.0,
+            minVisibleAreaFraction: 0.5,
+            baseZoom: 1.0
+        )
+        let sourceSize = CGSize(width: 1920, height: 1080)
+        let events = [
+            InputEvent(type: .mouseDown, timestamp: 1.0, position: CGPoint(x: 1800, y: 900))
+        ]
+
+        let plan = planner.plan(
+            events: events,
+            sourceSize: sourceSize,
+            duration: 2.0,
+            constraints: constraints
+        )
+
+        XCTAssertEqual(plan.duration, 2.0, accuracy: 0.0001)
+        guard let firstKeyframe = plan.keyframes.first, let lastKeyframe = plan.keyframes.last else {
+            XCTFail("Expected keyframes in plan")
+            return
+        }
+        XCTAssertEqual(firstKeyframe.time, 0.0, accuracy: 0.0001)
+        XCTAssertEqual(lastKeyframe.time, 2.0, accuracy: 0.0001)
+
+        let allowedMaxZoom = constraints.clampedZoom(constraints.maxZoom)
+        for keyframe in plan.keyframes {
+            XCTAssertLessThanOrEqual(keyframe.zoom, allowedMaxZoom + 0.0001)
+            let clampedCenter = constraints.clampedCenter(
+                keyframe.center,
+                in: sourceSize,
+                zoom: keyframe.zoom
+            )
+            XCTAssertEqual(keyframe.center.x, clampedCenter.x, accuracy: 0.0001)
+            XCTAssertEqual(keyframe.center.y, clampedCenter.y, accuracy: 0.0001)
+        }
     }
 }

--- a/Tests/projectMigrationTests/ProjectMigrationTests.swift
+++ b/Tests/projectMigrationTests/ProjectMigrationTests.swift
@@ -10,6 +10,60 @@ final class ProjectMigrationTests: XCTestCase {
         XCTAssertEqual(data, migrated)
     }
 
+    func testMigrationUpgradesV1Document() throws {
+        struct ProjectV1: Codable {
+            let id: UUID
+            let createdAt: Date
+        }
+
+        struct ProjectDocumentV1: Codable {
+            let projectVersion: Int
+            let project: ProjectV1
+            let recordingFileName: String
+            let systemAudioFileName: String?
+            let micAudioFileName: String?
+            let eventsFileName: String?
+        }
+
+        let encoder = ProjectStore.makeDefaultEncoder()
+        let projectV1 = ProjectV1(id: UUID(), createdAt: Date())
+        let documentV1 = ProjectDocumentV1(
+            projectVersion: 1,
+            project: projectV1,
+            recordingFileName: ProjectFile.recordingMov,
+            systemAudioFileName: nil,
+            micAudioFileName: nil,
+            eventsFileName: nil
+        )
+        let data = try encoder.encode(documentV1)
+
+        let migrated = try ProjectMigration.migrateIfNeeded(data)
+        let decoder = ProjectStore.makeDefaultDecoder()
+        let decoded = try decoder.decode(ProjectDocument.self, from: migrated)
+
+        XCTAssertEqual(decoded.projectVersion, ProjectSchemaVersion.current)
+        XCTAssertEqual(decoded.project.id, projectV1.id)
+        XCTAssertEqual(decoded.project.autoZoom, AutoZoomSettings())
+        XCTAssertNil(decoded.project.captureMetadata)
+    }
+
+    func testMigrationUpgradesV2Document() throws {
+        var document = ProjectDocument()
+        document.projectVersion = 2
+        document.project.autoZoom = AutoZoomSettings(isEnabled: false, intensity: 0.5)
+
+        let encoder = ProjectStore.makeDefaultEncoder()
+        let data = try encoder.encode(document)
+
+        let migrated = try ProjectMigration.migrateIfNeeded(data)
+        let decoder = ProjectStore.makeDefaultDecoder()
+        let decoded = try decoder.decode(ProjectDocument.self, from: migrated)
+
+        XCTAssertEqual(decoded.projectVersion, ProjectSchemaVersion.current)
+        XCTAssertEqual(decoded.project.autoZoom, document.project.autoZoom)
+        XCTAssertNil(decoded.project.captureMetadata)
+    }
+
     func testMigrationRejectsMissingVersion() throws {
         let encoder = ProjectStore.makeDefaultEncoder()
         let project = Project()

--- a/Tests/uiTests/AutoZoomPlanSupportTests.swift
+++ b/Tests/uiTests/AutoZoomPlanSupportTests.swift
@@ -1,0 +1,88 @@
+import CoreGraphics
+import InputTracking
+import Project
+@testable import UI
+import XCTest
+
+final class AutoZoomPlanSupportTests: XCTestCase {
+    func testMapEventsToCaptureSpaceUsesContentRectAndPixelScale() {
+        let metadata = CaptureMetadata(
+            source: .window,
+            contentRect: CaptureRect(originX: 100, originY: 200, width: 400, height: 300),
+            pixelScale: 2
+        )
+        let sourceSize = CGSize(width: 800, height: 600)
+        let events = [
+            makeEvent(xValue: 100, yValue: 500, time: 0),
+            makeEvent(xValue: 300, yValue: 350, time: 0.5),
+            makeEvent(xValue: 500, yValue: 200, time: 1.0)
+        ]
+
+        let mapped = AutoZoomPlanSupport.mapEventsToCaptureSpace(
+            events,
+            metadata: metadata,
+            sourceSize: sourceSize
+        )
+
+        XCTAssertEqual(mapped.count, events.count)
+        assertPoint(mapped[0].position.cgPoint, equals: CGPoint(x: 0, y: 0))
+        assertPoint(mapped[1].position.cgPoint, equals: CGPoint(x: 400, y: 300))
+        assertPoint(mapped[2].position.cgPoint, equals: CGPoint(x: 800, y: 600))
+    }
+
+    func testCacheKeyIsStableAcrossSmallDurationAndSizeDifferences() {
+        let settings = AutoZoomSettings(isEnabled: true, intensity: 0.5, minimumKeyframeInterval: 1.0 / 30.0)
+        let events = [makeEvent(xValue: 10, yValue: 20, time: 0)]
+
+        let keyA = AutoZoomPlanSupport.makeCacheKey(
+            events: events,
+            settings: settings,
+            duration: 5.0004,
+            sourceSize: CGSize(width: 1920.004, height: 1080.004)
+        )
+        let keyB = AutoZoomPlanSupport.makeCacheKey(
+            events: events,
+            settings: settings,
+            duration: 5.00049,
+            sourceSize: CGSize(width: 1920.0049, height: 1080.0049)
+        )
+
+        XCTAssertEqual(keyA, keyB)
+    }
+
+    func testCacheKeyChangesWhenEventsOrSettingsChange() {
+        let settings = AutoZoomSettings(isEnabled: true, intensity: 0.5, minimumKeyframeInterval: 1.0 / 30.0)
+        let sourceSize = CGSize(width: 1920, height: 1080)
+
+        let keyA = AutoZoomPlanSupport.makeCacheKey(
+            events: [makeEvent(xValue: 10, yValue: 20, time: 0)],
+            settings: settings,
+            duration: 5.0,
+            sourceSize: sourceSize
+        )
+        let keyB = AutoZoomPlanSupport.makeCacheKey(
+            events: [makeEvent(xValue: 12, yValue: 20, time: 0)],
+            settings: settings,
+            duration: 5.0,
+            sourceSize: sourceSize
+        )
+        let keyC = AutoZoomPlanSupport.makeCacheKey(
+            events: [makeEvent(xValue: 10, yValue: 20, time: 0)],
+            settings: AutoZoomSettings(isEnabled: true, intensity: 0.6, minimumKeyframeInterval: 1.0 / 30.0),
+            duration: 5.0,
+            sourceSize: sourceSize
+        )
+
+        XCTAssertNotEqual(keyA, keyB)
+        XCTAssertNotEqual(keyA, keyC)
+    }
+
+    private func makeEvent(xValue: Double, yValue: Double, time: TimeInterval) -> InputEvent {
+        InputEvent(type: .cursorMoved, timestamp: time, position: CGPoint(x: xValue, y: yValue))
+    }
+
+    private func assertPoint(_ actual: CGPoint, equals expected: CGPoint, accuracy: CGFloat = 0.001) {
+        XCTAssertEqual(actual.x, expected.x, accuracy: accuracy)
+        XCTAssertEqual(actual.y, expected.y, accuracy: accuracy)
+    }
+}

--- a/automation/AttentionModel.swift
+++ b/automation/AttentionModel.swift
@@ -1,5 +1,138 @@
+import CoreGraphics
 import Foundation
+import InputTracking
+
+public struct AttentionSample: Equatable {
+    public let time: TimeInterval
+    public let position: CGPoint
+    public let intensity: Double
+    public let isDwell: Bool
+    public let isClick: Bool
+}
 
 public struct AttentionModel {
     public init() {}
+
+    public func samples(from events: [InputEvent], constraints: ZoomConstraints) -> [AttentionSample] {
+        let orderedEvents = stableSort(events)
+        guard !orderedEvents.isEmpty else { return [] }
+
+        var samples: [AttentionSample] = []
+        samples.reserveCapacity(orderedEvents.count)
+
+        var previousMove: InputEvent?
+        var smoothedSpeed: Double = 0
+        var dwellStart: TimeInterval?
+        var isDwell = false
+
+        for event in orderedEvents {
+            let isClick = event.type == .mouseDown || event.type == .mouseUp
+            if event.type == .cursorMoved {
+                if let previous = previousMove {
+                    let deltaTime = max(event.timestamp - previous.timestamp, 0.0001)
+                    let distance = distanceBetween(previous.position.cgPoint, event.position.cgPoint)
+                    let speed = distance / deltaTime
+                    let alpha = Double(max(0, min(constraints.velocitySmoothingAlpha, 1.0)))
+                    smoothedSpeed = alpha * speed + (1 - alpha) * smoothedSpeed
+                }
+                previousMove = event
+
+                let threshold = Double(max(0.01, constraints.dwellSpeedThreshold))
+                if smoothedSpeed < threshold {
+                    dwellStart = dwellStart ?? event.timestamp
+                    if let start = dwellStart, event.timestamp - start >= constraints.dwellDuration {
+                        isDwell = true
+                    }
+                } else {
+                    dwellStart = nil
+                    isDwell = false
+                }
+            }
+
+            let intensity = clampIntensity(
+                isClick: isClick,
+                isDwell: isDwell,
+                constraints: constraints
+            )
+
+            samples.append(
+                AttentionSample(
+                    time: event.timestamp,
+                    position: event.position.cgPoint,
+                    intensity: intensity,
+                    isDwell: isDwell,
+                    isClick: isClick
+                )
+            )
+        }
+
+        return coalesceSamples(samples)
+    }
+}
+
+private func coalesceSamples(_ samples: [AttentionSample]) -> [AttentionSample] {
+    guard let first = samples.first else { return [] }
+    var result: [AttentionSample] = []
+    result.reserveCapacity(samples.count)
+
+    var current = first
+    for sample in samples.dropFirst() {
+        if sample.time == current.time {
+            current = mergeSamples(current, sample)
+        } else {
+            result.append(current)
+            current = sample
+        }
+    }
+    result.append(current)
+    return result
+}
+
+private func mergeSamples(_ first: AttentionSample, _ second: AttentionSample) -> AttentionSample {
+    let firstPriority = samplePriority(first)
+    let secondPriority = samplePriority(second)
+    if secondPriority > firstPriority {
+        return second
+    }
+    if secondPriority == firstPriority {
+        if second.intensity > first.intensity {
+            return second
+        }
+        if second.intensity == first.intensity {
+            return second
+        }
+    }
+    return first
+}
+
+private func samplePriority(_ sample: AttentionSample) -> Int {
+    if sample.isClick { return 2 }
+    if sample.isDwell { return 1 }
+    return 0
+}
+
+private func stableSort(_ events: [InputEvent]) -> [InputEvent] {
+    events.enumerated().sorted { left, right in
+        if left.element.timestamp == right.element.timestamp {
+            return left.offset < right.offset
+        }
+        return left.element.timestamp < right.element.timestamp
+    }.map(\.element)
+}
+
+private func distanceBetween(_ start: CGPoint, _ end: CGPoint) -> Double {
+    let deltaX = Double(start.x - end.x)
+    let deltaY = Double(start.y - end.y)
+    return (deltaX * deltaX + deltaY * deltaY).squareRoot()
+}
+
+private func clampIntensity(isClick: Bool, isDwell: Bool, constraints: ZoomConstraints) -> Double {
+    let intensity: Double = if isClick {
+        constraints.clickIntensity
+    } else if isDwell {
+        constraints.dwellIntensity
+    } else {
+        constraints.motionIntensity
+    }
+    return min(max(intensity, 0), 1)
 }

--- a/automation/VirtualCameraPlanner.swift
+++ b/automation/VirtualCameraPlanner.swift
@@ -1,5 +1,314 @@
+import CoreGraphics
 import Foundation
+import InputTracking
+
+public struct CameraKeyframe: Equatable {
+    public let time: TimeInterval
+    public let center: CGPoint
+    public let zoom: CGFloat
+
+    public init(time: TimeInterval, center: CGPoint, zoom: CGFloat) {
+        self.time = time
+        self.center = center
+        self.zoom = zoom
+    }
+}
+
+public struct CameraPlan: Equatable {
+    public let sourceSize: CGSize
+    public let keyframes: [CameraKeyframe]
+    public let duration: TimeInterval
+
+    public init(sourceSize: CGSize, keyframes: [CameraKeyframe], duration: TimeInterval) {
+        self.sourceSize = sourceSize
+        self.keyframes = keyframes
+        self.duration = duration
+    }
+}
 
 public final class VirtualCameraPlanner {
-    public init() {}
+    private let attentionModel: AttentionModel
+
+    public init(attentionModel: AttentionModel = AttentionModel()) {
+        self.attentionModel = attentionModel
+    }
+
+    public func plan(
+        events: [InputEvent],
+        sourceSize: CGSize,
+        duration: TimeInterval,
+        constraints: ZoomConstraints = ZoomConstraints()
+    ) -> CameraPlan {
+        let sanitizedDuration = max(duration, events.map(\.timestamp).max() ?? 0)
+        let samples = attentionModel.samples(from: events, constraints: constraints)
+
+        if samples.isEmpty {
+            let center = CGPoint(x: sourceSize.width / 2, y: sourceSize.height / 2)
+            let zoom = constraints.clampedZoom(constraints.idleZoom)
+            let keyframes = makeIdleKeyframes(center: center, zoom: zoom, duration: sanitizedDuration)
+            return CameraPlan(sourceSize: sourceSize, keyframes: keyframes, duration: sanitizedDuration)
+        }
+
+        let targets = makeAnchoredTargets(
+            from: samples,
+            sourceSize: sourceSize,
+            duration: sanitizedDuration,
+            constraints: constraints
+        )
+        let reducedTargets = reduceTargets(
+            targets,
+            minimumInterval: max(0, constraints.minimumKeyframeInterval)
+        )
+
+        let rawKeyframes = reducedTargets.map { target in
+            makeKeyframe(for: target, sourceSize: sourceSize, constraints: constraints)
+        }
+
+        let constrainedKeyframes = applyPanConstraints(
+            to: rawKeyframes,
+            sourceSize: sourceSize,
+            constraints: constraints
+        )
+
+        return CameraPlan(sourceSize: sourceSize, keyframes: constrainedKeyframes, duration: sanitizedDuration)
+    }
+}
+
+private struct FocusTarget {
+    let time: TimeInterval
+    let position: CGPoint
+    let intensity: Double
+    let isClick: Bool
+    let isDwell: Bool
+    let isAnchor: Bool
+
+    func withAnchor() -> FocusTarget {
+        FocusTarget(
+            time: time,
+            position: position,
+            intensity: intensity,
+            isClick: isClick,
+            isDwell: isDwell,
+            isAnchor: true
+        )
+    }
+}
+
+private func makeAnchoredTargets(
+    from samples: [AttentionSample],
+    sourceSize: CGSize,
+    duration: TimeInterval,
+    constraints: ZoomConstraints
+) -> [FocusTarget] {
+    var targets = samples.map { sample in
+        FocusTarget(
+            time: sample.time,
+            position: sample.position,
+            intensity: sample.intensity,
+            isClick: sample.isClick,
+            isDwell: sample.isDwell,
+            isAnchor: false
+        )
+    }
+
+    guard !targets.isEmpty else { return [] }
+
+    let midpoint = CGPoint(x: sourceSize.width / 2, y: sourceSize.height / 2)
+    let minimumInterval = max(0, constraints.minimumKeyframeInterval)
+
+    if let first = targets.first {
+        if first.time == 0 {
+            targets[0] = first.withAnchor()
+        } else {
+            let useFirst = first.time <= minimumInterval
+            let anchor = FocusTarget(
+                time: 0,
+                position: useFirst ? first.position : midpoint,
+                intensity: useFirst ? first.intensity : 0,
+                isClick: useFirst ? first.isClick : false,
+                isDwell: useFirst ? first.isDwell : false,
+                isAnchor: true
+            )
+            targets.insert(anchor, at: 0)
+        }
+    }
+
+    if let last = targets.last {
+        if last.time == duration {
+            targets[targets.count - 1] = last.withAnchor()
+        } else {
+            let useLast = duration - last.time <= minimumInterval
+            let anchor = FocusTarget(
+                time: duration,
+                position: last.position,
+                intensity: last.intensity,
+                isClick: useLast ? last.isClick : false,
+                isDwell: useLast ? last.isDwell : false,
+                isAnchor: true
+            )
+            targets.append(anchor)
+        }
+    }
+
+    return targets
+}
+
+private func makeIdleKeyframes(center: CGPoint, zoom: CGFloat, duration: TimeInterval) -> [CameraKeyframe] {
+    let start = CameraKeyframe(time: 0, center: center, zoom: zoom)
+    guard duration > 0 else { return [start] }
+    let end = CameraKeyframe(time: duration, center: center, zoom: zoom)
+    return [start, end]
+}
+
+private func makeKeyframe(
+    for target: FocusTarget,
+    sourceSize: CGSize,
+    constraints: ZoomConstraints
+) -> CameraKeyframe {
+    let baseZoom = max(1.0, constraints.baseZoom)
+    let maxZoom = constraints.clampedZoom(constraints.maxZoom)
+    let intensity = CGFloat(min(max(target.intensity, 0), 1))
+    let zoom = constraints.clampedZoom(baseZoom + (maxZoom - baseZoom) * intensity)
+    let clampedTarget = constraints.clampedTarget(target.position, in: sourceSize)
+    let center = constraints.clampedCenter(for: clampedTarget, in: sourceSize, zoom: zoom)
+    return CameraKeyframe(time: target.time, center: center, zoom: zoom)
+}
+
+private func applyPanConstraints(
+    to keyframes: [CameraKeyframe],
+    sourceSize: CGSize,
+    constraints: ZoomConstraints
+) -> [CameraKeyframe] {
+    guard keyframes.count > 1 else { return keyframes }
+    var adjusted: [CameraKeyframe] = []
+    adjusted.reserveCapacity(keyframes.count)
+
+    var previousVelocity = CGPoint.zero
+
+    for frame in keyframes {
+        guard let last = adjusted.last else {
+            let center = constraints.clampedCenter(frame.center, in: sourceSize, zoom: frame.zoom)
+            adjusted.append(CameraKeyframe(time: frame.time, center: center, zoom: frame.zoom))
+            previousVelocity = .zero
+            continue
+        }
+
+        let deltaTime = max(frame.time - last.time, 0.0001)
+        let deltaTimeValue = CGFloat(deltaTime)
+        var desiredCenter = frame.center
+        var delta = desiredCenter - last.center
+        let maxDistance = constraints.maxPanSpeed * deltaTimeValue
+        if delta.magnitude > maxDistance {
+            delta = delta.scaled(to: maxDistance)
+            desiredCenter = last.center + delta
+        }
+
+        var velocity = delta / deltaTimeValue
+        let velocityDelta = velocity - previousVelocity
+        let maxVelocityDelta = constraints.maxPanAcceleration * deltaTimeValue
+        if velocityDelta.magnitude > maxVelocityDelta {
+            let limitedDelta = velocityDelta.scaled(to: maxVelocityDelta)
+            velocity = previousVelocity + limitedDelta
+            desiredCenter = last.center + velocity * deltaTimeValue
+        }
+
+        desiredCenter = constraints.clampedCenter(desiredCenter, in: sourceSize, zoom: frame.zoom)
+        adjusted.append(CameraKeyframe(time: frame.time, center: desiredCenter, zoom: frame.zoom))
+        previousVelocity = velocity
+    }
+
+    return adjusted
+}
+
+private func reduceTargets(_ targets: [FocusTarget], minimumInterval: TimeInterval) -> [FocusTarget] {
+    guard minimumInterval > 0 else { return coalesceTargetsByTimestamp(targets) }
+    guard let first = targets.first else { return [] }
+
+    var reduced: [FocusTarget] = []
+    reduced.reserveCapacity(targets.count)
+
+    var bucketStart = first.time
+    var bucketBest = first
+
+    for target in targets.dropFirst() {
+        if target.time - bucketStart < minimumInterval {
+            bucketBest = pickBestTarget(bucketBest, target)
+        } else {
+            reduced.append(bucketBest)
+            bucketStart = target.time
+            bucketBest = target
+        }
+    }
+    reduced.append(bucketBest)
+    return coalesceTargetsByTimestamp(reduced)
+}
+
+private func coalesceTargetsByTimestamp(_ targets: [FocusTarget]) -> [FocusTarget] {
+    guard let first = targets.first else { return [] }
+    var result: [FocusTarget] = []
+    result.reserveCapacity(targets.count)
+
+    var current = first
+    for target in targets.dropFirst() {
+        if target.time == current.time {
+            current = pickBestTarget(current, target)
+        } else {
+            result.append(current)
+            current = target
+        }
+    }
+    result.append(current)
+    return result
+}
+
+private func pickBestTarget(_ first: FocusTarget, _ second: FocusTarget) -> FocusTarget {
+    let firstPriority = targetPriority(first)
+    let secondPriority = targetPriority(second)
+    if secondPriority > firstPriority {
+        return second
+    }
+    if secondPriority == firstPriority {
+        if second.intensity > first.intensity {
+            return second
+        }
+        if second.intensity == first.intensity {
+            return second
+        }
+    }
+    return first
+}
+
+private func targetPriority(_ target: FocusTarget) -> Int {
+    if target.isAnchor { return 3 }
+    if target.isClick { return 2 }
+    if target.isDwell { return 1 }
+    return 0
+}
+
+private extension CGPoint {
+    static func - (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        CGPoint(x: lhs.x - rhs.x, y: lhs.y - rhs.y)
+    }
+
+    static func + (lhs: CGPoint, rhs: CGPoint) -> CGPoint {
+        CGPoint(x: lhs.x + rhs.x, y: lhs.y + rhs.y)
+    }
+
+    static func / (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
+        CGPoint(x: lhs.x / rhs, y: lhs.y / rhs)
+    }
+
+    var magnitude: CGFloat {
+        (x * x + y * y).squareRoot()
+    }
+
+    func scaled(to length: CGFloat) -> CGPoint {
+        let current = magnitude
+        guard current > 0 else { return .zero }
+        return self * (length / current)
+    }
+
+    static func * (lhs: CGPoint, rhs: CGFloat) -> CGPoint {
+        CGPoint(x: lhs.x * rhs, y: lhs.y * rhs)
+    }
 }

--- a/automation/ZoomConstraints.swift
+++ b/automation/ZoomConstraints.swift
@@ -1,5 +1,122 @@
+import CoreGraphics
 import Foundation
 
-public struct ZoomConstraints {
-    public init() {}
+public struct ZoomConstraints: Equatable {
+    public var maxZoom: CGFloat
+    public var minVisibleAreaFraction: CGFloat
+    public var safeMarginFraction: CGFloat
+    public var dwellDuration: TimeInterval
+    public var dwellSpeedThreshold: CGFloat
+    public var velocitySmoothingAlpha: CGFloat
+    public var maxPanSpeed: CGFloat
+    public var maxPanAcceleration: CGFloat
+    public var idleZoom: CGFloat
+    public var baseZoom: CGFloat
+    public var minimumKeyframeInterval: TimeInterval
+    public var motionIntensity: Double
+    public var dwellIntensity: Double
+    public var clickIntensity: Double
+
+    public init(
+        maxZoom: CGFloat = 2.5,
+        minVisibleAreaFraction: CGFloat = 0.4,
+        safeMarginFraction: CGFloat = 0.1,
+        dwellDuration: TimeInterval = 0.35,
+        dwellSpeedThreshold: CGFloat = 40,
+        velocitySmoothingAlpha: CGFloat = 0.2,
+        maxPanSpeed: CGFloat = 1400,
+        maxPanAcceleration: CGFloat = 3600,
+        idleZoom: CGFloat = 1.05,
+        baseZoom: CGFloat = 1.0,
+        minimumKeyframeInterval: TimeInterval = 1.0 / 30.0,
+        motionIntensity: Double = 0.25,
+        dwellIntensity: Double = 0.7,
+        clickIntensity: Double = 1.0
+    ) {
+        self.maxZoom = maxZoom
+        self.minVisibleAreaFraction = minVisibleAreaFraction
+        self.safeMarginFraction = safeMarginFraction
+        self.dwellDuration = dwellDuration
+        self.dwellSpeedThreshold = dwellSpeedThreshold
+        self.velocitySmoothingAlpha = velocitySmoothingAlpha
+        self.maxPanSpeed = maxPanSpeed
+        self.maxPanAcceleration = maxPanAcceleration
+        self.idleZoom = idleZoom
+        self.baseZoom = baseZoom
+        self.minimumKeyframeInterval = minimumKeyframeInterval
+        self.motionIntensity = motionIntensity
+        self.dwellIntensity = dwellIntensity
+        self.clickIntensity = clickIntensity
+    }
+
+    public func clampedZoom(_ zoom: CGFloat) -> CGFloat {
+        let minimumZoom: CGFloat = 1.0
+        let minArea = max(0.01, min(minVisibleAreaFraction, 1.0))
+        let maxByArea = 1.0 / minArea
+        let allowedMaxZoom = min(maxZoom, maxByArea)
+        return min(max(zoom, minimumZoom), allowedMaxZoom)
+    }
+
+    public func clampedTarget(_ point: CGPoint, in sourceSize: CGSize) -> CGPoint {
+        guard sourceSize.width > 0, sourceSize.height > 0 else { return point }
+        let margin = max(0, min(safeMarginFraction, 0.25))
+        let insetX = sourceSize.width * margin
+        let insetY = sourceSize.height * margin
+        let minX = insetX
+        let maxX = sourceSize.width - insetX
+        let minY = insetY
+        let maxY = sourceSize.height - insetY
+        let clampedX = min(max(point.x, minX), maxX)
+        let clampedY = min(max(point.y, minY), maxY)
+        return CGPoint(x: clampedX, y: clampedY)
+    }
+
+    public func clampedCenter(_ center: CGPoint, in sourceSize: CGSize, zoom: CGFloat) -> CGPoint {
+        guard sourceSize.width > 0, sourceSize.height > 0 else { return center }
+        let zoomed = clampedZoom(zoom)
+        let viewWidth = sourceSize.width / zoomed
+        let viewHeight = sourceSize.height / zoomed
+        let halfWidth = viewWidth / 2
+        let halfHeight = viewHeight / 2
+        let minX = halfWidth
+        let maxX = sourceSize.width - halfWidth
+        let minY = halfHeight
+        let maxY = sourceSize.height - halfHeight
+        let clampedX = min(max(center.x, minX), maxX)
+        let clampedY = min(max(center.y, minY), maxY)
+        return CGPoint(x: clampedX, y: clampedY)
+    }
+
+    public func clampedCenter(for target: CGPoint, in sourceSize: CGSize, zoom: CGFloat) -> CGPoint {
+        guard sourceSize.width > 0, sourceSize.height > 0 else { return target }
+        let zoomed = clampedZoom(zoom)
+        let viewWidth = sourceSize.width / zoomed
+        let viewHeight = sourceSize.height / zoomed
+        let halfWidth = viewWidth / 2
+        let halfHeight = viewHeight / 2
+
+        let minCenterX = halfWidth
+        let maxCenterX = sourceSize.width - halfWidth
+        let minCenterY = halfHeight
+        let maxCenterY = sourceSize.height - halfHeight
+
+        let margin = max(0, min(safeMarginFraction, 0.25))
+        let marginX = viewWidth * margin
+        let marginY = viewHeight * margin
+        let innerHalfWidth = max(0, halfWidth - marginX)
+        let innerHalfHeight = max(0, halfHeight - marginY)
+
+        let minAllowedX = max(minCenterX, target.x - innerHalfWidth)
+        let maxAllowedX = min(maxCenterX, target.x + innerHalfWidth)
+        let minAllowedY = max(minCenterY, target.y - innerHalfHeight)
+        let maxAllowedY = min(maxCenterY, target.y + innerHalfHeight)
+
+        guard minAllowedX <= maxAllowedX, minAllowedY <= maxAllowedY else {
+            return clampedCenter(target, in: sourceSize, zoom: zoom)
+        }
+
+        let clampedX = min(max(target.x, minAllowedX), maxAllowedX)
+        let clampedY = min(max(target.y, minAllowedY), maxAllowedY)
+        return CGPoint(x: clampedX, y: clampedY)
+    }
 }

--- a/capture/CaptureDescriptor.swift
+++ b/capture/CaptureDescriptor.swift
@@ -1,0 +1,23 @@
+import CoreGraphics
+import Foundation
+
+public struct CaptureDescriptor: Equatable {
+    public enum Source: String {
+        case display
+        case window
+    }
+
+    public let source: Source
+    public let contentRect: CGRect
+    public let pixelScale: CGFloat
+
+    public init(source: Source, contentRect: CGRect, pixelScale: CGFloat) {
+        self.source = source
+        self.contentRect = contentRect
+        self.pixelScale = pixelScale
+    }
+
+    public var pixelSize: CGSize {
+        CGSize(width: contentRect.width * pixelScale, height: contentRect.height * pixelScale)
+    }
+}

--- a/capture/CaptureEngine+Descriptor.swift
+++ b/capture/CaptureEngine+Descriptor.swift
@@ -1,0 +1,19 @@
+import CoreGraphics
+import ScreenCaptureKit
+
+extension CaptureEngine {
+    func makeDescriptor(filter: SCContentFilter) -> CaptureDescriptor? {
+        guard #available(macOS 14.0, *) else { return nil }
+        let rect = filter.contentRect
+        let scale = CGFloat(filter.pointPixelScale)
+        let source: CaptureDescriptor.Source = filter.style == .window ? .window : .display
+        return CaptureDescriptor(source: source, contentRect: rect, pixelScale: scale)
+    }
+
+    func makeDisplayDescriptor(display: SCDisplay) -> CaptureDescriptor {
+        let bounds = CGDisplayBounds(display.displayID)
+        let pixelWidth = CGFloat(CGDisplayPixelsWide(display.displayID))
+        let scale = bounds.width > 0 ? max(1, pixelWidth / bounds.width) : 1
+        return CaptureDescriptor(source: .display, contentRect: bounds, pixelScale: scale)
+    }
+}

--- a/capture/CaptureEngine.swift
+++ b/capture/CaptureEngine.swift
@@ -13,6 +13,7 @@ public final class CaptureEngine: NSObject, ObservableObject {
     @Published public internal(set) var isRecording: Bool = false
     @Published public internal(set) var recordingURL: URL?
     @Published public internal(set) var recordingDuration: TimeInterval = 0
+    @Published public private(set) var captureDescriptor: CaptureDescriptor?
 
     private let ciContext = CIContext(options: nil)
     private let sampleQueue = DispatchQueue(label: "gg.capture.sample")
@@ -68,6 +69,7 @@ public final class CaptureEngine: NSObject, ObservableObject {
             await MainActor.run {
                 self.isRunning = true
                 self.lastError = nil
+                self.captureDescriptor = makeDisplayDescriptor(display: display)
             }
         } catch {
             audioCapture.stop()
@@ -108,6 +110,11 @@ public final class CaptureEngine: NSObject, ObservableObject {
             await MainActor.run {
                 self.isRunning = true
                 self.lastError = nil
+                self.captureDescriptor = CaptureDescriptor(
+                    source: .window,
+                    contentRect: window.frame,
+                    pixelScale: scale
+                )
             }
         } catch {
             audioCapture.stop()
@@ -135,6 +142,7 @@ public final class CaptureEngine: NSObject, ObservableObject {
         isRunning = false
         latestFrame = nil
         self.stream = nil
+        captureDescriptor = nil
     }
 
     @MainActor
@@ -191,6 +199,7 @@ public final class CaptureEngine: NSObject, ObservableObject {
             await MainActor.run {
                 self.isRunning = true
                 self.lastError = nil
+                self.captureDescriptor = makeDescriptor(filter: filter)
             }
         } catch {
             audioCapture.stop()

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -84,7 +84,7 @@ Build an open-source macOS app that records:
 Notes:
 
 - System audio is only exposed when OS + source support it; UI must disable otherwise with explanation.
-- Cursor/click tracking is optional and permission-gated.
+- Cursor/click tracking is optional and permission-gated; enabled by default with a toggle to disable.
 - If 12.3+ video-only support is validated, expand matrix and gate by OS at runtime.
 
 ---
@@ -121,6 +121,7 @@ Notes:
 - Motion blur (camera + cursor only; no optical-flow blur)
 - Background framing: padding, rounded corners, shadow
 - Aspect-ratio exports: 16:9, 9:16 (camera path re-planned per ratio)
+- Auto-zoom tuning: toggle, intensity, and minimum keyframe interval
 
 ### 7.3 Basic editing (v1)
 
@@ -227,10 +228,11 @@ Fallback behavior:
 
 - Max zoom-in: 2.5×
 - Min visible area: ≥ 40% of source
-- Safe margin: 8–12% frame
+- Safe margin: 8–12% of visible frame
 - Dwell threshold: cursor speed < V for ≥ 350 ms
 - Cursor velocity filter (EMA or Kalman) before dwell/pan evaluation to reduce jitter.
 - Max pan speed & acceleration capped (“no nausea” rule)
+- Minimum keyframe interval: 1/30 s (coalesce same-timestamp events; bucket to limit density)
 - If no events: mild center framing only
 
 ---
@@ -245,7 +247,7 @@ Project container:
 
 Project directory contents:
 
-- `project.json` (includes `projectVersion`)
+- `project.json` (includes `projectVersion` + capture metadata for event-to-capture mapping)
 - `recording.mov`
 - `audio_system.m4a` (optional)
 - `audio_mic.m4a` (optional)
@@ -390,7 +392,7 @@ Progress (current repo)
 Progress (current repo)
 
 - [x] Input Monitoring permission flow + event tracking
-- [ ] Auto-zoom planning + constraints
+- [x] Auto-zoom planning + constraints (planner + renderer wiring + UI tuning)
 - [ ] Background framing
 - [ ] Vertical export with re-planned camera
 - [ ] Localization updated for Phase 2 UI

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -126,7 +126,7 @@ Notes:
 ### 7.3 Basic editing (v1)
 
 - Trim in/out
-- Preview playback + scrubber
+- Preview playback + scrubber + playback speed control
 
 ### 7.4 Export
 

--- a/inputTracking/InputEventLog.swift
+++ b/inputTracking/InputEventLog.swift
@@ -16,9 +16,18 @@ public struct InputEventLog: Codable, Equatable {
         try data.write(to: url, options: [.atomic])
     }
 
+    public static func load(from url: URL, decoder: JSONDecoder = InputEventLog.makeDecoder()) throws -> InputEventLog {
+        let data = try Data(contentsOf: url)
+        return try decoder.decode(InputEventLog.self, from: data)
+    }
+
     public static func makeEncoder() -> JSONEncoder {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
         return encoder
+    }
+
+    public static func makeDecoder() -> JSONDecoder {
+        JSONDecoder()
     }
 }

--- a/project/AutoZoomSettings.swift
+++ b/project/AutoZoomSettings.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+public struct AutoZoomSettings: Codable, Equatable {
+    public static let intensityRange: ClosedRange<Double> = 0 ... 1
+    public static let minimumKeyframeIntervalRange: ClosedRange<TimeInterval> =
+        1.0 / 60.0 ... 1.0 / 10.0
+
+    public var isEnabled: Bool
+    public var intensity: Double
+    public var minimumKeyframeInterval: TimeInterval
+
+    public init(
+        isEnabled: Bool = true,
+        intensity: Double = 1.0,
+        minimumKeyframeInterval: TimeInterval = 1.0 / 30.0
+    ) {
+        self.isEnabled = isEnabled
+        self.intensity = intensity
+        self.minimumKeyframeInterval = minimumKeyframeInterval
+    }
+
+    public func clamped() -> AutoZoomSettings {
+        var clamped = self
+        let intensity = intensity.isFinite ? intensity : 1.0
+        clamped.intensity = min(
+            max(intensity, AutoZoomSettings.intensityRange.lowerBound),
+            AutoZoomSettings.intensityRange.upperBound
+        )
+        let interval = minimumKeyframeInterval.isFinite ? minimumKeyframeInterval : 1.0 / 30.0
+        let range = AutoZoomSettings.minimumKeyframeIntervalRange
+        clamped.minimumKeyframeInterval = min(max(interval, range.lowerBound), range.upperBound)
+        return clamped
+    }
+}

--- a/project/CaptureMetadata.swift
+++ b/project/CaptureMetadata.swift
@@ -1,0 +1,60 @@
+import CoreGraphics
+import Foundation
+
+public struct CaptureRect: Codable, Equatable {
+    public var originX: Double
+    public var originY: Double
+    public var width: Double
+    public var height: Double
+
+    public init(originX: Double, originY: Double, width: Double, height: Double) {
+        self.originX = originX
+        self.originY = originY
+        self.width = width
+        self.height = height
+    }
+
+    public init(rect: CGRect) {
+        self.init(
+            originX: rect.origin.x,
+            originY: rect.origin.y,
+            width: rect.size.width,
+            height: rect.size.height
+        )
+    }
+
+    public var cgRect: CGRect {
+        CGRect(x: originX, y: originY, width: width, height: height)
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case originX = "x"
+        case originY = "y"
+        case width
+        case height
+    }
+}
+
+public struct CaptureMetadata: Codable, Equatable {
+    public enum Source: String, Codable {
+        case display
+        case window
+    }
+
+    public var source: Source
+    public var contentRect: CaptureRect
+    public var pixelScale: Double
+
+    public init(source: Source, contentRect: CaptureRect, pixelScale: Double) {
+        self.source = source
+        self.contentRect = contentRect
+        self.pixelScale = pixelScale
+    }
+
+    public var pixelSize: CGSize {
+        CGSize(
+            width: contentRect.width * pixelScale,
+            height: contentRect.height * pixelScale
+        )
+    }
+}

--- a/project/Project.swift
+++ b/project/Project.swift
@@ -3,9 +3,33 @@ import Foundation
 public struct Project: Codable, Identifiable, Equatable {
     public let id: UUID
     public var createdAt: Date
+    public var autoZoom: AutoZoomSettings
+    public var captureMetadata: CaptureMetadata?
 
-    public init(id: UUID = UUID(), createdAt: Date = Date()) {
+    public init(
+        id: UUID = UUID(),
+        createdAt: Date = Date(),
+        autoZoom: AutoZoomSettings = AutoZoomSettings(),
+        captureMetadata: CaptureMetadata? = nil
+    ) {
         self.id = id
         self.createdAt = createdAt
+        self.autoZoom = autoZoom
+        self.captureMetadata = captureMetadata
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case createdAt
+        case autoZoom
+        case captureMetadata
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(UUID.self, forKey: .id)
+        createdAt = try container.decode(Date.self, forKey: .createdAt)
+        autoZoom = try container.decodeIfPresent(AutoZoomSettings.self, forKey: .autoZoom) ?? AutoZoomSettings()
+        captureMetadata = try container.decodeIfPresent(CaptureMetadata.self, forKey: .captureMetadata)
     }
 }

--- a/project/ProjectSchemaVersion.swift
+++ b/project/ProjectSchemaVersion.swift
@@ -1,5 +1,5 @@
 import Foundation
 
 public enum ProjectSchemaVersion {
-    public static let current = 1
+    public static let current = 3
 }

--- a/rendering/CameraPlanVideoCompositionBuilder.swift
+++ b/rendering/CameraPlanVideoCompositionBuilder.swift
@@ -1,0 +1,129 @@
+import Automation
+import AVFoundation
+import CoreGraphics
+
+enum CameraPlanVideoCompositionBuilder {
+    static func makeComposition(
+        asset: AVAsset,
+        track: AVAssetTrack,
+        renderSize: CGSize,
+        frameRate: Double,
+        plan: CameraPlan?
+    ) async throws -> AVVideoComposition? {
+        guard renderSize.width > 0, renderSize.height > 0 else { return nil }
+
+        let naturalSize = try await track.load(.naturalSize)
+        let preferredTransform = try await track.load(.preferredTransform)
+        let duration = try await asset.load(.duration)
+
+        let requiresScaling = naturalSize.width != renderSize.width || naturalSize.height != renderSize.height
+        let requiresTransform = !preferredTransform.isIdentity
+        let hasPlan = !(plan?.keyframes.isEmpty ?? true)
+
+        if !hasPlan, !requiresScaling, !requiresTransform {
+            return nil
+        }
+
+        let baseTransform = makeBaseTransform(
+            preferredTransform: preferredTransform,
+            naturalSize: naturalSize,
+            renderSize: renderSize
+        )
+
+        let layerInstruction = makeLayerInstruction(
+            track: track,
+            baseTransform: baseTransform,
+            plan: plan,
+            sourceSize: naturalSize,
+            duration: duration
+        )
+
+        let instruction = AVMutableVideoCompositionInstruction()
+        instruction.timeRange = CMTimeRange(start: .zero, duration: duration)
+        instruction.layerInstructions = [layerInstruction]
+
+        let composition = AVMutableVideoComposition()
+        composition.renderSize = renderSize
+        let timescale = max(1, Int32(frameRate.rounded()))
+        composition.frameDuration = CMTime(value: 1, timescale: timescale)
+        composition.instructions = [instruction]
+        return composition
+    }
+}
+
+private func makeLayerInstruction(
+    track: AVAssetTrack,
+    baseTransform: CGAffineTransform,
+    plan: CameraPlan?,
+    sourceSize: CGSize,
+    duration: CMTime
+) -> AVMutableVideoCompositionLayerInstruction {
+    let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: track)
+    guard let plan, !plan.keyframes.isEmpty else {
+        layerInstruction.setTransform(baseTransform, at: .zero)
+        return layerInstruction
+    }
+
+    let keyframes = plan.keyframes.sorted(by: { $0.time < $1.time })
+    let firstTransform = baseTransform.concatenating(
+        cameraTransform(for: keyframes[0], sourceSize: sourceSize)
+    )
+    layerInstruction.setTransform(firstTransform, at: .zero)
+
+    var previous = keyframes[0]
+    for keyframe in keyframes.dropFirst() {
+        let startTime = clampTime(previous.time, duration: duration)
+        let endTime = clampTime(keyframe.time, duration: duration)
+        if endTime <= startTime {
+            previous = keyframe
+            continue
+        }
+
+        let startTransform = baseTransform.concatenating(
+            cameraTransform(for: previous, sourceSize: sourceSize)
+        )
+        let endTransform = baseTransform.concatenating(
+            cameraTransform(for: keyframe, sourceSize: sourceSize)
+        )
+        let timeRange = CMTimeRange(start: startTime, end: endTime)
+        layerInstruction.setTransformRamp(
+            fromStart: startTransform,
+            toEnd: endTransform,
+            timeRange: timeRange
+        )
+        previous = keyframe
+    }
+
+    return layerInstruction
+}
+
+private func makeBaseTransform(
+    preferredTransform: CGAffineTransform,
+    naturalSize: CGSize,
+    renderSize: CGSize
+) -> CGAffineTransform {
+    let scale = min(renderSize.width / naturalSize.width, renderSize.height / naturalSize.height)
+    let scaledSize = CGSize(width: naturalSize.width * scale, height: naturalSize.height * scale)
+    let translateX = (renderSize.width - scaledSize.width) / 2
+    let translateY = (renderSize.height - scaledSize.height) / 2
+
+    var transform = preferredTransform
+    transform = transform.scaledBy(x: scale, y: scale)
+    transform = transform.translatedBy(x: translateX, y: translateY)
+    return transform
+}
+
+private func cameraTransform(for keyframe: CameraKeyframe, sourceSize: CGSize) -> CGAffineTransform {
+    let zoom = max(1, keyframe.zoom)
+    let sourceCenter = CGPoint(x: sourceSize.width / 2, y: sourceSize.height / 2)
+    var transform = CGAffineTransform(translationX: sourceCenter.x, y: sourceCenter.y)
+    transform = transform.scaledBy(x: zoom, y: zoom)
+    transform = transform.translatedBy(x: -keyframe.center.x, y: -keyframe.center.y)
+    return transform
+}
+
+private func clampTime(_ time: TimeInterval, duration: CMTime) -> CMTime {
+    let durationSeconds = max(0, duration.seconds)
+    let clamped = min(max(0, time), durationSeconds)
+    return CMTime(seconds: clamped, preferredTimescale: 600)
+}

--- a/rendering/ExportRenderer.swift
+++ b/rendering/ExportRenderer.swift
@@ -1,5 +1,25 @@
+import Automation
+import AVFoundation
 import Foundation
 
 public final class ExportRenderer {
     public init() {}
+
+    public func makeVideoComposition(
+        asset: AVAsset,
+        renderSize: CGSize,
+        frameRate: Double,
+        plan: CameraPlan?
+    ) async throws -> AVVideoComposition? {
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        guard let track = tracks.first else { return nil }
+
+        return try await CameraPlanVideoCompositionBuilder.makeComposition(
+            asset: asset,
+            track: track,
+            renderSize: renderSize,
+            frameRate: frameRate,
+            plan: plan
+        )
+    }
 }

--- a/rendering/PreviewRenderer.swift
+++ b/rendering/PreviewRenderer.swift
@@ -1,5 +1,26 @@
+import Automation
+import AVFoundation
 import Foundation
 
 public final class PreviewRenderer {
     public init() {}
+
+    public func makeVideoComposition(
+        asset: AVAsset,
+        plan: CameraPlan?
+    ) async throws -> AVVideoComposition? {
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        guard let track = tracks.first else { return nil }
+        let naturalSize = try await track.load(.naturalSize)
+        let nominalFrameRate = try await track.load(.nominalFrameRate)
+        let frameRate = nominalFrameRate > 0 ? Double(nominalFrameRate) : 30
+
+        return try await CameraPlanVideoCompositionBuilder.makeComposition(
+            asset: asset,
+            track: track,
+            renderSize: naturalSize,
+            frameRate: frameRate,
+            plan: plan
+        )
+    }
 }

--- a/ui/AutoZoomPlanSupport.swift
+++ b/ui/AutoZoomPlanSupport.swift
@@ -1,0 +1,120 @@
+import Automation
+import AVFoundation
+import CoreGraphics
+import InputTracking
+import Project
+
+struct CameraPlanCacheKey: Equatable {
+    let eventsSignature: UInt64
+    let settings: AutoZoomSettings
+    let duration: TimeInterval
+    let sourceSize: CGSize
+}
+
+struct CameraPlanCache {
+    let key: CameraPlanCacheKey
+    let plan: CameraPlan?
+    let composition: AVVideoComposition?
+}
+
+enum AutoZoomPlanSupport {
+    static func makeCacheKey(
+        events: [InputEvent],
+        settings: AutoZoomSettings,
+        duration: TimeInterval,
+        sourceSize: CGSize
+    ) -> CameraPlanCacheKey {
+        CameraPlanCacheKey(
+            eventsSignature: eventsSignature(events),
+            settings: settings.clamped(),
+            duration: roundedTime(duration, scale: 1000),
+            sourceSize: roundedSize(sourceSize, scale: 100)
+        )
+    }
+
+    static func mapEventsToCaptureSpace(
+        _ events: [InputEvent],
+        metadata: CaptureMetadata,
+        sourceSize: CGSize
+    ) -> [InputEvent] {
+        let rect = metadata.contentRect.cgRect
+        let scale = CGFloat(max(0.01, metadata.pixelScale))
+        guard rect.width > 0, rect.height > 0 else { return events }
+
+        let pixelSize = metadata.pixelSize
+        let scaleX = pixelSize.width > 0 ? sourceSize.width / pixelSize.width : 1
+        let scaleY = pixelSize.height > 0 ? sourceSize.height / pixelSize.height : 1
+
+        return events.map { event in
+            let point = event.position.cgPoint
+            let normalizedX = point.x - rect.minX
+            let normalizedY = rect.maxY - point.y
+            var mapped = CGPoint(
+                x: normalizedX * scale * scaleX,
+                y: normalizedY * scale * scaleY
+            )
+            mapped.x = min(max(mapped.x, 0), max(0, sourceSize.width))
+            mapped.y = min(max(mapped.y, 0), max(0, sourceSize.height))
+            return InputEvent(
+                type: event.type,
+                timestamp: event.timestamp,
+                position: mapped,
+                button: event.button
+            )
+        }
+    }
+
+    static func eventsSignature(_ events: [InputEvent]) -> UInt64 {
+        var hash: UInt64 = 0xCBF2_9CE4_8422_2325
+        for event in events {
+            hash = fnvCombine(hash, eventTypeCode(event.type))
+            hash = fnvCombine(hash, buttonCode(event.button))
+            hash = fnvCombine(hash, event.timestamp.bitPattern)
+            hash = fnvCombine(hash, event.position.xValue.bitPattern)
+            hash = fnvCombine(hash, event.position.yValue.bitPattern)
+        }
+        return hash
+    }
+}
+
+private func roundedTime(_ value: TimeInterval, scale: Double) -> TimeInterval {
+    (value * scale).rounded() / scale
+}
+
+private func roundedSize(_ size: CGSize, scale: CGFloat) -> CGSize {
+    CGSize(
+        width: (size.width * scale).rounded() / scale,
+        height: (size.height * scale).rounded() / scale
+    )
+}
+
+private func fnvCombine(_ hash: UInt64, _ value: UInt64) -> UInt64 {
+    let prime: UInt64 = 0x100_0000_01B3
+    var result = hash ^ value
+    result &*= prime
+    return result
+}
+
+private func eventTypeCode(_ type: InputEventType) -> UInt64 {
+    switch type {
+    case .cursorMoved:
+        1
+    case .mouseDown:
+        2
+    case .mouseUp:
+        3
+    }
+}
+
+private func buttonCode(_ button: MouseButton?) -> UInt64 {
+    switch button {
+    case .left:
+        1
+    case .right:
+        2
+    case .other:
+        3
+    case .none:
+        0
+    }
+}

--- a/ui/GuerillaglassDocument.swift
+++ b/ui/GuerillaglassDocument.swift
@@ -109,4 +109,8 @@ public struct GuerillaglassDocument: FileDocument {
     public mutating func updateEventsSource(_ url: URL?) {
         assets.eventsURL = url
     }
+
+    public mutating func updateCaptureMetadata(_ metadata: CaptureMetadata?) {
+        projectDocument.project.captureMetadata = metadata
+    }
 }

--- a/ui/RootView+AutoZoom.swift
+++ b/ui/RootView+AutoZoom.swift
@@ -1,0 +1,203 @@
+import Automation
+import AVFoundation
+import Capture
+import CoreGraphics
+import InputTracking
+import Project
+import Rendering
+import SwiftUI
+
+extension RootView {
+    var autoZoomSettings: AutoZoomSettings {
+        get { document.projectDocument.project.autoZoom }
+        nonmutating set { document.projectDocument.project.autoZoom = newValue.clamped() }
+    }
+
+    var autoZoomEnabledBinding: Binding<Bool> {
+        Binding(
+            get: { autoZoomSettings.isEnabled },
+            set: { newValue in
+                var settings = autoZoomSettings
+                settings.isEnabled = newValue
+                autoZoomSettings = settings
+            }
+        )
+    }
+
+    var autoZoomIntensityBinding: Binding<Double> {
+        Binding(
+            get: { autoZoomSettings.intensity },
+            set: { newValue in
+                var settings = autoZoomSettings
+                settings.intensity = newValue
+                autoZoomSettings = settings
+            }
+        )
+    }
+
+    var autoZoomKeyframeIntervalBinding: Binding<Double> {
+        Binding(
+            get: { autoZoomSettings.minimumKeyframeInterval },
+            set: { newValue in
+                var settings = autoZoomSettings
+                settings.minimumKeyframeInterval = newValue
+                autoZoomSettings = settings
+            }
+        )
+    }
+
+    var autoZoomIntensityLabel: String {
+        let percent = Int((autoZoomSettings.intensity * 100).rounded())
+        return "\(percent)%"
+    }
+
+    var autoZoomKeyframeIntervalLabel: String {
+        let milliseconds = Int((autoZoomSettings.minimumKeyframeInterval * 1000).rounded())
+        return "\(milliseconds) ms"
+    }
+
+    @MainActor
+    func refreshPreviewComposition(for url: URL?) {
+        previewRefreshTask?.cancel()
+        let assetURL = url
+        previewRefreshTask = Task { [assetURL] in
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            await applyCameraPlanPreview(for: assetURL)
+        }
+    }
+
+    @MainActor
+    func makeCameraPlan(for asset: AVAsset) async -> CameraPlan? {
+        let settings = autoZoomSettings.clamped()
+        guard settings.isEnabled else { return nil }
+
+        guard let inputs = await makePlanInputs(for: asset, settings: settings) else { return nil }
+        if let cache = cameraPlanCache, cache.key == inputs.key {
+            return cache.plan
+        }
+
+        let constraints = constraints(for: settings)
+        let plan = cameraPlanner.plan(
+            events: inputs.events,
+            sourceSize: inputs.sourceSize,
+            duration: inputs.duration,
+            constraints: constraints
+        )
+
+        cameraPlanCache = CameraPlanCache(key: inputs.key, plan: plan, composition: nil)
+        return plan
+    }
+
+    @MainActor
+    func syncCaptureMetadata() {
+        guard let descriptor = captureEngine.captureDescriptor else {
+            document.updateCaptureMetadata(nil)
+            return
+        }
+        document.updateCaptureMetadata(CaptureMetadata(descriptor: descriptor))
+    }
+}
+
+private extension RootView {
+    @MainActor
+    func applyCameraPlanPreview(for url: URL?) async {
+        guard let url else {
+            playbackModel.applyVideoComposition(nil)
+            return
+        }
+
+        let asset = AVAsset(url: url)
+        let settings = autoZoomSettings.clamped()
+        guard settings.isEnabled else {
+            playbackModel.applyVideoComposition(nil)
+            return
+        }
+
+        guard let inputs = await makePlanInputs(for: asset, settings: settings) else {
+            playbackModel.applyVideoComposition(nil)
+            return
+        }
+
+        if let cache = cameraPlanCache, cache.key == inputs.key, let composition = cache.composition {
+            guard playbackModel.currentURL == url else { return }
+            playbackModel.applyVideoComposition(composition)
+            return
+        }
+
+        let constraints = constraints(for: settings)
+        let plan = cameraPlanner.plan(
+            events: inputs.events,
+            sourceSize: inputs.sourceSize,
+            duration: inputs.duration,
+            constraints: constraints
+        )
+        let composition = try? await previewRenderer.makeVideoComposition(asset: asset, plan: plan)
+
+        cameraPlanCache = CameraPlanCache(key: inputs.key, plan: plan, composition: composition)
+        guard playbackModel.currentURL == url else { return }
+        playbackModel.applyVideoComposition(composition)
+    }
+
+    func loadInputEvents() -> [InputEvent] {
+        guard let eventsURL = document.assets.eventsURL else { return [] }
+        return (try? InputEventLog.load(from: eventsURL))?.events ?? []
+    }
+
+    func makePlanInputs(for asset: AVAsset, settings: AutoZoomSettings) async -> CameraPlanInputs? {
+        let tracks = try? await asset.loadTracks(withMediaType: .video)
+        guard let track = tracks?.first else { return nil }
+        let duration = await (try? asset.load(.duration))?.seconds ?? 0
+        let naturalSize = await (try? track.load(.naturalSize)) ?? .zero
+        guard naturalSize.width > 0, naturalSize.height > 0 else { return nil }
+
+        let events = mappedInputEvents(for: naturalSize)
+        let key = AutoZoomPlanSupport.makeCacheKey(
+            events: events,
+            settings: settings,
+            duration: duration,
+            sourceSize: naturalSize
+        )
+        return CameraPlanInputs(events: events, sourceSize: naturalSize, duration: duration, key: key)
+    }
+
+    func mappedInputEvents(for sourceSize: CGSize) -> [InputEvent] {
+        let events = loadInputEvents()
+        guard let metadata = document.projectDocument.project.captureMetadata else { return events }
+        return AutoZoomPlanSupport.mapEventsToCaptureSpace(events, metadata: metadata, sourceSize: sourceSize)
+    }
+
+    func constraints(for settings: AutoZoomSettings) -> ZoomConstraints {
+        let intensity = max(0, min(settings.intensity, 1))
+        var constraints = ZoomConstraints()
+        constraints.minimumKeyframeInterval = settings.minimumKeyframeInterval
+        let followSmoothing: CGFloat = 0.75
+        constraints.maxPanSpeed *= followSmoothing
+        constraints.maxPanAcceleration *= followSmoothing
+        let maxZoomDelta = constraints.maxZoom - 1
+        constraints.maxZoom = 1 + maxZoomDelta * CGFloat(intensity)
+        let idleZoomDelta = constraints.idleZoom - 1
+        constraints.idleZoom = 1 + idleZoomDelta * CGFloat(intensity)
+        constraints.motionIntensity *= intensity
+        constraints.dwellIntensity *= intensity
+        constraints.clickIntensity *= intensity
+        return constraints
+    }
+}
+
+private struct CameraPlanInputs {
+    let events: [InputEvent]
+    let sourceSize: CGSize
+    let duration: TimeInterval
+    let key: CameraPlanCacheKey
+}
+
+private extension CaptureMetadata {
+    init(descriptor: CaptureDescriptor) {
+        let source: CaptureMetadata.Source = descriptor.source == .window ? .window : .display
+        self.init(
+            source: source,
+            contentRect: CaptureRect(rect: descriptor.contentRect),
+            pixelScale: Double(descriptor.pixelScale)
+        )
+    }
+}

--- a/ui/RootView+Export.swift
+++ b/ui/RootView+Export.swift
@@ -19,11 +19,14 @@ extension RootView {
                 end: trimOutSeconds,
                 duration: duration
             )
+            let asset = AVAsset(url: recordingURL)
+            let cameraPlan = await makeCameraPlan(for: asset)
             _ = try await exportPipeline.export(
                 recordingURL: recordingURL,
                 preset: selectedPreset,
                 trimRange: trimRange,
-                outputURL: outputURL
+                outputURL: outputURL,
+                cameraPlan: cameraPlan
             )
             exportStatus = String(localized: "Export complete.")
         } catch {

--- a/ui/RootView+Toolbar.swift
+++ b/ui/RootView+Toolbar.swift
@@ -52,6 +52,9 @@ extension RootView {
                             let referenceTime = CaptureClock().now().seconds
                             try await captureEngine.startRecording()
                             await MainActor.run {
+                                syncCaptureMetadata()
+                            }
+                            await MainActor.run {
                                 inputTrackingModel.startIfPermitted(referenceTime: referenceTime)
                             }
                         }

--- a/ui/capture/InputTrackingModel.swift
+++ b/ui/capture/InputTrackingModel.swift
@@ -3,7 +3,7 @@ import InputTracking
 
 @MainActor
 final class InputTrackingModel: ObservableObject {
-    @Published var isEnabled = false
+    @Published var isEnabled = true
     @Published private(set) var permissionStatus: InputMonitoringStatus
     @Published var showPermissionAlert = false
     @Published private(set) var lastEventsURL: URL?
@@ -44,7 +44,14 @@ final class InputTrackingModel: ObservableObject {
 
     func startIfPermitted(referenceTime: TimeInterval? = nil) {
         permissionStatus = permissionManager.status()
-        guard isEnabled, permissionStatus == .authorized else { return }
+        guard isEnabled else { return }
+        if permissionStatus == .notDetermined {
+            permissionStatus = permissionManager.requestAccess()
+        }
+        guard permissionStatus == .authorized else {
+            showPermissionAlert = true
+            return
+        }
         session.start(referenceTime: referenceTime)
     }
 

--- a/ui/editor/RecordingPlaybackView+PlaybackSpeed.swift
+++ b/ui/editor/RecordingPlaybackView+PlaybackSpeed.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension RecordingPlaybackView {
+    var playbackRates: [Double] {
+        [0.5, 0.75, 1.0, 1.25, 1.5, 2.0]
+    }
+
+    func rateLabel(_ rate: Double) -> String {
+        let formatted = rate.truncatingRemainder(dividingBy: 1) == 0
+            ? String(format: "%.0f", rate)
+            : String(format: "%.2g", rate)
+        return "\(formatted)x"
+    }
+}


### PR DESCRIPTION
# Summary
- Wired auto‑zoom planner into preview/export, added capture metadata mapping, and persisted auto‑zoom settings with schema/migrations and tests.
- Added playback speed control, adaptive filmstrip sampling, and auto‑scrolling playhead behavior.
- Redesigned inspector into carded layout with tighter, adaptive row sizing to fit initial width.

<img width="1580" height="1017" alt="Bildschirmfoto 2026-01-31 um 23 38 18" src="https://github.com/user-attachments/assets/e4e5ee54-fe9f-4632-9950-2e17bf06b967" />


# Checklist
- [x] Ran `Scripts/full_gate.sh`
- [x] Scoped to a single area (UI, capture, export, docs, tooling)
- [x] UI changes include screenshots

# Testing (optional)
- [x] swift test
