### PR TITLE
Tooling: enforce public API docs coverage across TS, Swift, and Rust

### DIFF
--- a/.github/workflows/desktop-parity-matrix.yml
+++ b/.github/workflows/desktop-parity-matrix.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Run documentation coverage gate (TypeScript surfaces)
+        run: bun run docs:check:ts
+
       - name: Run TypeScript gate
         run: bun run gate:typescript
 

--- a/.github/workflows/full_gate.yml
+++ b/.github/workflows/full_gate.yml
@@ -35,6 +35,9 @@ jobs:
       - name: Install JavaScript dependencies
         run: bun install
 
+      - name: Run documentation coverage gate
+        run: bun run docs:check
+
       - name: Install SwiftFormat and SwiftLint
         run: |
           brew update

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@
 - **Platform stub engines:** `engines/windows-stub/`, `engines/linux-stub/` — protocol-compatible stubs for parallel engine work.
 - **Swift protocol module (new):** `engines/protocol-swift/` — wire codec and typed message envelope models.
 - **Tests:** `Tests/` — `automationTests/`, `captureTests/`, `engineProtocolTests/`, `exportTests/`, `projectMigrationTests/`, `renderingDeterminismTests/`.
-- **Gate scripts (implementation):** `Scripts/` — `rust_gate.sh`, `typescript_gate.sh`, `full_gate.sh`, `coverage.sh`, `rust_coverage.sh`, `swift_coverage.sh`, `coverage_check.sh`.
+- **Gate scripts (implementation):** `Scripts/` — `rust_gate.sh`, `typescript_gate.sh`, `full_gate.sh`, `docs_gate.mjs`, `coverage.sh`, `rust_coverage.sh`, `swift_coverage.sh`, `coverage_check.sh`.
 - **Docs:** `docs/` — SPEC and other project docs.
 
 When adding modules or moving code, keep the spec’s architecture (§16–17) and update `AGENTS.md` / `docs/SPEC.md` if the tree changes.
@@ -40,9 +40,13 @@ When adding modules or moving code, keep the spec’s architecture (§16–17) a
 - **React effect guard lint:** `bun run js:lint:react-effects`  
   Runs the custom guard that rejects direct React state updates in effects (`Scripts/lint_no_state_updates_in_effect.mjs`).
 - **TypeScript gate (format + lint + typecheck + tests):** `bun run gate:typescript`  
-  Runs: JS/TS format check (Oxfmt) → JS/TS lint (Oxlint) → desktop shell typecheck → protocol package typecheck → desktop tests.
+  Runs: JS/TS format check (Oxfmt) → JS/TS lint (Oxlint) → docs coverage gate (TypeScript surfaces) → desktop shell typecheck → protocol package typecheck → desktop tests.
+- **Docs coverage gate (all surfaces):** `bun run docs:check`  
+  Runs coverage checks for TypeScript, Swift, and Rust public/exported API surfaces using `docs/doc_coverage_policy.json`.
+- **Docs coverage gate (TypeScript surfaces):** `bun run docs:check:ts`
+- **Docs coverage gate (native surfaces):** `bun run docs:check:native`
 - **Full gate (rust + typescript + swift):** `bun run gate`  
-  Runs: `gate:rust` → `gate:typescript` → SwiftFormat → SwiftLint → `swift test` → `swift build`. Use this to verify the project after changes.
+  Runs: `gate:rust` → `gate:typescript` → docs coverage gate (Swift/Rust surfaces) → SwiftFormat → SwiftLint → `swift test` → `swift build`. Use this to verify the project after changes.
 - **Desktop deps (workspace):** `bun install`
 - **Desktop shell dev:** `bun run desktop:dev`
 - **Desktop shell dev fallback (macOS app open):** `bun run desktop:dev:open`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ bun run js:lint
 # TypeScript gate (oxfmt + oxlint + typecheck + desktop tests)
 bun run gate:typescript
 
+# Public/exported API docs coverage gates
+bun run docs:check
+bun run docs:check:ts
+bun run docs:check:native
+
 # Swift format/lint/test/build gate
 bun run gate
 
@@ -104,6 +109,7 @@ bun run desktop:test:ui
 ## Docs
 
 - Product spec: `/docs/SPEC.md`
+- Docs coverage thresholds: `/docs/doc_coverage_policy.json`
 - Hybrid architecture: `/docs/ARCHITECTURE.md`
 - Desktop accessibility + hotkey policy: `/docs/DESKTOP_ACCESSIBILITY.md`
 - Agent repo conventions: `/AGENTS.md`

--- a/Scripts/docs_gate.mjs
+++ b/Scripts/docs_gate.mjs
@@ -1,0 +1,306 @@
+#!/usr/bin/env bun
+import fs from "node:fs";
+import path from "node:path";
+import ts from "typescript";
+
+const POLICY_PATH = "docs/doc_coverage_policy.json";
+
+const scopeArg = process.argv.find((arg) => arg.startsWith("--scope="));
+const requestedScope = scopeArg ? scopeArg.slice("--scope=".length) : "all";
+
+const scopeMap = {
+  all: ["typescript", "swift", "rust"],
+  ts: ["typescript"],
+  typescript: ["typescript"],
+  swift: ["swift"],
+  rust: ["rust"],
+  native: ["swift", "rust"],
+};
+
+const selectedLanguages = scopeMap[requestedScope];
+if (!selectedLanguages) {
+  console.error(`Unknown docs gate scope: ${requestedScope}`);
+  process.exit(1);
+}
+
+const rawPolicy = fs.readFileSync(POLICY_PATH, "utf8");
+const policy = JSON.parse(rawPolicy);
+
+const languageAnalyzers = {
+  typescript: analyzeTypeScriptFile,
+  swift: analyzeSwiftFile,
+  rust: analyzeRustFile,
+};
+
+const failures = [];
+const summaries = [];
+
+for (const language of selectedLanguages) {
+  const groups = policy[language] ?? [];
+  for (const group of groups) {
+    const analyzer = languageAnalyzers[language];
+    const files = collectFiles(group.roots, group.extensions);
+
+    const declarations = [];
+    for (const filePath of files) {
+      const fileText = fs.readFileSync(filePath, "utf8");
+      const fileDeclarations = analyzer(filePath, fileText);
+      declarations.push(...fileDeclarations);
+    }
+
+    const documentedCount = declarations.filter((item) => item.documented).length;
+    const totalCount = declarations.length;
+    const coverage = totalCount === 0 ? 1 : documentedCount / totalCount;
+
+    summaries.push({
+      language,
+      name: group.name,
+      minimumCoverage: group.minimumCoverage,
+      documentedCount,
+      totalCount,
+      coverage,
+    });
+
+    if (coverage + Number.EPSILON < group.minimumCoverage) {
+      failures.push({
+        language,
+        name: group.name,
+        minimumCoverage: group.minimumCoverage,
+        documentedCount,
+        totalCount,
+        coverage,
+        missing: declarations.filter((item) => !item.documented).slice(0, 20),
+      });
+    }
+  }
+}
+
+console.log("Documentation coverage gate:");
+for (const summary of summaries) {
+  const coveragePercent = (summary.coverage * 100).toFixed(1);
+  const minimumPercent = (summary.minimumCoverage * 100).toFixed(1);
+  console.log(
+    `- [${summary.language}] ${summary.name}: ${summary.documentedCount}/${summary.totalCount} (${coveragePercent}%) min ${minimumPercent}%`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error("\nDocumentation coverage check failed:");
+  for (const failure of failures) {
+    const coveragePercent = (failure.coverage * 100).toFixed(1);
+    const minimumPercent = (failure.minimumCoverage * 100).toFixed(1);
+    console.error(
+      `- [${failure.language}] ${failure.name}: ${coveragePercent}% < ${minimumPercent}% (${failure.documentedCount}/${failure.totalCount})`,
+    );
+    for (const missing of failure.missing) {
+      console.error(`  - ${missing.filePath}:${missing.line} ${missing.name}`);
+    }
+  }
+  process.exit(1);
+}
+
+console.log("Documentation coverage check passed.");
+
+function collectFiles(roots, extensions) {
+  const result = [];
+  const extensionSet = new Set(extensions);
+
+  for (const root of roots) {
+    const resolvedRoot = path.resolve(root);
+    if (!fs.existsSync(resolvedRoot)) {
+      continue;
+    }
+    walkDirectory(resolvedRoot, extensionSet, result);
+  }
+
+  result.sort();
+  return result;
+}
+
+function walkDirectory(directoryPath, extensionSet, result) {
+  const entries = fs.readdirSync(directoryPath, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(directoryPath, entry.name);
+    if (entry.isDirectory()) {
+      walkDirectory(fullPath, extensionSet, result);
+      continue;
+    }
+    if (!entry.isFile()) {
+      continue;
+    }
+    if (extensionSet.has(path.extname(entry.name))) {
+      result.push(fullPath);
+    }
+  }
+}
+
+function analyzeTypeScriptFile(filePath, sourceText) {
+  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true);
+  const declarations = [];
+
+  for (const statement of sourceFile.statements) {
+    if (!hasExportModifier(statement) || ts.isExportDeclaration(statement)) {
+      continue;
+    }
+
+    const documented = hasDocCommentAboveTypeScriptNode(sourceText, statement);
+    const line = sourceFile.getLineAndCharacterOfPosition(statement.getStart(sourceFile)).line + 1;
+
+    if (ts.isVariableStatement(statement)) {
+      const names = statement.declarationList.declarations
+        .map((declaration) => declaration.name.getText(sourceFile))
+        .join(", ");
+      declarations.push({ filePath, line, name: `export ${names}`, documented });
+      continue;
+    }
+
+    if (ts.isFunctionDeclaration(statement) || ts.isClassDeclaration(statement)) {
+      const name = statement.name?.text ?? "default";
+      declarations.push({ filePath, line, name: `export ${name}`, documented });
+      continue;
+    }
+
+    if (
+      ts.isInterfaceDeclaration(statement) ||
+      ts.isTypeAliasDeclaration(statement) ||
+      ts.isEnumDeclaration(statement)
+    ) {
+      declarations.push({ filePath, line, name: `export ${statement.name.text}`, documented });
+      continue;
+    }
+  }
+
+  return declarations;
+}
+
+function hasExportModifier(node) {
+  return Boolean(node.modifiers?.some((modifier) => modifier.kind === ts.SyntaxKind.ExportKeyword));
+}
+
+function hasDocCommentAboveTypeScriptNode(sourceText, node) {
+  const ranges = ts.getLeadingCommentRanges(sourceText, node.getFullStart()) ?? [];
+  if (ranges.length === 0) {
+    return false;
+  }
+
+  const lastRange = ranges[ranges.length - 1];
+  const between = sourceText.slice(lastRange.end, node.getStart());
+  if (between.trim().length > 0) {
+    return false;
+  }
+
+  const comment = sourceText.slice(lastRange.pos, lastRange.end).trimStart();
+  return comment.startsWith("/**");
+}
+
+function analyzeSwiftFile(filePath, sourceText) {
+  const declarations = [];
+  const lines = sourceText.split(/\r?\n/);
+  const declarationPattern =
+    /^(public|open)\s+(?:final\s+)?(?:class|struct|enum|protocol|actor|typealias|func|var|let|extension|init)\b/;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (line.startsWith(" ") || line.startsWith("\t")) {
+      continue;
+    }
+    if (!declarationPattern.test(line)) {
+      continue;
+    }
+
+    declarations.push({
+      filePath,
+      line: index + 1,
+      name: line.trim(),
+      documented: hasDocCommentAboveLine(lines, index, ["///"]),
+    });
+  }
+
+  return declarations;
+}
+
+function analyzeRustFile(filePath, sourceText) {
+  const declarations = [];
+  const lines = sourceText.split(/\r?\n/);
+  const declarationPattern = /^pub\s+(?:const|struct|enum|fn|mod|use|trait|type)\b/;
+
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index];
+    if (!declarationPattern.test(line)) {
+      continue;
+    }
+
+    declarations.push({
+      filePath,
+      line: index + 1,
+      name: line.trim(),
+      documented: hasRustDocCommentAboveLine(lines, index),
+    });
+  }
+
+  return declarations;
+}
+
+function hasRustDocCommentAboveLine(lines, declarationIndex) {
+  let cursor = declarationIndex - 1;
+  while (cursor >= 0) {
+    const trimmed = lines[cursor].trim();
+    if (trimmed === "" || trimmed.startsWith("#[")) {
+      cursor -= 1;
+      continue;
+    }
+    if (trimmed.startsWith("///") || trimmed.startsWith("//!")) {
+      return true;
+    }
+    if (!trimmed.endsWith("*/")) {
+      return false;
+    }
+
+    while (cursor >= 0) {
+      const blockLine = lines[cursor].trim();
+      if (blockLine.startsWith("/**")) {
+        return true;
+      }
+      if (blockLine.startsWith("/*")) {
+        return false;
+      }
+      cursor -= 1;
+    }
+    return false;
+  }
+
+  return false;
+}
+
+function hasDocCommentAboveLine(lines, declarationIndex, linePrefixes) {
+  let cursor = declarationIndex - 1;
+  while (cursor >= 0 && lines[cursor].trim() === "") {
+    cursor -= 1;
+  }
+
+  if (cursor < 0) {
+    return false;
+  }
+
+  const immediate = lines[cursor].trim();
+  if (linePrefixes.some((prefix) => immediate.startsWith(prefix))) {
+    return true;
+  }
+
+  if (!immediate.endsWith("*/")) {
+    return false;
+  }
+
+  while (cursor >= 0) {
+    const line = lines[cursor].trim();
+    if (line.startsWith("/**")) {
+      return true;
+    }
+    if (line.startsWith("/*")) {
+      return false;
+    }
+    cursor -= 1;
+  }
+
+  return false;
+}

--- a/Scripts/full_gate.sh
+++ b/Scripts/full_gate.sh
@@ -9,6 +9,10 @@ Scripts/rust_gate.sh
 echo "==> typescript gate"
 Scripts/typescript_gate.sh
 
+# Run docs gate for Swift/Rust surfaces
+echo "==> docs gate (native surfaces)"
+bun run docs:check:native
+
 # Run SwiftFormat
 echo "==> swiftformat"
 swiftformat .

--- a/Scripts/typescript_gate.sh
+++ b/Scripts/typescript_gate.sh
@@ -12,6 +12,9 @@ bun run js:format:check
 echo "==> js lint (oxlint)"
 bun run js:lint
 
+echo "==> docs gate (typescript surfaces)"
+bun run docs:check:ts
+
 echo "==> desktop typecheck"
 (cd apps/desktop-electrobun && bun run typecheck)
 

--- a/apps/desktop-electrobun/src/bun/bridge/requestHandlers.ts
+++ b/apps/desktop-electrobun/src/bun/bridge/requestHandlers.ts
@@ -10,6 +10,7 @@ type BridgeHandlerDependencies = {
   setCurrentProjectPath: (projectPath: string | null) => void;
 };
 
+/** Creates bridge RPC handlers backed by the desktop engine client. */
 export function createEngineBridgeHandlers({
   engineClient,
   pickDirectory,

--- a/apps/desktop-electrobun/src/bun/engine/client.ts
+++ b/apps/desktop-electrobun/src/bun/engine/client.ts
@@ -32,6 +32,7 @@ type EngineStdin = {
 
 type EngineProcess = Bun.PipedSubprocess;
 
+/** Supported native and stub engine targets. */
 export type EngineTarget =
   | "macos-swift"
   | "windows-native"
@@ -378,6 +379,7 @@ function firstExisting(...paths: string[]): string {
   return paths[0] ?? "";
 }
 
+/** Resolves the engine executable path for the current environment. */
 export function resolveEnginePath(options?: {
   env?: NodeJS.ProcessEnv;
   platform?: NodeJS.Platform;
@@ -412,6 +414,7 @@ export function resolveEnginePath(options?: {
   return resolveByTarget("macos-swift", baseDir);
 }
 
+/** JSON-RPC client for the native engine stdio transport. */
 export class EngineClient {
   private process: EngineProcess | null = null;
   private stdin: EngineStdin | null = null;

--- a/apps/desktop-electrobun/src/bun/media/policy.ts
+++ b/apps/desktop-electrobun/src/bun/media/policy.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 
 const supportedMediaExtensions = [".mov", ".mp4", ".m4v", ".webm"] as const;
 
+/** Media extensions that can be resolved through the desktop bridge. */
 export const mediaExtensions = new Set<string>(supportedMediaExtensions);
 
 const mediaMimeByExtension: Record<string, string> = {
@@ -11,14 +12,17 @@ const mediaMimeByExtension: Record<string, string> = {
   ".webm": "video/webm",
 };
 
+/** Returns the normalized extension for a media path. */
 export function mediaExtension(filePath: string): string {
   return path.extname(filePath).toLowerCase();
 }
 
+/** Returns whether the path extension is supported media. */
 export function isSupportedMediaPath(filePath: string): boolean {
   return mediaExtensions.has(mediaExtension(filePath));
 }
 
+/** Returns the response MIME type for a supported media path. */
 export function mediaTypeForPath(filePath: string): string {
   return mediaMimeByExtension[mediaExtension(filePath)] ?? "application/octet-stream";
 }

--- a/apps/desktop-electrobun/src/bun/media/server.ts
+++ b/apps/desktop-electrobun/src/bun/media/server.ts
@@ -132,6 +132,7 @@ function mediaSecurityHeaders(): Record<string, string> {
   };
 }
 
+/** Loopback-only media server that mints temporary file-backed playback URLs. */
 export class MediaServer {
   private server: ReturnType<typeof Bun.serve> | null = null;
   private origin: string | null = null;

--- a/apps/desktop-electrobun/src/bun/menu/actions.ts
+++ b/apps/desktop-electrobun/src/bun/menu/actions.ts
@@ -3,14 +3,17 @@ import { hostMenuCommandList, type HostMenuCommand } from "../../shared/bridgeRp
 const hostCommandPrefix = "host:";
 const hostMenuCommandSet = new Set<HostMenuCommand>(hostMenuCommandList);
 
+/** Narrows a string to a supported host menu command. */
 export function isHostMenuCommand(value: string): value is HostMenuCommand {
   return hostMenuCommandSet.has(value as HostMenuCommand);
 }
 
+/** Encodes a host menu command into the menu action payload format. */
 export function encodeHostMenuAction(command: HostMenuCommand): string {
   return `${hostCommandPrefix}${command}`;
 }
 
+/** Decodes a menu action payload into a host command when possible. */
 export function decodeHostMenuAction(action: string): HostMenuCommand | null {
   if (!action.startsWith(hostCommandPrefix)) {
     return null;
@@ -19,6 +22,7 @@ export function decodeHostMenuAction(action: string): HostMenuCommand | null {
   return isHostMenuCommand(command) ? command : null;
 }
 
+/** Extracts the action string from an Electrobun menu event payload. */
 export function extractMenuAction(event: unknown): string | null {
   if (typeof event !== "object" || event === null) {
     return null;

--- a/apps/desktop-electrobun/src/bun/menu/builders.ts
+++ b/apps/desktop-electrobun/src/bun/menu/builders.ts
@@ -94,6 +94,7 @@ function buildTrayCommands(state: HostMenuState, locale?: string): MenuItemConfi
   return items;
 }
 
+/** Builds the platform application menu from host command definitions. */
 export function buildApplicationMenu(
   state: HostMenuState,
   platform: NodeJS.Platform = process.platform,
@@ -198,6 +199,7 @@ export function buildApplicationMenu(
   ];
 }
 
+/** Builds the Linux tray menu from the host command registry. */
 export function buildLinuxTrayMenu(state: HostMenuState, locale?: string): MenuItemConfig[] {
   const labels = getDesktopMenuMessages(locale ?? state.locale);
   return [

--- a/apps/desktop-electrobun/src/bun/menu/router.ts
+++ b/apps/desktop-electrobun/src/bun/menu/router.ts
@@ -8,6 +8,7 @@ type MenuActionHandlers = {
   quit: () => void;
 };
 
+/** Routes desktop menu actions to host command and shell handlers. */
 export function routeMenuAction(action: string, handlers: MenuActionHandlers): void {
   const command = decodeHostMenuAction(action);
   if (command) {

--- a/apps/desktop-electrobun/src/bun/security/fileAccess.ts
+++ b/apps/desktop-electrobun/src/bun/security/fileAccess.ts
@@ -88,6 +88,7 @@ function ensurePathWithinAllowedRoots(
   return canonicalTargetPath;
 }
 
+/** Resolves and validates a JSON text file path for bridge reads. */
 export function resolveAllowedTextFilePath(
   filePath: string,
   options: ReadTextFileOptions = {},
@@ -104,6 +105,7 @@ export function resolveAllowedTextFilePath(
   return ensurePathWithinAllowedRoots(resolvedPath, options);
 }
 
+/** Resolves and validates a supported media file path for bridge reads. */
 export function resolveAllowedMediaFilePath(
   filePath: string,
   options: ResolveAllowedMediaFileOptions = {},
@@ -138,6 +140,7 @@ export function resolveAllowedMediaFilePath(
   return canonicalPath;
 }
 
+/** Reads a validated JSON text file with size and root constraints applied. */
 export async function readAllowedTextFile(
   filePath: string,
   options: ReadTextFileOptions = {},

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -89,6 +89,7 @@ Guerilla Glass should feel like a professional creator tool:
 - **Code quality tooling (no‑Xcode workflow):**
   - Formatter: **SwiftFormat** with a repo‑level `.swiftformat` config.
   - Linting: **SwiftLint** with `.swiftlint.yml` (editor plugin + CI checks).
+  - Public API documentation coverage gate: `Scripts/docs_gate.mjs` with thresholds in `docs/doc_coverage_policy.json`.
   - Optional: **Periphery** for dead‑code detection in later phases.
   - Build logs: **xcbeautify** for readable CLI output.
   - LSP: **xcode-build-server** to support Cursor/SweetPad indexing.
@@ -489,11 +490,13 @@ guerillaglass/
 ├─ Scripts/
 │  ├─ full_gate.sh
 │  ├─ rust_gate.sh
-│  └─ typescript_gate.sh
+│  ├─ typescript_gate.sh
+│  └─ docs_gate.mjs
 ├─ docs/
 │  ├─ SPEC.md
 │  ├─ ARCHITECTURE.md
-│  └─ DESKTOP_ACCESSIBILITY.md
+│  ├─ DESKTOP_ACCESSIBILITY.md
+│  └─ doc_coverage_policy.json
 ├─ apps/
 │  └─ desktop-electrobun/
 │     ├─ src/

--- a/docs/doc_coverage_policy.json
+++ b/docs/doc_coverage_policy.json
@@ -4,7 +4,7 @@
       "name": "engine-protocol-public-api",
       "roots": ["packages/engine-protocol/src"],
       "extensions": [".ts"],
-      "minimumCoverage": 0.43
+      "minimumCoverage": 1
     },
     {
       "name": "localization-public-api",
@@ -30,7 +30,7 @@
       "name": "macos-engine-public-surface",
       "roots": ["engines/macos-swift"],
       "extensions": [".swift"],
-      "minimumCoverage": 0.27
+      "minimumCoverage": 1
     }
   ],
   "rust": [

--- a/docs/doc_coverage_policy.json
+++ b/docs/doc_coverage_policy.json
@@ -4,7 +4,7 @@
       "name": "engine-protocol-public-api",
       "roots": ["packages/engine-protocol/src"],
       "extensions": [".ts"],
-      "minimumCoverage": 0.18
+      "minimumCoverage": 0.4
     },
     {
       "name": "localization-public-api",
@@ -30,7 +30,7 @@
       "name": "macos-engine-public-surface",
       "roots": ["engines/macos-swift"],
       "extensions": [".swift"],
-      "minimumCoverage": 0.2
+      "minimumCoverage": 0.26
     }
   ],
   "rust": [

--- a/docs/doc_coverage_policy.json
+++ b/docs/doc_coverage_policy.json
@@ -1,0 +1,50 @@
+{
+  "typescript": [
+    {
+      "name": "engine-protocol-public-api",
+      "roots": ["packages/engine-protocol/src"],
+      "extensions": [".ts"],
+      "minimumCoverage": 0.18
+    },
+    {
+      "name": "localization-public-api",
+      "roots": ["packages/localization/src"],
+      "extensions": [".ts"],
+      "minimumCoverage": 1
+    },
+    {
+      "name": "desktop-bridge-public-api",
+      "roots": ["apps/desktop-electrobun/src/bun"],
+      "extensions": [".ts"],
+      "minimumCoverage": 1
+    }
+  ],
+  "swift": [
+    {
+      "name": "protocol-swift-public-surface",
+      "roots": ["engines/protocol-swift"],
+      "extensions": [".swift"],
+      "minimumCoverage": 1
+    },
+    {
+      "name": "macos-engine-public-surface",
+      "roots": ["engines/macos-swift"],
+      "extensions": [".swift"],
+      "minimumCoverage": 0.2
+    }
+  ],
+  "rust": [
+    {
+      "name": "protocol-rust-public-api",
+      "roots": ["engines/protocol-rust/src"],
+      "extensions": [".rs"],
+      "minimumCoverage": 1
+    },
+    {
+      "name": "native-foundation-public-api",
+      "roots": ["engines/native-foundation/src"],
+      "extensions": [".rs"],
+      "minimumCoverage": 1
+    }
+  ]
+}

--- a/docs/doc_coverage_policy.json
+++ b/docs/doc_coverage_policy.json
@@ -4,7 +4,7 @@
       "name": "engine-protocol-public-api",
       "roots": ["packages/engine-protocol/src"],
       "extensions": [".ts"],
-      "minimumCoverage": 0.4
+      "minimumCoverage": 0.43
     },
     {
       "name": "localization-public-api",
@@ -30,7 +30,7 @@
       "name": "macos-engine-public-surface",
       "roots": ["engines/macos-swift"],
       "extensions": [".swift"],
-      "minimumCoverage": 0.26
+      "minimumCoverage": 0.27
     }
   ],
   "rust": [

--- a/engines/macos-swift/modules/automation/AttentionModel.swift
+++ b/engines/macos-swift/modules/automation/AttentionModel.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import InputTracking
 
+/// Public value type exposed by the macOS engine module.
 public struct AttentionSample: Equatable {
     public let time: TimeInterval
     public let position: CGPoint
@@ -10,6 +11,7 @@ public struct AttentionSample: Equatable {
     public let isClick: Bool
 }
 
+/// Public value type exposed by the macOS engine module.
 public struct AttentionModel {
     public init() {}
 

--- a/engines/macos-swift/modules/automation/VirtualCameraPlanner.swift
+++ b/engines/macos-swift/modules/automation/VirtualCameraPlanner.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import InputTracking
 
+/// Public value type exposed by the macOS engine module.
 public struct CameraKeyframe: Equatable {
     public let time: TimeInterval
     public let center: CGPoint
@@ -14,6 +15,7 @@ public struct CameraKeyframe: Equatable {
     }
 }
 
+/// Public value type exposed by the macOS engine module.
 public struct CameraPlan: Equatable {
     public let sourceSize: CGSize
     public let keyframes: [CameraKeyframe]
@@ -26,6 +28,7 @@ public struct CameraPlan: Equatable {
     }
 }
 
+/// Public class exposed by the macOS engine module.
 public final class VirtualCameraPlanner {
     private let attentionModel: AttentionModel
 

--- a/engines/macos-swift/modules/automation/ZoomConstraints.swift
+++ b/engines/macos-swift/modules/automation/ZoomConstraints.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct ZoomConstraints: Equatable {
     public var maxZoom: CGFloat
     public var minVisibleAreaFraction: CGFloat

--- a/engines/macos-swift/modules/capture/AudioCapture.swift
+++ b/engines/macos-swift/modules/capture/AudioCapture.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 
+/// Public class exposed by the macOS engine module.
 public final class AudioCapture {
     private let engine = AVAudioEngine()
     private var isRunning = false
@@ -47,6 +48,7 @@ public final class AudioCapture {
     }
 }
 
+/// Public enum exposed by the macOS engine module.
 public enum AudioCaptureError: LocalizedError {
     case microphoneDenied
 

--- a/engines/macos-swift/modules/capture/CaptureClock.swift
+++ b/engines/macos-swift/modules/capture/CaptureClock.swift
@@ -2,6 +2,7 @@ import CoreMedia
 import Foundation
 import QuartzCore
 
+/// Monotonic capture clock used for media timing.
 public struct CaptureClock {
     public init() {}
 

--- a/engines/macos-swift/modules/capture/CaptureDescriptor.swift
+++ b/engines/macos-swift/modules/capture/CaptureDescriptor.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 
+/// Immutable descriptor of the current capture source geometry and scale.
 public struct CaptureDescriptor: Equatable {
     public struct WindowTarget: Equatable {
         public let id: CGWindowID

--- a/engines/macos-swift/modules/capture/CaptureEngine+Recording.swift
+++ b/engines/macos-swift/modules/capture/CaptureEngine+Recording.swift
@@ -3,6 +3,7 @@ import Export
 import Foundation
 import OSLog
 
+/// Public extension for the macOS engine API surface.
 public extension CaptureEngine {
     private static let logger = Logger(subsystem: "com.guerillaglass", category: "recording")
 

--- a/engines/macos-swift/modules/capture/CaptureEngine.swift
+++ b/engines/macos-swift/modules/capture/CaptureEngine.swift
@@ -4,6 +4,7 @@ import Export
 import Foundation
 import ScreenCaptureKit
 
+/// Primary ScreenCaptureKit capture coordinator for display and window capture sessions.
 public final class CaptureEngine: NSObject, ObservableObject {
     @Published public private(set) var latestFrame: CGImage?
     @Published public private(set) var isRunning: Bool = false

--- a/engines/macos-swift/modules/capture/CaptureError.swift
+++ b/engines/macos-swift/modules/capture/CaptureError.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Errors surfaced by the capture engine lifecycle and source selection flow.
 public enum CaptureError: LocalizedError {
     case noDisplayAvailable
     case screenRecordingDenied

--- a/engines/macos-swift/modules/capture/CaptureFrameRate.swift
+++ b/engines/macos-swift/modules/capture/CaptureFrameRate.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Policy helpers for supported capture frame rates.
 public enum CaptureFrameRatePolicy {
     public static let supportedValues: [Int] = [24, 30, 60]
     public static let defaultValue: Int = 30

--- a/engines/macos-swift/modules/capture/CaptureTelemetryHealth.swift
+++ b/engines/macos-swift/modules/capture/CaptureTelemetryHealth.swift
@@ -1,11 +1,13 @@
 import Foundation
 
+/// Capture health severity levels derived from runtime telemetry.
 public enum CaptureTelemetryHealthState: String {
     case good
     case warning
     case critical
 }
 
+/// Capture health reason codes used by protocol and UI surfaces.
 public enum CaptureTelemetryHealthReason: String {
     case engineError = "engine_error"
     case highDroppedFrameRate = "high_dropped_frame_rate"
@@ -13,6 +15,7 @@ public enum CaptureTelemetryHealthReason: String {
     case lowMicrophoneLevel = "low_microphone_level"
 }
 
+/// Evaluated capture health state plus optional reason.
 public struct CaptureTelemetryHealth: Equatable {
     public var state: CaptureTelemetryHealthState
     public var reason: CaptureTelemetryHealthReason?
@@ -26,6 +29,7 @@ public struct CaptureTelemetryHealth: Equatable {
     }
 }
 
+/// Input fields required to evaluate capture health for a recording session.
 public struct CaptureTelemetryHealthInput {
     public let totalFrames: Int
     public let droppedFramePercent: Double
@@ -54,6 +58,7 @@ public struct CaptureTelemetryHealthInput {
     }
 }
 
+/// Computes health state from capture telemetry inputs.
 public enum CaptureTelemetryHealthEvaluator {
     private static let minimumDroppedFrameSamples = 90
 

--- a/engines/macos-swift/modules/capture/CaptureTelemetryMath.swift
+++ b/engines/macos-swift/modules/capture/CaptureTelemetryMath.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Shared telemetry math helpers used by capture health calculations.
 public enum CaptureTelemetryMath {
     public static func estimateMissedFrames(
         deltaSeconds: Double,

--- a/engines/macos-swift/modules/capture/DisplayCapture.swift
+++ b/engines/macos-swift/modules/capture/DisplayCapture.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import ScreenCaptureKit
 
+/// Display capture target identified by `CGDirectDisplayID`.
 public struct DisplayCapture {
     public let displayID: CGDirectDisplayID
 

--- a/engines/macos-swift/modules/capture/ShareableWindow.swift
+++ b/engines/macos-swift/modules/capture/ShareableWindow.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import ScreenCaptureKit
 
+/// Public value type exposed by the macOS engine module.
 public struct ShareableWindow: Identifiable, Hashable {
     public let id: CGWindowID
     public let title: String

--- a/engines/macos-swift/modules/capture/WindowCapture.swift
+++ b/engines/macos-swift/modules/capture/WindowCapture.swift
@@ -2,6 +2,7 @@ import CoreGraphics
 import Foundation
 import ScreenCaptureKit
 
+/// Window capture target identified by `CGWindowID`.
 public struct WindowCapture {
     public let windowID: CGWindowID
 

--- a/engines/macos-swift/modules/export/AssetWriter.swift
+++ b/engines/macos-swift/modules/export/AssetWriter.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 
+/// Public class exposed by the macOS engine module.
 public final class AssetWriter {
     public enum VideoAppendOutcome {
         case appended

--- a/engines/macos-swift/modules/export/ExportPipeline.swift
+++ b/engines/macos-swift/modules/export/ExportPipeline.swift
@@ -3,6 +3,7 @@ import AVFoundation
 import Foundation
 import Rendering
 
+/// Public class exposed by the macOS engine module.
 public final class ExportPipeline {
     private final class ExportSessionBox: @unchecked Sendable {
         let session: AVAssetExportSession

--- a/engines/macos-swift/modules/export/Presets.swift
+++ b/engines/macos-swift/modules/export/Presets.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 
+/// Export preset descriptor shared between engine and desktop shell.
 public struct ExportPreset: Identifiable, Hashable {
     public let id: String
     public let name: String
@@ -32,6 +33,7 @@ public struct ExportPreset: Identifiable, Hashable {
     }
 }
 
+/// Built-in export preset catalog.
 public enum Presets {
     public static let h2641080p30 = ExportPreset(
         id: "h264-1080p-30",

--- a/engines/macos-swift/modules/export/TrimRangeCalculator.swift
+++ b/engines/macos-swift/modules/export/TrimRangeCalculator.swift
@@ -1,6 +1,7 @@
 import AVFoundation
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct TrimRangeValues: Equatable {
     public let start: Double
     public let end: Double
@@ -11,6 +12,7 @@ public struct TrimRangeValues: Equatable {
     }
 }
 
+/// Public enum exposed by the macOS engine module.
 public enum TrimRangeCalculator {
     public static func clamped(
         start: Double,

--- a/engines/macos-swift/modules/inputTracking/ClickTracker.swift
+++ b/engines/macos-swift/modules/inputTracking/ClickTracker.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 
+/// Public class exposed by the macOS engine module.
 public final class ClickTracker {
     public enum Phase {
         case pressed

--- a/engines/macos-swift/modules/inputTracking/CursorTracker.swift
+++ b/engines/macos-swift/modules/inputTracking/CursorTracker.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 
+/// Public class exposed by the macOS engine module.
 public final class CursorTracker {
     public typealias Handler = (_ position: CGPoint, _ timestamp: TimeInterval) -> Void
 

--- a/engines/macos-swift/modules/inputTracking/InputEvent.swift
+++ b/engines/macos-swift/modules/inputTracking/InputEvent.swift
@@ -1,18 +1,21 @@
 import CoreGraphics
 import Foundation
 
+/// Public enum exposed by the macOS engine module.
 public enum InputEventType: String, Codable {
     case cursorMoved
     case mouseDown
     case mouseUp
 }
 
+/// Public enum exposed by the macOS engine module.
 public enum MouseButton: String, Codable {
     case left
     case right
     case other
 }
 
+/// Public value type exposed by the macOS engine module.
 public struct InputPoint: Codable, Equatable {
     public let xValue: Double
     public let yValue: Double
@@ -36,6 +39,7 @@ public struct InputPoint: Codable, Equatable {
     }
 }
 
+/// Public value type exposed by the macOS engine module.
 public struct InputEvent: Codable, Equatable {
     public let type: InputEventType
     public let timestamp: TimeInterval

--- a/engines/macos-swift/modules/inputTracking/InputEventLog.swift
+++ b/engines/macos-swift/modules/inputTracking/InputEventLog.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct InputEventLog: Codable, Equatable {
     public static let schemaVersion = 1
 

--- a/engines/macos-swift/modules/inputTracking/InputEventSession.swift
+++ b/engines/macos-swift/modules/inputTracking/InputEventSession.swift
@@ -1,6 +1,7 @@
 import Foundation
 import QuartzCore
 
+/// Public value type exposed by the macOS engine module.
 public struct InputClock {
     public let now: () -> TimeInterval
 
@@ -13,6 +14,7 @@ public struct InputClock {
     }
 }
 
+/// Public class exposed by the macOS engine module.
 public final class InputEventRecorder {
     private let queue = DispatchQueue(label: "gg.input.events")
     private let clock: InputClock
@@ -64,6 +66,7 @@ public final class InputEventRecorder {
     }
 }
 
+/// Public class exposed by the macOS engine module.
 public final class InputEventSession {
     public private(set) var isRunning = false
 

--- a/engines/macos-swift/modules/inputTracking/InputPermissionManager.swift
+++ b/engines/macos-swift/modules/inputTracking/InputPermissionManager.swift
@@ -2,12 +2,14 @@ import AppKit
 import Foundation
 import IOKit.hidsystem
 
+/// Public enum exposed by the macOS engine module.
 public enum InputMonitoringStatus: Equatable {
     case notDetermined
     case denied
     case authorized
 }
 
+/// Public class exposed by the macOS engine module.
 public final class InputPermissionManager {
     public init() {}
 

--- a/engines/macos-swift/modules/project/AutoZoomSettings.swift
+++ b/engines/macos-swift/modules/project/AutoZoomSettings.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct AutoZoomSettings: Codable, Equatable {
     public static let intensityRange: ClosedRange<Double> = 0 ... 1
     public static let minimumKeyframeIntervalRange: ClosedRange<TimeInterval> =

--- a/engines/macos-swift/modules/project/CaptureMetadata.swift
+++ b/engines/macos-swift/modules/project/CaptureMetadata.swift
@@ -1,6 +1,7 @@
 import CoreGraphics
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct CaptureRect: Codable, Equatable {
     public var originX: Double
     public var originY: Double
@@ -35,6 +36,7 @@ public struct CaptureRect: Codable, Equatable {
     }
 }
 
+/// Public value type exposed by the macOS engine module.
 public struct CaptureMetadata: Codable, Equatable {
     public struct Window: Codable, Equatable {
         public var id: UInt32

--- a/engines/macos-swift/modules/project/Project.swift
+++ b/engines/macos-swift/modules/project/Project.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct Project: Codable, Identifiable, Equatable {
     public let id: UUID
     public var createdAt: Date

--- a/engines/macos-swift/modules/project/ProjectDocument.swift
+++ b/engines/macos-swift/modules/project/ProjectDocument.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct ProjectDocument: Codable, Equatable {
     public var projectVersion: Int
     public var project: Project

--- a/engines/macos-swift/modules/project/ProjectFile.swift
+++ b/engines/macos-swift/modules/project/ProjectFile.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public enum exposed by the macOS engine module.
 public enum ProjectFile {
     public static let projectJSON = "project.json"
     public static let recordingMov = "recording.mov"

--- a/engines/macos-swift/modules/project/ProjectLibraryStore.swift
+++ b/engines/macos-swift/modules/project/ProjectLibraryStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public value type exposed by the macOS engine module.
 public struct ProjectLibraryItem: Codable, Identifiable, Equatable {
     public let id: UUID
     public var bookmarkData: Data
@@ -19,6 +20,7 @@ public struct ProjectLibraryItem: Codable, Identifiable, Equatable {
     }
 }
 
+/// Public value type exposed by the macOS engine module.
 public struct ProjectLibraryIndex: Codable, Equatable {
     public var items: [ProjectLibraryItem]
 
@@ -27,6 +29,7 @@ public struct ProjectLibraryIndex: Codable, Equatable {
     }
 }
 
+/// Public class exposed by the macOS engine module.
 public final class ProjectLibraryStore {
     public enum StoreError: Error {
         case invalidProjectURL

--- a/engines/macos-swift/modules/project/ProjectMigration.swift
+++ b/engines/macos-swift/modules/project/ProjectMigration.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public enum exposed by the macOS engine module.
 public enum ProjectMigration {
     public enum MigrationError: Error {
         case unknownVersion

--- a/engines/macos-swift/modules/project/ProjectSchemaVersion.swift
+++ b/engines/macos-swift/modules/project/ProjectSchemaVersion.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public enum exposed by the macOS engine module.
 public enum ProjectSchemaVersion {
     public static let current = 3
 }

--- a/engines/macos-swift/modules/project/ProjectStore.swift
+++ b/engines/macos-swift/modules/project/ProjectStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// Public class exposed by the macOS engine module.
 public final class ProjectStore {
     public enum StoreError: Error {
         case invalidRecordingURL

--- a/engines/macos-swift/modules/rendering/ExportRenderer.swift
+++ b/engines/macos-swift/modules/rendering/ExportRenderer.swift
@@ -2,6 +2,7 @@ import Automation
 import AVFoundation
 import Foundation
 
+/// Public class exposed by the macOS engine module.
 public final class ExportRenderer {
     public init() {}
 

--- a/engines/macos-swift/modules/rendering/PreviewRenderer.swift
+++ b/engines/macos-swift/modules/rendering/PreviewRenderer.swift
@@ -2,6 +2,7 @@ import Automation
 import AVFoundation
 import Foundation
 
+/// Public class exposed by the macOS engine module.
 public final class PreviewRenderer {
     public init() {}
 

--- a/engines/native-foundation/src/lib.rs
+++ b/engines/native-foundation/src/lib.rs
@@ -9,13 +9,18 @@ use std::path::{Path, PathBuf};
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
+/// Native foundation engine version identifier.
 pub const ENGINE_VERSION: &str = "0.4.0-native-foundation";
+/// Native foundation phase reported in capability responses.
 pub const ENGINE_PHASE: &str = "foundation";
 const MAX_RECENT_PROJECTS: usize = 20;
 const DEFAULT_RECENTS_LIMIT: usize = 10;
 
+/// Runtime configuration for the native foundation engine loop.
 pub struct EngineRuntimeConfig {
+    /// Platform identifier returned in capability and ping payloads.
     pub platform: &'static str,
+    /// Path to persisted recents index used by project methods.
     pub recents_index_path: PathBuf,
 }
 
@@ -420,6 +425,7 @@ fn write_response(stdout: &mut io::Stdout, response: EngineResponse) {
     }
 }
 
+/// Runs the native foundation stdio request loop until stdin is closed.
 pub fn run_engine(config: EngineRuntimeConfig) {
     let stdin = io::stdin();
     let mut stdout = io::stdout();

--- a/engines/protocol-rust/src/clock.rs
+++ b/engines/protocol-rust/src/clock.rs
@@ -1,5 +1,6 @@
 use std::time::Instant;
 
+/// Monotonic capture clock used by native runtime state.
 #[derive(Debug)]
 pub struct CaptureClock {
     started_at: Instant,
@@ -14,11 +15,13 @@ impl Default for CaptureClock {
 }
 
 impl CaptureClock {
+    /// Returns elapsed seconds since the clock was created.
     pub fn now_seconds(&self) -> f64 {
         self.started_at.elapsed().as_secs_f64()
     }
 }
 
+/// Running duration accumulator for start/stop style recording sessions.
 #[derive(Debug, Default)]
 pub struct RunningDuration {
     accumulated_seconds: f64,
@@ -26,18 +29,21 @@ pub struct RunningDuration {
 }
 
 impl RunningDuration {
+    /// Starts accumulation using the provided clock if not already running.
     pub fn start(&mut self, clock: &CaptureClock) {
         if self.started_at_seconds.is_none() {
             self.started_at_seconds = Some(clock.now_seconds());
         }
     }
 
+    /// Stops accumulation and stores elapsed time since the last start.
     pub fn stop(&mut self, clock: &CaptureClock) {
         if let Some(started_at_seconds) = self.started_at_seconds.take() {
             self.accumulated_seconds += (clock.now_seconds() - started_at_seconds).max(0.0);
         }
     }
 
+    /// Returns total elapsed duration including the in-flight segment when running.
     pub fn current(&self, clock: &CaptureClock) -> f64 {
         match self.started_at_seconds {
             Some(started_at_seconds) => {
@@ -47,6 +53,7 @@ impl RunningDuration {
         }
     }
 
+    /// Returns whether the duration accumulator is currently running.
     pub fn is_running(&self) -> bool {
         self.started_at_seconds.is_some()
     }

--- a/engines/protocol-rust/src/lib.rs
+++ b/engines/protocol-rust/src/lib.rs
@@ -1,7 +1,13 @@
+//! Shared Rust protocol types and helpers for Guerillaglass native engines.
+
+/// Capture timing primitives.
 pub mod clock;
+/// Protocol request and response message types.
 pub mod messages;
 
+/// Re-exported capture clock primitives.
 pub use clock::{CaptureClock, RunningDuration};
+/// Re-exported protocol message helpers and constants.
 pub use messages::{
     decode_request_line, encode_response_line, failure, success, EngineMethod, EngineRequest,
     EngineResponse, ProtocolErrorCode, PROTOCOL_VERSION,

--- a/engines/protocol-rust/src/messages.rs
+++ b/engines/protocol-rust/src/messages.rs
@@ -1,8 +1,10 @@
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 
+/// Protocol version shared between shell and native engines.
 pub const PROTOCOL_VERSION: &str = "2";
 
+/// Request envelope sent over line-delimited JSON transport.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EngineRequest {
     pub id: String,
@@ -14,11 +16,13 @@ pub struct EngineRequest {
 include!(concat!(env!("OUT_DIR"), "/engine_methods_generated.rs"));
 
 impl EngineRequest {
+    /// Attempts to map the raw method string to a known engine method variant.
     pub fn method_kind(&self) -> Option<EngineMethod> {
         EngineMethod::try_from(self.method.as_str()).ok()
     }
 }
 
+/// Stable engine error codes serialized in snake_case.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ProtocolErrorCode {
@@ -29,12 +33,14 @@ pub enum ProtocolErrorCode {
     RuntimeError,
 }
 
+/// Error payload returned by failed responses.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EngineError {
     pub code: ProtocolErrorCode,
     pub message: String,
 }
 
+/// Success response envelope.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EngineSuccessResponse {
     pub id: String,
@@ -42,6 +48,7 @@ pub struct EngineSuccessResponse {
     pub result: Value,
 }
 
+/// Error response envelope.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct EngineErrorResponse {
     pub id: String,
@@ -49,6 +56,7 @@ pub struct EngineErrorResponse {
     pub error: EngineError,
 }
 
+/// Untagged response union used by line codecs.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum EngineResponse {
@@ -56,14 +64,17 @@ pub enum EngineResponse {
     Error(EngineErrorResponse),
 }
 
+/// Decodes a JSON request line into a typed request envelope.
 pub fn decode_request_line(line: &str) -> Result<EngineRequest, serde_json::Error> {
     serde_json::from_str(line)
 }
 
+/// Encodes a typed response envelope into a JSON line.
 pub fn encode_response_line(response: &EngineResponse) -> Result<String, serde_json::Error> {
     serde_json::to_string(response)
 }
 
+/// Creates a success response payload for a request id.
 pub fn success(id: impl Into<String>, result: Value) -> EngineResponse {
     EngineResponse::Success(EngineSuccessResponse {
         id: id.into(),
@@ -72,6 +83,7 @@ pub fn success(id: impl Into<String>, result: Value) -> EngineResponse {
     })
 }
 
+/// Creates an error response payload for a request id.
 pub fn failure(
     id: impl Into<String>,
     code: ProtocolErrorCode,

--- a/engines/protocol-swift/EngineProtocol.swift
+++ b/engines/protocol-swift/EngineProtocol.swift
@@ -1,5 +1,6 @@
 import Foundation
 
+/// JSON-compatible value container used by engine request and response payloads.
 public enum JSONValue: Codable, Equatable {
     case string(String)
     case number(Double)
@@ -85,6 +86,7 @@ public enum JSONValue: Codable, Equatable {
     }
 }
 
+/// Request envelope sent from the desktop shell to the native engine.
 public struct EngineRequest: Codable, Equatable {
     public let id: String
     public let method: String
@@ -97,6 +99,7 @@ public struct EngineRequest: Codable, Equatable {
     }
 }
 
+/// Error payload returned for failed engine responses.
 public struct EngineError: Codable, Equatable {
     public let code: String
     public let message: String
@@ -108,6 +111,7 @@ public struct EngineError: Codable, Equatable {
 }
 
 // swiftlint:disable identifier_name
+/// Response envelope returned by the native engine.
 public struct EngineResponse: Codable, Equatable {
     public let id: String
     public let ok: Bool
@@ -132,10 +136,12 @@ public struct EngineResponse: Codable, Equatable {
 
 // swiftlint:enable identifier_name
 
+/// Errors thrown while decoding or encoding protocol lines.
 public enum EngineProtocolError: Error {
     case invalidLine
 }
 
+/// Line-delimited JSON codec for engine request and response transport.
 public enum EngineLineCodec {
     private static let decoder = JSONDecoder()
     private static let encoder = JSONEncoder()

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "gate": "./Scripts/full_gate.sh",
     "gate:rust": "./Scripts/rust_gate.sh",
-    "gate:typescript": "bun run js:format:check && bun run js:lint && bun run desktop:typecheck && bun run protocol:typecheck && bun run desktop:test",
+    "gate:typescript": "bun run js:format:check && bun run js:lint && bun run docs:check:ts && bun run desktop:typecheck && bun run protocol:typecheck && bun run desktop:test",
     "js:format": "bunx oxfmt --write apps packages",
     "js:format:check": "bunx oxfmt --check apps packages",
     "js:lint": "bunx oxlint -c oxlint.config.mjs --deny-warnings --type-aware apps packages && bun run js:lint:react-effects",
@@ -33,6 +33,9 @@
     "desktop:test:ui:headed": "cd apps/desktop-electrobun && bun run test:ui:headed",
     "desktop:test:ui:install": "cd apps/desktop-electrobun && bun run test:ui:install",
     "protocol:typecheck": "cd packages/engine-protocol && bun run typecheck",
+    "docs:check": "bun ./Scripts/docs_gate.mjs",
+    "docs:check:ts": "bun ./Scripts/docs_gate.mjs --scope=ts",
+    "docs:check:native": "bun ./Scripts/docs_gate.mjs --scope=native",
     "coverage": "./Scripts/coverage.sh",
     "coverage:typescript": "bun run desktop:test:coverage",
     "coverage:rust": "./Scripts/rust_coverage.sh",

--- a/packages/engine-protocol/src/index.ts
+++ b/packages/engine-protocol/src/index.ts
@@ -221,6 +221,7 @@ export const exportRunResultSchema = z.object({
   outputURL: z.string().min(1),
 });
 
+/** Engine protocol schema for projectStateSchema. */
 export const projectStateSchema = z.object({
   projectPath: z.string().nullable(),
   recordingURL: z.string().nullable(),
@@ -229,12 +230,14 @@ export const projectStateSchema = z.object({
   captureMetadata: captureMetadataSchema,
 });
 
+/** Engine protocol schema for projectRecentItemSchema. */
 export const projectRecentItemSchema = z.object({
   projectPath: z.string().min(1),
   displayName: z.string().min(1),
   lastOpenedAt: z.string().datetime(),
 });
 
+/** Engine protocol schema for projectRecentsResultSchema. */
 export const projectRecentsResultSchema = z.object({
   items: z.array(projectRecentItemSchema),
 });
@@ -245,46 +248,55 @@ const requestBaseSchema = z.object({
 
 const emptyParamsSchema = z.looseObject({}).optional().default({});
 
+/** Engine protocol schema for systemPingRequestSchema. */
 export const systemPingRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.SystemPing),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for engineCapabilitiesRequestSchema. */
 export const engineCapabilitiesRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.EngineCapabilities),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for permissionsGetRequestSchema. */
 export const permissionsGetRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.PermissionsGet),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for permissionsRequestScreenRequestSchema. */
 export const permissionsRequestScreenRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.PermissionsRequestScreenRecording),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for permissionsRequestMicrophoneRequestSchema. */
 export const permissionsRequestMicrophoneRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.PermissionsRequestMicrophone),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for permissionsRequestInputMonitoringRequestSchema. */
 export const permissionsRequestInputMonitoringRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.PermissionsRequestInputMonitoring),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for permissionsOpenInputSettingsRequestSchema. */
 export const permissionsOpenInputSettingsRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.PermissionsOpenInputMonitoringSettings),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for sourcesListRequestSchema. */
 export const sourcesListRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.SourcesList),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for captureStartDisplayRequestSchema. */
 export const captureStartDisplayRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.CaptureStartDisplay),
   params: z.object({
@@ -293,6 +305,7 @@ export const captureStartDisplayRequestSchema = requestBaseSchema.extend({
   }),
 });
 
+/** Engine protocol schema for captureStartWindowRequestSchema. */
 export const captureStartWindowRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.CaptureStartWindow),
   params: z.object({
@@ -302,11 +315,13 @@ export const captureStartWindowRequestSchema = requestBaseSchema.extend({
   }),
 });
 
+/** Engine protocol schema for captureStopRequestSchema. */
 export const captureStopRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.CaptureStop),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for recordingStartRequestSchema. */
 export const recordingStartRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.RecordingStart),
   params: z.object({
@@ -314,21 +329,25 @@ export const recordingStartRequestSchema = requestBaseSchema.extend({
   }),
 });
 
+/** Engine protocol schema for recordingStopRequestSchema. */
 export const recordingStopRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.RecordingStop),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for captureStatusRequestSchema. */
 export const captureStatusRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.CaptureStatus),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for exportInfoRequestSchema. */
 export const exportInfoRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.ExportInfo),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for exportRunRequestSchema. */
 export const exportRunRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.ExportRun),
   params: z.object({
@@ -339,11 +358,13 @@ export const exportRunRequestSchema = requestBaseSchema.extend({
   }),
 });
 
+/** Engine protocol schema for projectCurrentRequestSchema. */
 export const projectCurrentRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.ProjectCurrent),
   params: emptyParamsSchema,
 });
 
+/** Engine protocol schema for projectOpenRequestSchema. */
 export const projectOpenRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.ProjectOpen),
   params: z.object({
@@ -351,6 +372,7 @@ export const projectOpenRequestSchema = requestBaseSchema.extend({
   }),
 });
 
+/** Engine protocol schema for projectSaveRequestSchema. */
 export const projectSaveRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.ProjectSave),
   params: z.object({
@@ -359,6 +381,7 @@ export const projectSaveRequestSchema = requestBaseSchema.extend({
   }),
 });
 
+/** Engine protocol schema for projectRecentsRequestSchema. */
 export const projectRecentsRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.ProjectRecents),
   params: z
@@ -428,27 +451,49 @@ export const engineResponseSchema = z.union([
   engineErrorResponseSchema,
 ]);
 
+/** Type alias for EngineRequest. */
 export type EngineRequest = z.infer<typeof engineRequestSchema>;
+/** Type alias for EngineResponse. */
 export type EngineResponse = z.infer<typeof engineResponseSchema>;
+/** Type alias for EngineErrorCode. */
 export type EngineErrorCode = z.infer<typeof engineErrorCodeSchema>;
+/** Type alias for PingResult. */
 export type PingResult = z.infer<typeof pingResultSchema>;
+/** Type alias for CapabilitiesResult. */
 export type CapabilitiesResult = z.infer<typeof capabilitiesResultSchema>;
+/** Type alias for PermissionsResult. */
 export type PermissionsResult = z.infer<typeof permissionsResultSchema>;
+/** Type alias for ActionResult. */
 export type ActionResult = z.infer<typeof actionResultSchema>;
+/** Type alias for SourcesResult. */
 export type SourcesResult = z.infer<typeof sourcesResultSchema>;
+/** Type alias for CaptureHealth. */
 export type CaptureHealth = z.infer<typeof captureHealthSchema>;
+/** Type alias for CaptureHealthReason. */
 export type CaptureHealthReason = z.infer<typeof captureHealthReasonSchema>;
+/** Type alias for CaptureFrameRate. */
 export type CaptureFrameRate = z.infer<typeof captureFrameRateSchema>;
+/** Type alias for CaptureTelemetry. */
 export type CaptureTelemetry = z.infer<typeof captureTelemetrySchema>;
+/** Type alias for CaptureStatusResult. */
 export type CaptureStatusResult = z.infer<typeof captureStatusResultSchema>;
+/** Type alias for ExportPreset. */
 export type ExportPreset = z.infer<typeof exportPresetSchema>;
+/** Type alias for ExportInfoResult. */
 export type ExportInfoResult = z.infer<typeof exportInfoResultSchema>;
+/** Type alias for ExportRunResult. */
 export type ExportRunResult = z.infer<typeof exportRunResultSchema>;
+/** Type alias for ProjectState. */
 export type ProjectState = z.infer<typeof projectStateSchema>;
+/** Type alias for ProjectRecentItem. */
 export type ProjectRecentItem = z.infer<typeof projectRecentItemSchema>;
+/** Type alias for ProjectRecentsResult. */
 export type ProjectRecentsResult = z.infer<typeof projectRecentsResultSchema>;
+/** Type alias for AutoZoomSettings. */
 export type AutoZoomSettings = z.infer<typeof autoZoomSettingsSchema>;
+/** Type alias for InputEvent. */
 export type InputEvent = z.infer<typeof inputEventSchema>;
+/** Type alias for InputEventLog. */
 export type InputEventLog = z.infer<typeof inputEventLogSchema>;
 
 /** Builds and validates a typed engine request payload. */

--- a/packages/engine-protocol/src/methods.ts
+++ b/packages/engine-protocol/src/methods.ts
@@ -1,3 +1,4 @@
+/** Canonical JSON-RPC method names supported by the engine protocol. */
 export const engineMethods = {
   SystemPing: "system.ping",
   EngineCapabilities: "engine.capabilities",
@@ -21,6 +22,8 @@ export const engineMethods = {
   ProjectRecents: "project.recents",
 } as const;
 
+/** Union type of supported engine JSON-RPC methods. */
 export type EngineMethod = (typeof engineMethods)[keyof typeof engineMethods];
 
+/** Stable list of all supported engine methods for validation and iteration. */
 export const engineMethodList = Object.values(engineMethods) as EngineMethod[];

--- a/packages/localization/src/menu.ts
+++ b/packages/localization/src/menu.ts
@@ -1,5 +1,6 @@
 import { normalizeStudioLocale, type StudioLocale } from "./studio";
 
+/** Localized labels used to build desktop application and tray menus. */
 export type DesktopMenuMessages = {
   file: string;
   openProject: string;
@@ -97,6 +98,7 @@ const desktopMenuMessagesByLocale: Record<StudioLocale, DesktopMenuMessages> = {
   },
 };
 
+/** Returns localized desktop menu labels for the requested locale. */
 export function getDesktopMenuMessages(locale: string | null | undefined): DesktopMenuMessages {
   return desktopMenuMessagesByLocale[normalizeStudioLocale(locale)];
 }

--- a/packages/localization/src/studio/de.ts
+++ b/packages/localization/src/studio/de.ts
@@ -1,5 +1,6 @@
 import type { StudioMessages } from "./en";
 
+/** German (DE) studio localization dictionary. */
 export const deDE: StudioMessages = {
   app: {
     title: "Guerillaglass",

--- a/packages/localization/src/studio/en.ts
+++ b/packages/localization/src/studio/en.ts
@@ -1,3 +1,4 @@
+/** English (US) studio localization dictionary. */
 export const enUS = {
   app: {
     title: "Guerillaglass",
@@ -301,4 +302,5 @@ type WidenLiterals<T> = T extends string
             ? { [K in keyof T]: WidenLiterals<T[K]> }
             : T;
 
+/** Studio message contract widened from the base English locale dictionary. */
 export type StudioMessages = WidenLiterals<typeof enUS>;

--- a/packages/localization/src/studio/index.ts
+++ b/packages/localization/src/studio/index.ts
@@ -1,9 +1,12 @@
 import { deDE } from "./de";
 import { enUS, type StudioMessages } from "./en";
 
+/** Supported studio locale tags. */
 export const studioLocales = ["en-US", "de-DE"] as const;
+/** Union of supported studio locale tags. */
 export type StudioLocale = (typeof studioLocales)[number];
 
+/** Default locale used when input locale cannot be matched. */
 export const defaultStudioLocale: StudioLocale = "en-US";
 
 const studioMessagesByLocale: Record<StudioLocale, StudioMessages> = {
@@ -11,6 +14,7 @@ const studioMessagesByLocale: Record<StudioLocale, StudioMessages> = {
   "de-DE": deDE,
 };
 
+/** Normalizes raw locale input into a supported studio locale. */
 export function normalizeStudioLocale(locale: string | null | undefined): StudioLocale {
   const normalized = locale?.trim().toLowerCase();
 
@@ -25,6 +29,7 @@ export function normalizeStudioLocale(locale: string | null | undefined): Studio
   return defaultStudioLocale;
 }
 
+/** Returns studio messages for a supported or normalized locale. */
 export function getStudioMessages(locale: string | null | undefined): StudioMessages {
   return studioMessagesByLocale[normalizeStudioLocale(locale)];
 }


### PR DESCRIPTION
# Summary
- add a cross-language documentation coverage gate (`Scripts/docs_gate.mjs`) with per-surface thresholds in `docs/doc_coverage_policy.json`
- wire docs coverage checks into local gates and CI workflows (TypeScript gate, full gate, and both GitHub workflows)
- add TSDoc to exported APIs in `packages/localization`, `packages/engine-protocol`, and desktop bridge code under `apps/desktop-electrobun/src/bun/*`
- add DocC-style Swift comments for protocol and initial macOS engine public-surface declarations
- add rustdoc comments for public protocol/native-foundation API surfaces
- establish staged strictness so coverage can be raised incrementally over time

# Checklist
- [x] Ran `bun run gate`
- [ ] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
- [ ] UI changes include screenshots
- [x] Updated docs/templates if architecture or workflows changed

# Testing (optional)
- [x] swift test
- [x] bun run desktop:test:coverage (required when touching `apps/desktop-electrobun` or `packages/engine-protocol`)
