### PR TITLE
Fix capture picker timeout flow, add full-screen picker mode, and restore Cmd+Q

### DIFF
--- a/apps/desktop-electrobun/src/bun/engineClient.ts
+++ b/apps/desktop-electrobun/src/bun/engineClient.ts
@@ -152,7 +152,8 @@ const engineMethodDefinitions = {
       captureFps,
     }),
     schema: captureStatusResultSchema,
-    timeoutMs: 15_000,
+    // 0 disables timeout: native window picker can remain open while users decide or cancel.
+    timeoutMs: 0,
     retryableRead: false,
   } satisfies EngineMethodDefinition<
     Awaited<ReturnType<typeof captureStatusResultSchema.parse>>,

--- a/apps/desktop-electrobun/src/bun/index.ts
+++ b/apps/desktop-electrobun/src/bun/index.ts
@@ -147,6 +147,7 @@ try {
 }
 
 const rpc = BrowserView.defineRPC<DesktopBridgeRPC>({
+  maxRequestTime: Infinity,
   handlers: {
     requests: createEngineBridgeHandlers({
       engineClient,

--- a/apps/desktop-electrobun/src/bun/menu/builders.ts
+++ b/apps/desktop-electrobun/src/bun/menu/builders.ts
@@ -122,7 +122,12 @@ export function buildApplicationMenu(
       action: "menu.file",
       submenu: [
         ...buildAppSectionCommands("file", state, locale),
-        ...(platform !== "darwin" ? [separator, { role: "quit" }] : []),
+        separator,
+        {
+          label: labels.quit,
+          action: "app.quit",
+          accelerator: "q",
+        },
       ],
     },
     {

--- a/apps/desktop-electrobun/src/mainview/app/studio/useStudioController.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/useStudioController.ts
@@ -151,7 +151,7 @@ export function useStudioController() {
 
   const settingsForm = useForm({
     defaultValues: {
-      captureSource: "display" as CaptureSourceMode,
+      captureSource: "window" as CaptureSourceMode,
       selectedWindowId: 0,
       captureFps: defaultCaptureFrameRate,
       micEnabled: false,

--- a/apps/desktop-electrobun/src/mainview/lib/electrobunRpcBridge.ts
+++ b/apps/desktop-electrobun/src/mainview/lib/electrobunRpcBridge.ts
@@ -25,6 +25,7 @@ export function initializeElectrobunRpcBridge(): void {
   }
 
   const rpc = Electroview.defineRPC<DesktopBridgeRPC>({
+    maxRequestTime: Infinity,
     handlers: {
       requests: {},
       messages: {

--- a/apps/desktop-electrobun/src/types/electrobun-bun-shim.d.ts
+++ b/apps/desktop-electrobun/src/types/electrobun-bun-shim.d.ts
@@ -44,7 +44,7 @@ export type MenuItemConfig =
     };
 
 export const BrowserView: {
-  defineRPC<T>(_config: { handlers: unknown }): T;
+  defineRPC<T>(_config: { maxRequestTime?: number; handlers: unknown }): T;
 };
 
 export class BrowserWindow<TRPC = unknown> {

--- a/apps/desktop-electrobun/src/types/electrobun-view-shim.d.ts
+++ b/apps/desktop-electrobun/src/types/electrobun-view-shim.d.ts
@@ -18,6 +18,7 @@ export class Electroview<TRPC = unknown> {
   constructor(options?: { rpc?: TRPC });
 
   static defineRPC<T extends { bun: RpcChannelSchema }>(_config: {
+    maxRequestTime?: number;
     handlers: unknown;
   }): {
     readonly request: RpcRequestClient<T["bun"]["requests"]>;

--- a/apps/desktop-electrobun/tests/engine-client.test.ts
+++ b/apps/desktop-electrobun/tests/engine-client.test.ts
@@ -231,6 +231,23 @@ describe("engine client resilience", () => {
     }
   });
 
+  test("does not apply a default timeout to capture.startWindow", async () => {
+    const client = new EngineClient(HANGING_ENGINE_PATH, 50);
+
+    try {
+      const captureOutcome = await Promise.race([
+        client
+          .startWindowCapture(0, false)
+          .then(() => "resolved")
+          .catch((error: Error) => `rejected:${error.message}`),
+        wait(200).then(() => "pending"),
+      ]);
+      expect(captureOutcome).toBe("pending");
+    } finally {
+      await client.stop();
+    }
+  });
+
   test("fails pending requests quickly when engine exits", async () => {
     const client = new EngineClient(CRASHING_ENGINE_PATH, 5000);
     const startedAt = Date.now();

--- a/apps/desktop-electrobun/tests/menu-shell.test.ts
+++ b/apps/desktop-electrobun/tests/menu-shell.test.ts
@@ -64,6 +64,22 @@ describe("shell menu helpers", () => {
     );
     expect(saveItem).toEqual(expect.objectContaining({ enabled: false, accelerator: "s" }));
 
+    const darwinFileMenu = darwinMenu.find(
+      (item): item is Exclude<ApplicationMenuItemConfig, { type: "divider" | "separator" }> =>
+        isNormalApplicationItem(item) && item.label === "File",
+    );
+    expect(darwinFileMenu).toBeDefined();
+    const darwinFileSubmenu: ApplicationMenuItemConfig[] = darwinFileMenu?.submenu ?? [];
+    const darwinQuitItem = darwinFileSubmenu.find(
+      (item) => isNormalApplicationItem(item) && item.label === "Quit",
+    );
+    expect(darwinQuitItem).toEqual(
+      expect.objectContaining({
+        action: "app.quit",
+        accelerator: "q",
+      }),
+    );
+
     const viewMenu = windowsMenu.find(
       (item): item is Exclude<ApplicationMenuItemConfig, { type: "divider" | "separator" }> =>
         isNormalApplicationItem(item) && item.label === "View",

--- a/engines/macos-swift/EngineService+CaptureRecording.swift
+++ b/engines/macos-swift/EngineService+CaptureRecording.swift
@@ -85,11 +85,26 @@ extension EngineService {
         }
 
         do {
-            try await captureEngine.startWindowCapture(
-                windowID: CGWindowID(windowID),
-                enableMic: enableMic,
-                targetFrameRate: captureFps
-            )
+            if windowID == 0 {
+                if #available(macOS 14.0, *) {
+                    try await captureEngine.startCaptureUsingPicker(
+                        enableMic: enableMic,
+                        targetFrameRate: captureFps
+                    )
+                } else {
+                    return .failure(
+                        id: id,
+                        code: "invalid_params",
+                        message: "windowId must be greater than 0 on macOS 13"
+                    )
+                }
+            } else {
+                try await captureEngine.startWindowCapture(
+                    windowID: CGWindowID(windowID),
+                    enableMic: enableMic,
+                    targetFrameRate: captureFps
+                )
+            }
             return captureStatusResponse(id: id)
         } catch {
             return .failure(id: id, code: "runtime_error", message: error.localizedDescription)

--- a/engines/macos-swift/modules/capture/CaptureEngine.swift
+++ b/engines/macos-swift/modules/capture/CaptureEngine.swift
@@ -163,7 +163,7 @@ public final class CaptureEngine: NSObject, ObservableObject {
 
     @available(macOS 14.0, *)
     public func startCaptureUsingPicker(
-        style: SCShareableContentStyle,
+        style: SCShareableContentStyle? = nil,
         enableMic: Bool = false,
         targetFrameRate: Int = 30
     ) async throws {
@@ -289,14 +289,14 @@ extension CaptureEngine {
 
     @available(macOS 14.0, *)
     @MainActor
-    private func pickContent(style: SCShareableContentStyle) async throws -> SCContentFilter {
+    private func pickContent(style: SCShareableContentStyle?) async throws -> SCContentFilter {
         if pickerContinuation != nil {
             throw CaptureError.pickerAlreadyActive
         }
 
         let picker = SCContentSharingPicker.shared
         var configuration = SCContentSharingPickerConfiguration()
-        configuration.allowedPickerModes = style == .display ? .singleDisplay : .singleWindow
+        configuration.allowedPickerModes = [.singleDisplay, .singleWindow]
         configuration.excludedWindowIDs = []
         if let bundleID = Bundle.main.bundleIdentifier {
             configuration.excludedBundleIDs = [bundleID]
@@ -310,7 +310,11 @@ extension CaptureEngine {
 
         return try await withCheckedThrowingContinuation { continuation in
             pickerContinuation = continuation
-            picker.present(using: style)
+            if let style {
+                picker.present(using: style)
+            } else {
+                picker.present()
+            }
         }
     }
 


### PR DESCRIPTION
# Summary
- Fix macOS capture start flow so native share picker can stay open for user selection/cancel without timing out.
- Keep picker options for both window and full-screen sharing.
- Restore `Cmd+Q` handling via explicit File menu quit action.
- Disable Electrobun bridge RPC timeout for long-running native dialogs to prevent premature timeout notices.

# Checklist
- [x] Ran `bun run gate`
- [ ] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
- [ ] UI changes include screenshots
- [ ] Updated docs/templates if architecture or workflows changed

# Testing (optional)
- [x] swift test
- [x] bun run desktop:test:coverage (required when touching `apps/desktop-electrobun` or `packages/engine-protocol`)
