### PR TITLE
docs: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+# These are supported funding model platforms
+github: [okikeSolutions]


### PR DESCRIPTION
# Summary
- Add `.github/FUNDING.yml` with the GitHub Sponsors account `okikeSolutions` so GitHub can display the Sponsor button for this repository.

# Checklist
- [x] Ran `bun run gate`
- [x] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
- [ ] UI changes include screenshots
- [ ] Updated docs/templates if architecture or workflows changed

# Testing (optional)
- [x] swift test
- [ ] bun run desktop:test:coverage (required when touching `apps/desktop-electrobun` or `packages/engine-protocol`)
