### PR TITLE
Desktop: harden save-as flow and register .gglassproj package type

### DIFF
--- a/Tests/captureTests/CaptureSourcesTests.swift
+++ b/Tests/captureTests/CaptureSourcesTests.swift
@@ -77,47 +77,25 @@ final class CaptureSourcesTests: XCTestCase {
     }
 
     func testShouldIncludeShareableWindowFiltersExpectedWindows() {
-        XCTAssertFalse(
-            CaptureEngine.shouldIncludeShareableWindow(
-                .init(bundleIdentifier: nil, frame: CGRect(x: 0, y: 0, width: 100, height: 100), isOnScreen: true)
-            )
-        )
-        XCTAssertFalse(
-            CaptureEngine.shouldIncludeShareableWindow(
-                .init(
-                    bundleIdentifier: "com.apple.WindowServer",
-                    frame: CGRect(x: 0, y: 0, width: 100, height: 100),
-                    isOnScreen: true
+        func assertExcluded(
+            bundleIdentifier: String?,
+            frame: CGRect = CGRect(x: 0, y: 0, width: 100, height: 100),
+            isOnScreen: Bool = true
+        ) {
+            XCTAssertFalse(
+                CaptureEngine.shouldIncludeShareableWindow(
+                    .init(bundleIdentifier: bundleIdentifier, frame: frame, isOnScreen: isOnScreen)
                 )
             )
-        )
-        XCTAssertFalse(
-            CaptureEngine.shouldIncludeShareableWindow(
-                .init(
-                    bundleIdentifier: "com.apple.dock",
-                    frame: CGRect(x: 0, y: 0, width: 100, height: 100),
-                    isOnScreen: true
-                )
-            )
-        )
-        XCTAssertFalse(
-            CaptureEngine.shouldIncludeShareableWindow(
-                .init(
-                    bundleIdentifier: "com.example.app",
-                    frame: CGRect(x: 0, y: 0, width: 1, height: 300),
-                    isOnScreen: true
-                )
-            )
-        )
-        XCTAssertFalse(
-            CaptureEngine.shouldIncludeShareableWindow(
-                .init(
-                    bundleIdentifier: "com.example.app",
-                    frame: CGRect(x: 0, y: 0, width: 200, height: 200),
-                    isOnScreen: false
-                )
-            )
-        )
+        }
+
+        assertExcluded(bundleIdentifier: nil)
+        assertExcluded(bundleIdentifier: "com.apple.WindowServer")
+        assertExcluded(bundleIdentifier: "com.apple.dock")
+        assertExcluded(bundleIdentifier: "com.apple.systemuiserver")
+        assertExcluded(bundleIdentifier: "com.example.app", frame: CGRect(x: 0, y: 0, width: 1, height: 300))
+        assertExcluded(bundleIdentifier: "com.example.app", isOnScreen: false)
+
         XCTAssertTrue(
             CaptureEngine.shouldIncludeShareableWindow(
                 .init(

--- a/Tests/captureTests/CaptureSourcesTests.swift
+++ b/Tests/captureTests/CaptureSourcesTests.swift
@@ -106,6 +106,25 @@ final class CaptureSourcesTests: XCTestCase {
             )
         )
     }
+
+    func testPreferredWindowOrderingUsesLowerWindowIDAsFinalTieBreaker() {
+        let candidateLowID = CaptureEngine.PreferredWindowCandidate(
+            windowID: 11,
+            area: 640_000,
+            hasTitle: true
+        )
+        let candidateHighID = CaptureEngine.PreferredWindowCandidate(
+            windowID: 22,
+            area: 640_000,
+            hasTitle: true
+        )
+
+        let preferred = [candidateHighID, candidateLowID].max {
+            CaptureEngine.arePreferredWindowsInIncreasingOrder(left: $0, right: $1)
+        }
+
+        XCTAssertEqual(preferred?.windowID, 11)
+    }
 }
 
 private enum CaptureSourcesTestError: Error, LocalizedError, Equatable {

--- a/apps/desktop-electrobun/README.md
+++ b/apps/desktop-electrobun/README.md
@@ -60,6 +60,15 @@ bun run desktop:test:ui
 bun run desktop:build
 ```
 
+## Project Package Registration (macOS)
+
+- Guerilla Glass projects use the `.gglassproj` package format.
+- During desktop build packaging, Electrobun hooks run `scripts/configure-macos-project-package.ts`.
+- The hook updates and validates generated `Info.plist` entries:
+  - `UTExportedTypeDeclarations` for `com.okikeSolutions.guerillaglass.project`
+  - `CFBundleDocumentTypes` with `LSItemContentTypes` and `LSTypeIsPackage=true`
+- Result: Finder treats `.gglassproj` as a package item (single project item by default, directory on disk).
+
 ## Key Paths
 
 - UI shell: `/apps/desktop-electrobun/src/mainview`

--- a/apps/desktop-electrobun/electrobun.config.ts
+++ b/apps/desktop-electrobun/electrobun.config.ts
@@ -21,4 +21,9 @@ export default {
       bundleCEF: false,
     },
   },
+  scripts: {
+    // Mark .gglassproj as a macOS package document type in generated Info.plist files.
+    postBuild: "scripts/configure-macos-project-package.ts",
+    postWrap: "scripts/configure-macos-project-package.ts",
+  },
 } satisfies ElectrobunConfig;

--- a/apps/desktop-electrobun/scripts/configure-macos-project-package.ts
+++ b/apps/desktop-electrobun/scripts/configure-macos-project-package.ts
@@ -1,0 +1,284 @@
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readdir, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const PACKAGE_EXTENSION = "gglassproj";
+const DOCUMENT_TYPE_NAME = "Guerilla Glass Project";
+const PROJECT_UTI = "com.okikeSolutions.guerillaglass.project";
+
+type PlistValue = string | number | boolean | null | PlistObject | PlistValue[];
+type PlistObject = Record<string, PlistValue>;
+
+const DESIRED_UT_TYPE_DECLARATION: PlistObject = {
+  UTTypeIdentifier: PROJECT_UTI,
+  UTTypeDescription: DOCUMENT_TYPE_NAME,
+  UTTypeConformsTo: ["com.apple.package", "public.data"],
+  UTTypeTagSpecification: {
+    "public.filename-extension": [PACKAGE_EXTENSION],
+  },
+};
+
+const DESIRED_DOCUMENT_TYPE_DECLARATION: PlistObject = {
+  CFBundleTypeName: DOCUMENT_TYPE_NAME,
+  CFBundleTypeRole: "Editor",
+  LSHandlerRank: "Owner",
+  LSTypeIsPackage: true,
+  LSItemContentTypes: [PROJECT_UTI],
+  CFBundleTypeExtensions: [PACKAGE_EXTENSION],
+};
+
+function isPlistObject(value: PlistValue | undefined): value is PlistObject {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function toObjectArray(value: PlistValue | undefined): PlistObject[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is PlistObject => isPlistObject(item));
+}
+
+function arraysEqual(left: string[], right: string[]): boolean {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function getStringArray(value: PlistValue | undefined): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter((item): item is string => typeof item === "string");
+}
+
+function getExtensionTags(entry: PlistObject): string[] {
+  if (!isPlistObject(entry.UTTypeTagSpecification)) {
+    return [];
+  }
+  const extensionTag = entry.UTTypeTagSpecification["public.filename-extension"];
+  if (typeof extensionTag === "string") {
+    return [extensionTag];
+  }
+  return getStringArray(extensionTag);
+}
+
+function isDesiredUTTypeDeclaration(entry: PlistObject): boolean {
+  if (entry.UTTypeIdentifier !== PROJECT_UTI) {
+    return false;
+  }
+  if (entry.UTTypeDescription !== DOCUMENT_TYPE_NAME) {
+    return false;
+  }
+  const conformsTo = getStringArray(entry.UTTypeConformsTo);
+  if (!arraysEqual(conformsTo, ["com.apple.package", "public.data"])) {
+    return false;
+  }
+  const extensionTags = getExtensionTags(entry);
+  return arraysEqual(extensionTags, [PACKAGE_EXTENSION]);
+}
+
+function matchesProjectDocumentType(entry: PlistObject): boolean {
+  const contentTypes = getStringArray(entry.LSItemContentTypes);
+  const extensions = getStringArray(entry.CFBundleTypeExtensions);
+  return contentTypes.includes(PROJECT_UTI) || extensions.includes(PACKAGE_EXTENSION);
+}
+
+function isDesiredProjectDocumentType(entry: PlistObject): boolean {
+  if (!matchesProjectDocumentType(entry)) {
+    return false;
+  }
+  if (entry.CFBundleTypeName !== DOCUMENT_TYPE_NAME) {
+    return false;
+  }
+  if (entry.CFBundleTypeRole !== "Editor") {
+    return false;
+  }
+  if (entry.LSHandlerRank !== "Owner") {
+    return false;
+  }
+  if (entry.LSTypeIsPackage !== true) {
+    return false;
+  }
+  const contentTypes = getStringArray(entry.LSItemContentTypes);
+  const extensions = getStringArray(entry.CFBundleTypeExtensions);
+  return arraysEqual(contentTypes, [PROJECT_UTI]) && arraysEqual(extensions, [PACKAGE_EXTENSION]);
+}
+
+function runPlutil(args: string[]): string {
+  const result = spawnSync("plutil", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    const stderr = result.stderr?.trim();
+    throw new Error(`plutil ${args.join(" ")} failed${stderr ? `: ${stderr}` : ""}`);
+  }
+  return result.stdout;
+}
+
+function readInfoPlistAsObject(infoPlistPath: string): PlistObject {
+  const output = runPlutil(["-convert", "json", "-o", "-", infoPlistPath]);
+  const parsed = JSON.parse(output) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`Expected plist root object for ${infoPlistPath}`);
+  }
+  return parsed as PlistObject;
+}
+
+async function writeObjectToInfoPlist(infoPlistPath: string, plist: PlistObject): Promise<void> {
+  const normalizedTemporaryDirectory = await mkdtemp(path.join(tmpdir(), "gglassproj-plist-"));
+  const jsonPath = path.join(normalizedTemporaryDirectory, "Info.json");
+  await writeFile(jsonPath, JSON.stringify(plist, null, 2), "utf8");
+  runPlutil(["-convert", "xml1", jsonPath, "-o", infoPlistPath]);
+  await rm(normalizedTemporaryDirectory, { recursive: true, force: true });
+}
+
+function ensureUTExportedTypeDeclarations(plist: PlistObject): boolean {
+  const currentEntries = toObjectArray(plist.UTExportedTypeDeclarations);
+  const projectEntries = currentEntries.filter((entry) => entry.UTTypeIdentifier === PROJECT_UTI);
+
+  if (projectEntries.length === 1 && isDesiredUTTypeDeclaration(projectEntries[0])) {
+    return false;
+  }
+
+  const nextEntries = currentEntries.filter((entry) => {
+    const identifier = entry.UTTypeIdentifier;
+    return !(typeof identifier === "string" && identifier === PROJECT_UTI);
+  });
+  nextEntries.push(DESIRED_UT_TYPE_DECLARATION);
+  plist.UTExportedTypeDeclarations = nextEntries;
+  return true;
+}
+
+function ensureDocumentTypes(plist: PlistObject): boolean {
+  const currentEntries = toObjectArray(plist.CFBundleDocumentTypes);
+  const projectEntries = currentEntries.filter((entry) => matchesProjectDocumentType(entry));
+
+  if (projectEntries.length === 1 && isDesiredProjectDocumentType(projectEntries[0])) {
+    return false;
+  }
+
+  const nextEntries = currentEntries.filter((entry) => !matchesProjectDocumentType(entry));
+  nextEntries.push(DESIRED_DOCUMENT_TYPE_DECLARATION);
+  plist.CFBundleDocumentTypes = nextEntries;
+  return true;
+}
+
+function assertProjectPackageRegistration(plist: PlistObject, infoPlistPath: string): void {
+  const utDeclarations = toObjectArray(plist.UTExportedTypeDeclarations);
+  const projectType = utDeclarations.find((entry) => entry.UTTypeIdentifier === PROJECT_UTI);
+  if (!projectType) {
+    throw new Error(`Missing UTExportedTypeDeclarations for ${PROJECT_UTI} in ${infoPlistPath}`);
+  }
+  const conformance = getStringArray(projectType.UTTypeConformsTo);
+  const expectedConformance = ["com.apple.package", "public.data"];
+  if (!arraysEqual(conformance, expectedConformance)) {
+    throw new Error(
+      `UTTypeConformsTo mismatch in ${infoPlistPath}: expected ${expectedConformance.join(", ")} got ${conformance.join(", ")}`,
+    );
+  }
+
+  const documentTypes = toObjectArray(plist.CFBundleDocumentTypes);
+  const projectDocumentType = documentTypes.find((entry) => {
+    const contentTypes = getStringArray(entry.LSItemContentTypes);
+    return contentTypes.includes(PROJECT_UTI);
+  });
+  if (!projectDocumentType) {
+    throw new Error(
+      `Missing CFBundleDocumentTypes declaration for ${PROJECT_UTI} in ${infoPlistPath}`,
+    );
+  }
+  if (projectDocumentType.LSTypeIsPackage !== true) {
+    throw new Error(
+      `Document type for ${PROJECT_UTI} must set LSTypeIsPackage=true in ${infoPlistPath}`,
+    );
+  }
+}
+
+async function findAppBundles(rootDirectory: string): Promise<string[]> {
+  const foundBundles: string[] = [];
+  const pendingDirectories: string[] = [rootDirectory];
+
+  while (pendingDirectories.length > 0) {
+    const directory = pendingDirectories.pop();
+    if (!directory) {
+      continue;
+    }
+
+    let entries;
+    try {
+      entries = await readdir(directory, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      if (!entry.isDirectory()) {
+        continue;
+      }
+      if (entry.name.endsWith(".app")) {
+        foundBundles.push(entryPath);
+        continue;
+      }
+      pendingDirectories.push(entryPath);
+    }
+  }
+
+  return foundBundles;
+}
+
+async function patchBundleInfoPlist(appBundlePath: string): Promise<void> {
+  const infoPlistPath = path.join(appBundlePath, "Contents", "Info.plist");
+  const infoStat = await stat(infoPlistPath);
+  if (!infoStat.isFile()) {
+    return;
+  }
+
+  const plist = readInfoPlistAsObject(infoPlistPath);
+  const changedDocumentTypes = ensureDocumentTypes(plist);
+  const changedUtTypes = ensureUTExportedTypeDeclarations(plist);
+  const modified = changedDocumentTypes || changedUtTypes;
+  if (modified) {
+    await writeObjectToInfoPlist(infoPlistPath, plist);
+  }
+
+  const validatedPlist = readInfoPlistAsObject(infoPlistPath);
+  assertProjectPackageRegistration(validatedPlist, infoPlistPath);
+
+  const status = modified ? "updated+validated" : "already configured";
+  process.stdout.write(`[project-package] ${status}: ${infoPlistPath}\n`);
+}
+
+async function main(): Promise<void> {
+  if (process.env.ELECTROBUN_OS !== "macos") {
+    return;
+  }
+
+  const explicitWrapperBundle = process.env.ELECTROBUN_WRAPPER_BUNDLE_PATH;
+  if (explicitWrapperBundle) {
+    await patchBundleInfoPlist(explicitWrapperBundle);
+    return;
+  }
+
+  const buildDirectory = process.env.ELECTROBUN_BUILD_DIR;
+  if (!buildDirectory) {
+    throw new Error("ELECTROBUN_BUILD_DIR is not set");
+  }
+
+  const appBundles = await findAppBundles(buildDirectory);
+  if (appBundles.length === 0) {
+    process.stderr.write(`[project-package] no .app bundles found in ${buildDirectory}\n`);
+    return;
+  }
+
+  for (const appBundlePath of appBundles) {
+    await patchBundleInfoPlist(appBundlePath);
+  }
+}
+
+await main();

--- a/apps/desktop-electrobun/src/bun/bridge/requestHandlers.ts
+++ b/apps/desktop-electrobun/src/bun/bridge/requestHandlers.ts
@@ -33,6 +33,8 @@ export function createEngineBridgeHandlers({
     ggEngineListSources: async () => engineClient.listSources(),
     ggEngineStartDisplayCapture: async ({ enableMic, captureFps }) =>
       engineClient.startDisplayCapture(enableMic, captureFps),
+    ggEngineStartCurrentWindowCapture: async ({ enableMic, captureFps }) =>
+      engineClient.startCurrentWindowCapture(enableMic, captureFps),
     ggEngineStartWindowCapture: async ({ windowId, enableMic, captureFps }) =>
       engineClient.startWindowCapture(windowId, enableMic, captureFps),
     ggEngineStopCapture: async () => engineClient.stopCapture(),

--- a/apps/desktop-electrobun/src/bun/bridge/requestHandlers.ts
+++ b/apps/desktop-electrobun/src/bun/bridge/requestHandlers.ts
@@ -1,10 +1,13 @@
-import type { BridgeRequestHandlerMap } from "../../shared/bridgeRpc";
+import type { BridgeRequestHandlerMap, HostPathPickerMode } from "../../shared/bridgeRpc";
 import { createBunBridgeHandlers } from "../../shared/bridgeBindings";
 import type { EngineClient } from "../engine/client";
 
 type BridgeHandlerDependencies = {
   engineClient: EngineClient;
-  pickDirectory: (startingFolder?: string) => Promise<string | null>;
+  pickPath: (params: {
+    mode: HostPathPickerMode;
+    startingFolder?: string;
+  }) => Promise<string | null>;
   readTextFile: (filePath: string) => Promise<string>;
   resolveMediaSourceURL: (filePath: string) => Promise<string>;
   setCurrentProjectPath: (projectPath: string | null) => void;
@@ -13,7 +16,7 @@ type BridgeHandlerDependencies = {
 /** Creates bridge RPC handlers backed by the desktop engine client. */
 export function createEngineBridgeHandlers({
   engineClient,
-  pickDirectory,
+  pickPath,
   readTextFile,
   resolveMediaSourceURL,
   setCurrentProjectPath,
@@ -55,7 +58,7 @@ export function createEngineBridgeHandlers({
       return projectState;
     },
     ggEngineProjectRecents: async ({ limit }) => engineClient.projectRecents(limit),
-    ggPickDirectory: async ({ startingFolder }) => pickDirectory(startingFolder),
+    ggPickPath: async ({ mode, startingFolder }) => pickPath({ mode, startingFolder }),
     ggReadTextFile: async ({ filePath }) => readTextFile(filePath),
     ggResolveMediaSourceURL: async ({ filePath }) => {
       try {

--- a/apps/desktop-electrobun/src/bun/engine/client.ts
+++ b/apps/desktop-electrobun/src/bun/engine/client.ts
@@ -145,6 +145,16 @@ const engineMethodDefinitions = {
     Awaited<ReturnType<typeof captureStatusResultSchema.parse>>,
     [enableMic: boolean, captureFps: CaptureFrameRate]
   >,
+  startCurrentWindowCapture: {
+    method: "capture.startCurrentWindow",
+    toParams: (enableMic: boolean, captureFps: CaptureFrameRate) => ({ enableMic, captureFps }),
+    schema: captureStatusResultSchema,
+    timeoutMs: 15_000,
+    retryableRead: false,
+  } satisfies EngineMethodDefinition<
+    Awaited<ReturnType<typeof captureStatusResultSchema.parse>>,
+    [enableMic: boolean, captureFps: CaptureFrameRate]
+  >,
   startWindowCapture: {
     method: "capture.startWindow",
     toParams: (windowId: number, enableMic: boolean, captureFps: CaptureFrameRate) => ({
@@ -564,6 +574,18 @@ export class EngineClient {
     captureFps: CaptureFrameRate = defaultCaptureFrameRate,
   ) {
     const definition = engineMethodDefinitions.startDisplayCapture;
+    return this.callAndParse(
+      definition.method,
+      definition.toParams(enableMic, captureFps),
+      definition.schema,
+    );
+  }
+
+  async startCurrentWindowCapture(
+    enableMic: boolean,
+    captureFps: CaptureFrameRate = defaultCaptureFrameRate,
+  ) {
+    const definition = engineMethodDefinitions.startCurrentWindowCapture;
     return this.callAndParse(
       definition.method,
       definition.toParams(enableMic, captureFps),

--- a/apps/desktop-electrobun/src/bun/path/picker.ts
+++ b/apps/desktop-electrobun/src/bun/path/picker.ts
@@ -38,7 +38,7 @@ function inferPathSeparator(path: string): "/" | "\\" {
 function getPathBaseName(path: string): string {
   const trimmedPath = trimTrailingSeparators(path);
   const segments = trimmedPath.split(/[\\/]/);
-  return segments.at(-1) ?? "";
+  return segments.pop() ?? "";
 }
 
 function getParentPath(path: string): string {

--- a/apps/desktop-electrobun/src/bun/path/picker.ts
+++ b/apps/desktop-electrobun/src/bun/path/picker.ts
@@ -1,0 +1,236 @@
+import type { HostPathPickerMode } from "../../shared/bridgeRpc";
+
+const projectPackageExtension = ".gglassproj";
+const defaultProjectName = "guerillaglass-project";
+
+type OpenFileDialogOptions = {
+  startingFolder?: string;
+  canChooseFiles?: boolean;
+  canChooseDirectory?: boolean;
+  allowsMultipleSelection?: boolean;
+  allowedFileTypes?: string | string[];
+};
+
+type SaveFileDialogOptions = {
+  startingFolder?: string;
+  defaultName?: string;
+  allowedFileTypes?: string | string[];
+};
+
+type FileDialogDependencies = {
+  currentProjectPath?: string | null;
+  startingFolder?: string;
+  documentsPath: string;
+  openFileDialog: (options: OpenFileDialogOptions) => Promise<string[]>;
+  saveFileDialog?: (options: SaveFileDialogOptions) => Promise<string | string[] | null>;
+};
+
+function trimTrailingSeparators(path: string): string {
+  return path.replace(/[\\/]+$/, "");
+}
+
+function inferPathSeparator(path: string): "/" | "\\" {
+  return path.includes("\\") && !path.includes("/") ? "\\" : "/";
+}
+
+function getPathBaseName(path: string): string {
+  const trimmedPath = trimTrailingSeparators(path);
+  const segments = trimmedPath.split(/[\\/]/);
+  return segments.at(-1) ?? "";
+}
+
+function getParentPath(path: string): string {
+  const trimmedPath = trimTrailingSeparators(path);
+  const separatorIndex = Math.max(trimmedPath.lastIndexOf("/"), trimmedPath.lastIndexOf("\\"));
+  if (separatorIndex <= 0) {
+    return trimmedPath;
+  }
+  return trimmedPath.slice(0, separatorIndex);
+}
+
+function stripProjectPackageExtension(name: string): string {
+  return name.toLowerCase().endsWith(projectPackageExtension)
+    ? name.slice(0, -projectPackageExtension.length)
+    : name;
+}
+
+function sanitizeProjectName(name: string): string {
+  let sanitizedName = "";
+  let previousWasDash = false;
+  for (const character of name.trim()) {
+    const characterCode = character.charCodeAt(0);
+    const isWhitespace = /\s/.test(character);
+    const isUnsupportedCharacter =
+      characterCode <= 31 ||
+      character === "<" ||
+      character === ">" ||
+      character === ":" ||
+      character === '"' ||
+      character === "/" ||
+      character === "\\" ||
+      character === "|" ||
+      character === "?" ||
+      character === "*";
+
+    if (isUnsupportedCharacter || isWhitespace || character === "-") {
+      if (!previousWasDash) {
+        sanitizedName += "-";
+        previousWasDash = true;
+      }
+      continue;
+    }
+
+    sanitizedName += character;
+    previousWasDash = false;
+  }
+
+  let startIndex = 0;
+  let endIndex = sanitizedName.length;
+  while (
+    startIndex < endIndex &&
+    (sanitizedName[startIndex] === "-" ||
+      sanitizedName[startIndex] === "." ||
+      /\s/.test(sanitizedName[startIndex] ?? ""))
+  ) {
+    startIndex += 1;
+  }
+  while (
+    endIndex > startIndex &&
+    (sanitizedName[endIndex - 1] === "-" ||
+      sanitizedName[endIndex - 1] === "." ||
+      /\s/.test(sanitizedName[endIndex - 1] ?? ""))
+  ) {
+    endIndex -= 1;
+  }
+
+  return sanitizedName.slice(startIndex, endIndex);
+}
+
+function buildProjectPackageName(currentProjectPath?: string | null): string {
+  const currentProjectName = currentProjectPath
+    ? stripProjectPackageExtension(getPathBaseName(currentProjectPath))
+    : "";
+  const sanitizedName = sanitizeProjectName(currentProjectName || defaultProjectName);
+  const fallbackName = sanitizedName.length > 0 ? sanitizedName : defaultProjectName;
+  return `${fallbackName}${projectPackageExtension}`;
+}
+
+function resolveStartingFolder(params: {
+  startingFolder?: string;
+  currentProjectPath?: string | null;
+  documentsPath: string;
+}): string {
+  const candidate = params.startingFolder ?? params.currentProjectPath ?? params.documentsPath;
+  if (candidate.toLowerCase().endsWith(projectPackageExtension)) {
+    return getParentPath(candidate);
+  }
+  return candidate;
+}
+
+function resolveFirstPath(value: string | string[] | null | undefined): string | null {
+  if (!value) {
+    return null;
+  }
+  if (Array.isArray(value)) {
+    return value[0] ?? null;
+  }
+  return value;
+}
+
+function resolveSaveAsProjectPath(params: {
+  selectedPath: string;
+  currentProjectPath?: string | null;
+}): string {
+  const selectedPath = trimTrailingSeparators(params.selectedPath);
+  if (selectedPath.toLowerCase().endsWith(projectPackageExtension)) {
+    return selectedPath;
+  }
+  const separator = inferPathSeparator(selectedPath);
+  const projectPackageName = buildProjectPackageName(params.currentProjectPath);
+  return `${selectedPath}${separator}${projectPackageName}`;
+}
+
+function resolveSaveDialogProjectPath(selectedPath: string): string {
+  const trimmedPath = trimTrailingSeparators(selectedPath);
+  if (trimmedPath.toLowerCase().endsWith(projectPackageExtension)) {
+    return trimmedPath;
+  }
+  return `${trimmedPath}${projectPackageExtension}`;
+}
+
+/** Opens the host file/save picker for a workflow mode and returns a resolved path target. */
+export async function pickPathForMode(
+  mode: HostPathPickerMode,
+  dependencies: FileDialogDependencies,
+): Promise<string | null> {
+  const startingFolder = resolveStartingFolder({
+    startingFolder: dependencies.startingFolder,
+    currentProjectPath: dependencies.currentProjectPath,
+    documentsPath: dependencies.documentsPath,
+  });
+
+  if (mode === "openProject") {
+    const selectedPath = resolveFirstPath(
+      await dependencies.openFileDialog({
+        startingFolder,
+        canChooseFiles: true,
+        canChooseDirectory: true,
+        allowsMultipleSelection: false,
+        allowedFileTypes: "gglassproj",
+      }),
+    );
+    if (!selectedPath?.toLowerCase().endsWith(projectPackageExtension)) {
+      return null;
+    }
+    return selectedPath;
+  }
+
+  if (mode === "saveProjectAs") {
+    if (typeof dependencies.saveFileDialog === "function") {
+      try {
+        const selectedPath = resolveFirstPath(
+          await dependencies.saveFileDialog({
+            startingFolder,
+            defaultName: buildProjectPackageName(dependencies.currentProjectPath),
+            allowedFileTypes: "gglassproj",
+          }),
+        );
+        if (selectedPath) {
+          return resolveSaveDialogProjectPath(selectedPath);
+        }
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        console.warn(`saveFileDialog failed, falling back to folder picker: ${reason}`);
+      }
+    }
+
+    const selectedPath = resolveFirstPath(
+      await dependencies.openFileDialog({
+        startingFolder,
+        canChooseFiles: false,
+        canChooseDirectory: true,
+        allowsMultipleSelection: false,
+        allowedFileTypes: "*",
+      }),
+    );
+    if (!selectedPath) {
+      return null;
+    }
+    return resolveSaveAsProjectPath({
+      selectedPath,
+      currentProjectPath: dependencies.currentProjectPath,
+    });
+  }
+
+  const selectedPath = resolveFirstPath(
+    await dependencies.openFileDialog({
+      startingFolder,
+      canChooseFiles: false,
+      canChooseDirectory: true,
+      allowsMultipleSelection: false,
+      allowedFileTypes: "*",
+    }),
+  );
+
+  return selectedPath;
+}

--- a/apps/desktop-electrobun/src/mainview/app/navigation/router.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/navigation/router.tsx
@@ -3,12 +3,10 @@ import {
   createRootRoute,
   createRoute,
   createRouter,
+  lazyRouteComponent,
   redirect,
 } from "@tanstack/react-router";
 import { normalizeStudioLocale } from "@guerillaglass/localization";
-import { CaptureRoute } from "../studio/routes/CaptureRoute";
-import { DeliverRoute } from "../studio/routes/DeliverRoute";
-import { EditRoute } from "../studio/routes/EditRoute";
 import { StudioShellLayout } from "../studio/layout/StudioShellLayout";
 import {
   getInitialStudioLocale,
@@ -16,6 +14,16 @@ import {
   localizedRouteTargetFor,
   type StudioLayoutRoute,
 } from "../studio/model/studioLayoutModel";
+
+const CaptureRoute = lazyRouteComponent(
+  () => import("../studio/routes/CaptureRoute"),
+  "CaptureRoute",
+);
+const EditRoute = lazyRouteComponent(() => import("../studio/routes/EditRoute"), "EditRoute");
+const DeliverRoute = lazyRouteComponent(
+  () => import("../studio/routes/DeliverRoute"),
+  "DeliverRoute",
+);
 
 function redirectToLocalizedRoute(route: StudioLayoutRoute, locale: string): never {
   throw redirect({

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
@@ -16,6 +16,7 @@ import {
   normalizeInspectorSelection,
   selectionFromPreset,
 } from "../../model/inspectorSelectionModel";
+import { resolveSelectedWindowId } from "../../model/preferredWindowSelection";
 import { useStudioHotkeys } from "./useStudioHotkeys";
 import { useStudioLayoutController } from "./useStudioLayoutController";
 import { useStudioMutations, type ExportFormApi, type SettingsFormApi } from "./useStudioMutations";
@@ -202,11 +203,7 @@ export function useStudioController() {
   }, [projectQuery.data?.autoZoom, settingsForm]);
 
   const selectedWindowId = useMemo(() => {
-    const selectedId = settingsForm.state.values.selectedWindowId;
-    if (windowChoices.some((windowItem) => windowItem.id === selectedId)) {
-      return selectedId;
-    }
-    return windowChoices[0]?.id ?? 0;
+    return resolveSelectedWindowId(windowChoices, settingsForm.state.values.selectedWindowId);
   }, [settingsForm.state.values.selectedWindowId, windowChoices]);
   const timelineFrameRate = useMemo(() => {
     const metadataFrameRate =

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
@@ -8,7 +8,7 @@ import {
 } from "@guerillaglass/engine-protocol";
 import { getStudioMessages } from "@guerillaglass/localization";
 import { desktopApi, sendHostMenuState } from "@/lib/engine";
-import type { HostMenuCommand } from "../../../../../shared/bridgeRpc";
+import type { HostMenuCommand, HostPathPickerMode } from "../../../../../shared/bridgeRpc";
 import { createHostCommandRunnerFromHandlers } from "../../../../../shared/hostCommandRegistry";
 import {
   emptyInspectorSelection,
@@ -289,10 +289,13 @@ export function useStudioController() {
     [activeMode, rawInspectorSelection],
   );
 
-  const pickDirectorySafely = useCallback(
-    async (startingFolder?: string): Promise<string | null> => {
+  const pickPathSafely = useCallback(
+    async (params: {
+      mode: HostPathPickerMode;
+      startingFolder?: string;
+    }): Promise<string | null> => {
       try {
-        return await desktopApi.pickDirectory(startingFolder);
+        return await desktopApi.pickPath(params);
       } catch (error) {
         if (isBridgeTimeoutError(error)) {
           setNotice({
@@ -327,7 +330,7 @@ export function useStudioController() {
     setNotice,
     setTimelinePlayback: setIsTimelinePlaying,
     resetPlayhead: () => setPlayheadSeconds(0),
-    pickDirectorySafely,
+    pickPathSafely,
     selectedWindowId,
     inputMonitoringDenied,
     recordingURL,
@@ -426,7 +429,7 @@ export function useStudioController() {
           setLocale("de-DE");
         },
         captureToggleRecording: () => {
-          void toggleRecordingMutation.mutateAsync();
+          void toggleRecordingMutation.mutateAsync(undefined);
         },
         captureStartPreview: () => {
           void startPreviewMutation.mutateAsync();
@@ -499,6 +502,7 @@ export function useStudioController() {
       canSave: !isRunningAction && Boolean(recordingURL),
       canExport: !isRunningAction && Boolean(recordingURL),
       isRecording: Boolean(captureStatusQuery.data?.isRecording),
+      recordingURL,
       locale,
       densityMode: layout.densityMode,
     });

--- a/apps/desktop-electrobun/src/mainview/app/studio/layout/StudioShellHeader.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/layout/StudioShellHeader.tsx
@@ -370,6 +370,7 @@ export function StudioShellHeader({
     studio.settingsForm.setFieldValue("captureSource", "window");
     void studio.toggleRecordingMutation.mutateAsync({
       captureSourceOverride: "window",
+      preferCurrentWindow: true,
     });
   };
 

--- a/apps/desktop-electrobun/src/mainview/app/studio/layout/StudioShellHeader.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/layout/StudioShellHeader.tsx
@@ -413,7 +413,7 @@ export function StudioShellHeader({
           </div>
 
           <div className="flex flex-wrap items-center gap-1.5 lg:justify-self-center">
-            <ButtonGroup className="gg-toolbar-group gap-1 rounded-lg border p-1">
+            <ButtonGroup className="gg-capture-button-group gg-toolbar-group gap-1 rounded-lg border p-1">
               <Tooltip>
                 <TooltipTrigger
                   render={

--- a/apps/desktop-electrobun/src/mainview/app/studio/model/preferredWindowSelection.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/model/preferredWindowSelection.ts
@@ -1,0 +1,58 @@
+import type { SourcesResult } from "@guerillaglass/engine-protocol";
+
+type SourceWindow = SourcesResult["windows"][number];
+
+const minimumPreferredWindowWidth = 120;
+const minimumPreferredWindowHeight = 80;
+
+function windowArea(windowItem: SourceWindow): number {
+  return windowItem.width * windowItem.height;
+}
+
+function hasTitle(windowItem: SourceWindow): boolean {
+  return windowItem.title.trim().length > 0;
+}
+
+function chooseLargestWindow(windows: SourceWindow[]): SourceWindow | null {
+  if (windows.length === 0) {
+    return null;
+  }
+
+  const [firstWindow, ...remainingWindows] = windows;
+  return remainingWindows.reduce((best, candidate) => {
+    const areaDelta = windowArea(candidate) - windowArea(best);
+    if (areaDelta !== 0) {
+      return areaDelta > 0 ? candidate : best;
+    }
+
+    const titleDelta = Number(hasTitle(candidate)) - Number(hasTitle(best));
+    if (titleDelta !== 0) {
+      return titleDelta > 0 ? candidate : best;
+    }
+
+    return candidate.id < best.id ? candidate : best;
+  }, firstWindow);
+}
+
+export function pickPreferredWindowId(windows: SourceWindow[]): number {
+  if (windows.length === 0) {
+    return 0;
+  }
+
+  const sizableWindows = windows.filter(
+    (windowItem) =>
+      windowItem.width >= minimumPreferredWindowWidth &&
+      windowItem.height >= minimumPreferredWindowHeight,
+  );
+
+  const preferredPool = sizableWindows.length > 0 ? sizableWindows : windows;
+  const preferredWindow = chooseLargestWindow(preferredPool);
+  return preferredWindow?.id ?? 0;
+}
+
+export function resolveSelectedWindowId(windows: SourceWindow[], selectedWindowId: number): number {
+  if (windows.some((windowItem) => windowItem.id === selectedWindowId)) {
+    return selectedWindowId;
+  }
+  return pickPreferredWindowId(windows);
+}

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
@@ -220,7 +220,7 @@ export function CaptureRoute() {
 
             <div className="gg-preview-workspace">
               <div className="gg-preview-stage-wrap">
-                <AspectRatio ratio={16 / 9} className="h-full w-full">
+                <AspectRatio ratio={16 / 9} className="h-auto w-auto">
                   <div className="gg-preview-stage">
                     {studio.captureStatusQuery.data?.isRecording ? (
                       <div className="space-y-2 text-center">

--- a/apps/desktop-electrobun/src/mainview/index.css
+++ b/apps/desktop-electrobun/src/mainview/index.css
@@ -291,6 +291,10 @@
     background-color: color-mix(in oklab, var(--gg-surface-1) 40%, transparent);
   }
 
+  .gg-capture-button-group > [data-slot] ~ [data-slot] {
+    border-left-width: 1px !important;
+  }
+
   .gg-surface-block {
     border: 1px solid var(--gg-border-subtle);
     background-color: color-mix(in oklab, var(--gg-surface-1) 66%, transparent);

--- a/apps/desktop-electrobun/src/mainview/lib/engine.ts
+++ b/apps/desktop-electrobun/src/mainview/lib/engine.ts
@@ -20,7 +20,11 @@ import {
   type ProjectState,
   type SourcesResult,
 } from "@guerillaglass/engine-protocol";
-import type { HostMenuState, WindowBridgeBindings } from "../../shared/bridgeRpc";
+import type {
+  HostMenuState,
+  HostPathPickerMode,
+  WindowBridgeBindings,
+} from "../../shared/bridgeRpc";
 
 function requireBridge<K extends keyof WindowBridgeBindings>(
   name: K,
@@ -137,8 +141,11 @@ export const engineApi = {
 };
 
 export const desktopApi = {
-  async pickDirectory(startingFolder?: string): Promise<string | null> {
-    return await requireBridge("ggPickDirectory")(startingFolder);
+  async pickPath(params: {
+    mode: HostPathPickerMode;
+    startingFolder?: string;
+  }): Promise<string | null> {
+    return await requireBridge("ggPickPath")(params);
   },
 
   async readTextFile(filePath: string): Promise<string> {

--- a/apps/desktop-electrobun/src/mainview/lib/engine.ts
+++ b/apps/desktop-electrobun/src/mainview/lib/engine.ts
@@ -79,6 +79,15 @@ export const engineApi = {
     );
   },
 
+  async startCurrentWindowCapture(
+    enableMic: boolean,
+    captureFps: CaptureFrameRate = defaultCaptureFrameRate,
+  ): Promise<CaptureStatusResult> {
+    return captureStatusResultSchema.parse(
+      await requireBridge("ggEngineStartCurrentWindowCapture")(enableMic, captureFps),
+    );
+  },
+
   async startWindowCapture(
     windowId: number,
     enableMic: boolean,

--- a/apps/desktop-electrobun/src/shared/bridgeRpc.ts
+++ b/apps/desktop-electrobun/src/shared/bridgeRpc.ts
@@ -39,9 +39,13 @@ export type HostMenuState = {
   canSave: boolean;
   canExport: boolean;
   isRecording: boolean;
+  recordingURL?: string | null;
   locale?: string;
   densityMode?: "comfortable" | "compact";
 };
+
+/** Host path-picker modes used by renderer workflows. */
+export type HostPathPickerMode = "openProject" | "saveProjectAs" | "export";
 
 type BridgeRequestDefinition<Params, Response, Args extends readonly unknown[]> = {
   toParams: (...args: Args) => Params;
@@ -122,11 +126,11 @@ export const bridgeRequestDefinitions = {
     ProjectRecentsResult,
     [limit?: number]
   >((limit) => ({ limit })),
-  ggPickDirectory: defineBridgeRequest<
-    { startingFolder?: string },
+  ggPickPath: defineBridgeRequest<
+    { mode: HostPathPickerMode; startingFolder?: string },
     string | null,
-    [startingFolder?: string]
-  >((startingFolder) => ({ startingFolder })),
+    [params: { mode: HostPathPickerMode; startingFolder?: string }]
+  >((params) => params),
   ggReadTextFile: defineBridgeRequest<{ filePath: string }, string, [filePath: string]>(
     (filePath) => ({ filePath }),
   ),

--- a/apps/desktop-electrobun/src/shared/bridgeRpc.ts
+++ b/apps/desktop-electrobun/src/shared/bridgeRpc.ts
@@ -79,6 +79,11 @@ export const bridgeRequestDefinitions = {
     CaptureStatusResult,
     [enableMic: boolean, captureFps: CaptureFrameRate]
   >((enableMic, captureFps) => ({ enableMic, captureFps })),
+  ggEngineStartCurrentWindowCapture: defineBridgeRequest<
+    { enableMic: boolean; captureFps: CaptureFrameRate },
+    CaptureStatusResult,
+    [enableMic: boolean, captureFps: CaptureFrameRate]
+  >((enableMic, captureFps) => ({ enableMic, captureFps })),
   ggEngineStartWindowCapture: defineBridgeRequest<
     { windowId: number; enableMic: boolean; captureFps: CaptureFrameRate },
     CaptureStatusResult,

--- a/apps/desktop-electrobun/src/types/electrobun-bun-shim.d.ts
+++ b/apps/desktop-electrobun/src/types/electrobun-bun-shim.d.ts
@@ -91,6 +91,7 @@ export const Updater: {
 export const Utils: {
   readonly paths: {
     readonly documents: string;
+    readonly videos?: string;
   };
   openFileDialog(options: {
     startingFolder?: string;
@@ -104,6 +105,15 @@ export const Utils: {
     defaultName?: string;
     allowedFileTypes?: string | string[];
   }) => Promise<string | string[] | null>;
+  showMessageBox(options: {
+    type?: "info" | "warning" | "error" | "question";
+    title?: string;
+    message?: string;
+    detail?: string;
+    buttons?: string[];
+    defaultId?: number;
+    cancelId?: number;
+  }): Promise<{ response: number }>;
   openExternal(url: string): Promise<void>;
   quit(): void;
 };

--- a/apps/desktop-electrobun/src/types/electrobun-bun-shim.d.ts
+++ b/apps/desktop-electrobun/src/types/electrobun-bun-shim.d.ts
@@ -99,6 +99,11 @@ export const Utils: {
     allowsMultipleSelection?: boolean;
     allowedFileTypes?: string | string[];
   }): Promise<string[]>;
+  saveFileDialog?: (options: {
+    startingFolder?: string;
+    defaultName?: string;
+    allowedFileTypes?: string | string[];
+  }) => Promise<string | string[] | null>;
   openExternal(url: string): Promise<void>;
   quit(): void;
 };

--- a/apps/desktop-electrobun/tests/engine-api.test.ts
+++ b/apps/desktop-electrobun/tests/engine-api.test.ts
@@ -104,6 +104,9 @@ describe("renderer engine bridge", () => {
       ggEngineStartDisplayCapture: async () => ({
         ...makeCaptureStatus({ isRunning: true }),
       }),
+      ggEngineStartCurrentWindowCapture: async () => ({
+        ...makeCaptureStatus({ isRunning: true }),
+      }),
       ggEngineStartWindowCapture: async () => ({
         ...makeCaptureStatus({ isRunning: true }),
       }),
@@ -178,6 +181,7 @@ describe("renderer engine bridge", () => {
     const exportInfo = await engineApi.exportInfo();
     const project = await engineApi.projectCurrent();
     const started = await engineApi.startDisplayCapture(true);
+    const startedCurrentWindow = await engineApi.startCurrentWindowCapture(true);
     const startedWindow = await engineApi.startWindowCapture(12, true);
     const recording = await engineApi.startRecording(true);
     const stoppedRecording = await engineApi.stopRecording();
@@ -214,6 +218,7 @@ describe("renderer engine bridge", () => {
     expect(exportInfo.presets[0]?.id).toBe("h264-1080p-30");
     expect(project.autoZoom.isEnabled).toBe(true);
     expect(started.isRunning).toBe(true);
+    expect(startedCurrentWindow.isRunning).toBe(true);
     expect(startedWindow.isRunning).toBe(true);
     expect(recording.isRecording).toBe(true);
     expect(stoppedRecording.isRecording).toBe(false);

--- a/apps/desktop-electrobun/tests/engine-api.test.ts
+++ b/apps/desktop-electrobun/tests/engine-api.test.ts
@@ -148,7 +148,8 @@ describe("renderer engine bridge", () => {
           },
         ],
       }),
-      ggPickDirectory: async () => "/tmp",
+      ggPickPath: async ({ mode }: { mode: string }) =>
+        mode === "saveProjectAs" ? "/tmp/alpha.gglassproj" : "/tmp",
       ggReadTextFile: async () =>
         JSON.stringify({
           schemaVersion: 1,
@@ -190,7 +191,7 @@ describe("renderer engine bridge", () => {
     const openedProject = await engineApi.projectOpen("/tmp/project.gglassproj");
     const savedProject = await engineApi.projectSave({ projectPath: "/tmp/project.gglassproj" });
     const recentProjects = await engineApi.projectRecents(5);
-    const picked = await desktopApi.pickDirectory();
+    const picked = await desktopApi.pickPath({ mode: "export" });
     const eventsRaw = await desktopApi.readTextFile("/tmp/events.json");
     const mediaSourceURL = await desktopApi.resolveMediaSourceURL("/tmp/out.mp4");
     sendHostMenuState({

--- a/apps/desktop-electrobun/tests/engine-client.test.ts
+++ b/apps/desktop-electrobun/tests/engine-client.test.ts
@@ -121,7 +121,7 @@ describe("engine client integration", () => {
       const sources = await client.listSources();
       expect(sources.displays.length).toBeGreaterThan(0);
 
-      const preview = await client.startDisplayCapture(false);
+      const preview = await client.startCurrentWindowCapture(false);
       expect(preview.isRunning).toBe(true);
 
       const recording = await client.startRecording(true);

--- a/apps/desktop-electrobun/tests/engine-protocol.test.ts
+++ b/apps/desktop-electrobun/tests/engine-protocol.test.ts
@@ -39,6 +39,10 @@ describe("engine protocol", () => {
 
   test("builds and validates parity method requests", () => {
     const capabilitiesRequest = buildRequest("engine.capabilities", {});
+    const startCurrentWindowRequest = buildRequest("capture.startCurrentWindow", {
+      enableMic: false,
+      captureFps: 30,
+    });
     const startRecordingRequest = buildRequest("recording.start", { trackInputEvents: true });
     const saveProjectRequest = buildRequest("project.save", {
       projectPath: "/tmp/test.gglassproj",
@@ -53,6 +57,9 @@ describe("engine protocol", () => {
     });
 
     expect(engineRequestSchema.parse(capabilitiesRequest).method).toBe("engine.capabilities");
+    expect(engineRequestSchema.parse(startCurrentWindowRequest).method).toBe(
+      "capture.startCurrentWindow",
+    );
     expect(engineRequestSchema.parse(startRecordingRequest).method).toBe("recording.start");
     expect(engineRequestSchema.parse(saveProjectRequest).method).toBe("project.save");
     expect(engineRequestSchema.parse(recentsRequest).method).toBe("project.recents");

--- a/apps/desktop-electrobun/tests/path-picker.test.ts
+++ b/apps/desktop-electrobun/tests/path-picker.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { pickPathForMode } from "../src/bun/path/picker";
+
+describe("host path picker", () => {
+  test("openProject only accepts project package paths", async () => {
+    const firstResult = await pickPathForMode("openProject", {
+      documentsPath: "/Users/demo/Documents",
+      openFileDialog: async () => ["/Users/demo/Projects/not-a-project"],
+    });
+
+    const secondResult = await pickPathForMode("openProject", {
+      documentsPath: "/Users/demo/Documents",
+      openFileDialog: async () => ["/Users/demo/Projects/alpha.gglassproj"],
+    });
+
+    expect(firstResult).toBeNull();
+    expect(secondResult).toBe("/Users/demo/Projects/alpha.gglassproj");
+  });
+
+  test("saveProjectAs uses save dialog when available and enforces extension", async () => {
+    const result = await pickPathForMode("saveProjectAs", {
+      currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
+      documentsPath: "/Users/demo/Documents",
+      openFileDialog: async () => {
+        throw new Error("fallback not expected");
+      },
+      saveFileDialog: async () => "/Users/demo/Projects/beta",
+    });
+
+    expect(result).toBe("/Users/demo/Projects/beta.gglassproj");
+  });
+
+  test("saveProjectAs falls back to folder picker when save dialog fails", async () => {
+    const result = await pickPathForMode("saveProjectAs", {
+      currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
+      documentsPath: "/Users/demo/Documents",
+      openFileDialog: async () => ["/Users/demo/Projects"],
+      saveFileDialog: async () => {
+        throw new Error("save dialog unavailable");
+      },
+    });
+
+    expect(result).toBe("/Users/demo/Projects/alpha.gglassproj");
+  });
+
+  test("export mode returns selected directory path", async () => {
+    const result = await pickPathForMode("export", {
+      documentsPath: "/Users/demo/Documents",
+      openFileDialog: async () => ["/Users/demo/Exports"],
+    });
+
+    expect(result).toBe("/Users/demo/Exports");
+  });
+
+  test("starting folder resolves to parent when current project path is a package", async () => {
+    let seenStartingFolder = "";
+    await pickPathForMode("openProject", {
+      currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
+      documentsPath: "/Users/demo/Documents",
+      openFileDialog: async ({ startingFolder }) => {
+        seenStartingFolder = startingFolder ?? "";
+        return [];
+      },
+    });
+
+    expect(seenStartingFolder).toBe("/Users/demo/Projects");
+  });
+});

--- a/apps/desktop-electrobun/tests/path-picker.test.ts
+++ b/apps/desktop-electrobun/tests/path-picker.test.ts
@@ -4,12 +4,12 @@ import { pickPathForMode } from "../src/bun/path/picker";
 describe("host path picker", () => {
   test("openProject only accepts project package paths", async () => {
     const firstResult = await pickPathForMode("openProject", {
-      documentsPath: "/Users/demo/Documents",
+      defaultFolder: "/Users/demo/Documents",
       openFileDialog: async () => ["/Users/demo/Projects/not-a-project"],
     });
 
     const secondResult = await pickPathForMode("openProject", {
-      documentsPath: "/Users/demo/Documents",
+      defaultFolder: "/Users/demo/Documents",
       openFileDialog: async () => ["/Users/demo/Projects/alpha.gglassproj"],
     });
 
@@ -20,7 +20,7 @@ describe("host path picker", () => {
   test("saveProjectAs uses save dialog when available and enforces extension", async () => {
     const result = await pickPathForMode("saveProjectAs", {
       currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
-      documentsPath: "/Users/demo/Documents",
+      defaultFolder: "/Users/demo/Documents",
       openFileDialog: async () => {
         throw new Error("fallback not expected");
       },
@@ -30,22 +30,101 @@ describe("host path picker", () => {
     expect(result).toBe("/Users/demo/Projects/beta.gglassproj");
   });
 
-  test("saveProjectAs falls back to folder picker when save dialog fails", async () => {
+  test("saveProjectAs returns null when save dialog is canceled", async () => {
+    let fallbackCalls = 0;
     const result = await pickPathForMode("saveProjectAs", {
       currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
-      documentsPath: "/Users/demo/Documents",
-      openFileDialog: async () => ["/Users/demo/Projects"],
+      defaultFolder: "/Users/demo/Documents",
+      openFileDialog: async () => {
+        fallbackCalls += 1;
+        return ["/Users/demo/Projects"];
+      },
+      saveFileDialog: async () => null,
+    });
+
+    expect(result).toBeNull();
+    expect(fallbackCalls).toBe(0);
+  });
+
+  test("saveProjectAs falls back to open picker when save dialog fails", async () => {
+    let openDialogCallCount = 0;
+
+    const result = await pickPathForMode("saveProjectAs", {
+      currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
+      defaultFolder: "/Users/demo/Documents",
+      openFileDialog: async () => {
+        openDialogCallCount += 1;
+        return ["/Users/demo/Projects"];
+      },
       saveFileDialog: async () => {
         throw new Error("save dialog unavailable");
       },
     });
 
     expect(result).toBe("/Users/demo/Projects/alpha.gglassproj");
+    expect(openDialogCallCount).toBe(1);
+  });
+
+  test("saveProjectAs fallback keeps explicit .gglassproj file selection", async () => {
+    const result = await pickPathForMode("saveProjectAs", {
+      currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
+      defaultFolder: "/Users/demo/Documents",
+      openFileDialog: async () => ["/Users/demo/Projects/beta.gglassproj"],
+      saveFileDialog: async () => {
+        throw new Error("save dialog unavailable");
+      },
+    });
+
+    expect(result).toBe("/Users/demo/Projects/beta.gglassproj");
+  });
+
+  test("saveProjectAs returns null when fallback open picker is canceled", async () => {
+    const result = await pickPathForMode("saveProjectAs", {
+      currentProjectPath: null,
+      defaultFolder: "/Users/demo/Documents",
+      openFileDialog: async () => [],
+    });
+
+    expect(result).toBeNull();
+  });
+
+  test("saveProjectAs asks for overwrite confirmation when target exists", async () => {
+    let confirmedPath = "";
+    const result = await pickPathForMode("saveProjectAs", {
+      currentProjectPath: null,
+      defaultFolder: "/Users/demo/Documents",
+      openFileDialog: async () => ["/Users/demo/Documents/existing.gglassproj"],
+      pathExists: async () => true,
+      confirmOverwritePath: async (filePath) => {
+        confirmedPath = filePath;
+        return false;
+      },
+    });
+
+    expect(confirmedPath).toBe("/Users/demo/Documents/existing.gglassproj");
+    expect(result).toBeNull();
+  });
+
+  test("saveProjectAs skips overwrite confirmation when target does not exist", async () => {
+    let confirmCalls = 0;
+    const result = await pickPathForMode("saveProjectAs", {
+      currentProjectPath: null,
+      defaultFolder: "/Users/demo/Documents",
+      openFileDialog: async () => ["/Users/demo/Documents/new-project.gglassproj"],
+      pathExists: async () => false,
+      confirmOverwritePath: async () => {
+        confirmCalls += 1;
+        return false;
+      },
+    });
+
+    expect(result).toBe("/Users/demo/Documents/new-project.gglassproj");
+    expect(confirmCalls).toBe(0);
   });
 
   test("export mode returns selected directory path", async () => {
     const result = await pickPathForMode("export", {
-      documentsPath: "/Users/demo/Documents",
+      defaultFolder: "/Users/demo/Documents",
       openFileDialog: async () => ["/Users/demo/Exports"],
     });
 
@@ -56,7 +135,7 @@ describe("host path picker", () => {
     let seenStartingFolder = "";
     await pickPathForMode("openProject", {
       currentProjectPath: "/Users/demo/Projects/alpha.gglassproj",
-      documentsPath: "/Users/demo/Documents",
+      defaultFolder: "/Users/demo/Documents",
       openFileDialog: async ({ startingFolder }) => {
         seenStartingFolder = startingFolder ?? "";
         return [];

--- a/apps/desktop-electrobun/tests/preferred-window-selection.test.ts
+++ b/apps/desktop-electrobun/tests/preferred-window-selection.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, test } from "bun:test";
+import {
+  pickPreferredWindowId,
+  resolveSelectedWindowId,
+} from "../src/mainview/app/studio/model/preferredWindowSelection";
+
+describe("preferred window selection", () => {
+  test("returns zero when no windows are available", () => {
+    expect(pickPreferredWindowId([])).toBe(0);
+    expect(resolveSelectedWindowId([], 55)).toBe(0);
+  });
+
+  test("prefers full-size windows over menu-band style windows", () => {
+    const windows = [
+      {
+        id: 101,
+        title: "",
+        appName: "SystemUIServer",
+        width: 1512,
+        height: 24,
+        isOnScreen: true,
+      },
+      {
+        id: 202,
+        title: "Untitled",
+        appName: "TextEdit",
+        width: 1280,
+        height: 720,
+        isOnScreen: true,
+      },
+    ];
+
+    expect(pickPreferredWindowId(windows)).toBe(202);
+  });
+
+  test("keeps a valid explicit selection", () => {
+    const windows = [
+      {
+        id: 11,
+        title: "Window A",
+        appName: "App",
+        width: 900,
+        height: 700,
+        isOnScreen: true,
+      },
+      {
+        id: 22,
+        title: "Window B",
+        appName: "App",
+        width: 1200,
+        height: 800,
+        isOnScreen: true,
+      },
+    ];
+
+    expect(resolveSelectedWindowId(windows, 11)).toBe(11);
+  });
+
+  test("falls back to the preferred window when selection is missing", () => {
+    const windows = [
+      {
+        id: 33,
+        title: "",
+        appName: "App",
+        width: 1200,
+        height: 80,
+        isOnScreen: true,
+      },
+      {
+        id: 44,
+        title: "Main",
+        appName: "App",
+        width: 1300,
+        height: 900,
+        isOnScreen: true,
+      },
+    ];
+
+    expect(resolveSelectedWindowId(windows, 999)).toBe(44);
+  });
+});

--- a/apps/desktop-electrobun/tests/project-package-registration-script.test.ts
+++ b/apps/desktop-electrobun/tests/project-package-registration-script.test.ts
@@ -1,0 +1,224 @@
+import { describe, expect, test } from "bun:test";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const SCRIPT_PATH = "scripts/configure-macos-project-package.ts";
+const PROJECT_UTI = "com.okikeSolutions.guerillaglass.project";
+
+const BASE_INFO_PLIST = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>launcher</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.okikeSolutions.guerillaglass.desktop</string>
+    <key>CFBundleName</key>
+    <string>Guerillaglass</string>
+    <key>CFBundleVersion</key>
+    <string>0.1.0</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+</dict>
+</plist>`;
+
+function runCommand(command: string[], env?: Record<string, string>) {
+  return Bun.spawnSync(command, {
+    cwd: process.cwd(),
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+async function createFixtureAppBundle(
+  temporaryDirectory: string,
+  appName: string,
+  infoPlistContents: string = BASE_INFO_PLIST,
+): Promise<{ appDirectory: string; infoPlistPath: string }> {
+  const appContentsDirectory = path.join(temporaryDirectory, `${appName}.app`, "Contents");
+  const infoPlistPath = path.join(appContentsDirectory, "Info.plist");
+  await mkdir(appContentsDirectory, { recursive: true });
+  await writeFile(infoPlistPath, infoPlistContents, "utf8");
+  return { appDirectory: path.dirname(appContentsDirectory), infoPlistPath };
+}
+
+function parseInfoPlistAsJson(infoPlistPath: string): Record<string, unknown> {
+  const plistAsJson = runCommand(["plutil", "-convert", "json", "-o", "-", infoPlistPath]);
+  expect(plistAsJson.exitCode).toBe(0);
+  return JSON.parse(plistAsJson.stdout.toString()) as Record<string, unknown>;
+}
+
+describe("project package registration hook", () => {
+  test("registers .gglassproj document type and is idempotent", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const temporaryDirectory = await mkdtemp(path.join(tmpdir(), "gglassproj-script-test-"));
+
+    try {
+      const { infoPlistPath } = await createFixtureAppBundle(temporaryDirectory, "Test");
+
+      const env = {
+        ELECTROBUN_OS: "macos",
+        ELECTROBUN_BUILD_DIR: temporaryDirectory,
+      };
+
+      const firstRun = runCommand([process.execPath, SCRIPT_PATH], env);
+      expect(firstRun.exitCode).toBe(0);
+      expect(firstRun.stdout.toString()).toContain("updated+validated");
+
+      const secondRun = runCommand([process.execPath, SCRIPT_PATH], env);
+      expect(secondRun.exitCode).toBe(0);
+      expect(secondRun.stdout.toString()).toContain("already configured");
+
+      const plistContents = JSON.stringify(parseInfoPlistAsJson(infoPlistPath));
+      expect(plistContents).toContain(`"UTTypeIdentifier":"${PROJECT_UTI}"`);
+      expect(plistContents).toContain(`"LSItemContentTypes":["${PROJECT_UTI}"]`);
+      expect(plistContents).toContain('"LSTypeIsPackage":true');
+      expect(plistContents).toContain('"CFBundleTypeExtensions":["gglassproj"]');
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("is a no-op when ELECTROBUN_OS is not macos", async () => {
+    const temporaryDirectory = await mkdtemp(path.join(tmpdir(), "gglassproj-script-test-"));
+
+    try {
+      const { infoPlistPath } = await createFixtureAppBundle(temporaryDirectory, "Noop");
+      const originalContents = await readFile(infoPlistPath, "utf8");
+
+      const run = runCommand([process.execPath, SCRIPT_PATH], {
+        ELECTROBUN_OS: "linux",
+        ELECTROBUN_BUILD_DIR: temporaryDirectory,
+      });
+      expect(run.exitCode).toBe(0);
+      expect(run.stdout.toString()).toBe("");
+
+      const nextContents = await readFile(infoPlistPath, "utf8");
+      expect(nextContents).toBe(originalContents);
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("fails fast when build directory is missing for macos run", () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const run = runCommand([process.execPath, SCRIPT_PATH], {
+      ELECTROBUN_OS: "macos",
+      ELECTROBUN_BUILD_DIR: "",
+    });
+
+    expect(run.exitCode).not.toBe(0);
+    expect(run.stderr.toString()).toContain("ELECTROBUN_BUILD_DIR is not set");
+  });
+
+  test("supports explicit wrapper bundle patching path", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const temporaryDirectory = await mkdtemp(path.join(tmpdir(), "gglassproj-script-test-"));
+
+    try {
+      const { appDirectory, infoPlistPath } = await createFixtureAppBundle(
+        temporaryDirectory,
+        "Wrapper",
+      );
+
+      const run = runCommand([process.execPath, SCRIPT_PATH], {
+        ELECTROBUN_OS: "macos",
+        ELECTROBUN_WRAPPER_BUNDLE_PATH: appDirectory,
+      });
+
+      expect(run.exitCode).toBe(0);
+      const plistContents = JSON.stringify(parseInfoPlistAsJson(infoPlistPath));
+      expect(plistContents).toContain(`"UTTypeIdentifier":"${PROJECT_UTI}"`);
+      expect(plistContents).toContain('"CFBundleTypeExtensions":["gglassproj"]');
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+
+  test("replaces malformed legacy project declarations with canonical values", async () => {
+    if (process.platform !== "darwin") {
+      return;
+    }
+
+    const temporaryDirectory = await mkdtemp(path.join(tmpdir(), "gglassproj-script-test-"));
+
+    try {
+      const malformedInfoPlist = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleExecutable</key>
+    <string>launcher</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.okikeSolutions.guerillaglass.desktop</string>
+    <key>UTExportedTypeDeclarations</key>
+    <array>
+        <dict>
+            <key>UTTypeIdentifier</key>
+            <string>${PROJECT_UTI}</string>
+            <key>UTTypeConformsTo</key>
+            <array>
+                <string>public.data</string>
+            </array>
+        </dict>
+    </array>
+    <key>CFBundleDocumentTypes</key>
+    <array>
+        <dict>
+            <key>CFBundleTypeName</key>
+            <string>Legacy Project</string>
+            <key>CFBundleTypeRole</key>
+            <string>Viewer</string>
+            <key>CFBundleTypeExtensions</key>
+            <array>
+                <string>gglassproj</string>
+            </array>
+        </dict>
+    </array>
+</dict>
+</plist>`;
+
+      const { infoPlistPath } = await createFixtureAppBundle(
+        temporaryDirectory,
+        "Legacy",
+        malformedInfoPlist,
+      );
+
+      const run = runCommand([process.execPath, SCRIPT_PATH], {
+        ELECTROBUN_OS: "macos",
+        ELECTROBUN_BUILD_DIR: temporaryDirectory,
+      });
+
+      expect(run.exitCode).toBe(0);
+      const plist = parseInfoPlistAsJson(infoPlistPath);
+      const documentTypes = (plist.CFBundleDocumentTypes as unknown[]) ?? [];
+      const utExportedTypes = (plist.UTExportedTypeDeclarations as unknown[]) ?? [];
+
+      expect(documentTypes.length).toBe(1);
+      expect(utExportedTypes.length).toBe(1);
+
+      const normalizedContents = JSON.stringify(plist);
+      expect(normalizedContents).toContain(`"UTTypeIdentifier":"${PROJECT_UTI}"`);
+      expect(normalizedContents).toContain(
+        '"UTTypeConformsTo":["com.apple.package","public.data"]',
+      );
+      expect(normalizedContents).toContain(
+        '"LSItemContentTypes":["com.okikeSolutions.guerillaglass.project"]',
+      );
+      expect(normalizedContents).toContain('"LSTypeIsPackage":true');
+    } finally {
+      await rm(temporaryDirectory, { recursive: true, force: true });
+    }
+  });
+});

--- a/apps/desktop-electrobun/tests/ui/studio-shell.smoke.ts
+++ b/apps/desktop-electrobun/tests/ui/studio-shell.smoke.ts
@@ -98,6 +98,12 @@ function installMockBridge() {
     return captureStatus();
   };
 
+  browserWindow.ggEngineStartCurrentWindowCapture = async () => {
+    state.isRunning = true;
+    state.lastError = null;
+    return captureStatus();
+  };
+
   browserWindow.ggEngineStartWindowCapture = async () => {
     state.isRunning = true;
     state.lastError = null;

--- a/apps/desktop-electrobun/vite.config.ts
+++ b/apps/desktop-electrobun/vite.config.ts
@@ -9,6 +9,25 @@ export default defineConfig({
   build: {
     outDir: "../../dist",
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (!id.includes("node_modules")) {
+            return;
+          }
+          if (id.includes("/@tanstack/")) {
+            return "vendor-tanstack";
+          }
+          if (id.includes("/lucide-react/")) {
+            return "vendor-icons";
+          }
+          if (id.includes("/zod/")) {
+            return "vendor-zod";
+          }
+          return;
+        },
+      },
+    },
   },
   server: {
     port: 5173,

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -56,7 +56,11 @@ Playback transport hardening (current):
 - Transient transport failures are retried in Bun for read-only methods only, using typed transport errors (not string matching).
 - Restart handling uses bounded attempts with backoff + jitter and a circuit-open cooldown after repeated crash loops.
 - Mutating methods (capture/recording start-stop, export run, project writes) are not auto-retried to avoid duplicate side effects.
-- Renderer directory-picker flows (`open project`, `save as`, export target selection) treat host RPC timeout responses as recoverable interruptions and show workflow guidance instead of a sticky fatal error state.
+- Renderer picker flows (`open project`, `save as`, export target selection) use a single host RPC (`ggPickPath`) with explicit modes: `openProject`, `saveProjectAs`, `export`.
+- `openProject` selections are constrained to `.gglassproj` package paths.
+- `saveProjectAs` prefers a native save dialog when the host runtime exposes one; otherwise it falls back to folder picking and host-side package-path resolution (`*.gglassproj`).
+- Renderer picker flows treat host RPC timeout responses as recoverable interruptions and show workflow guidance instead of a sticky fatal error state.
+- Renderer save flows surface the resolved target path before write confirmation.
 - Transport mutations (`start/stop preview`, record toggles) reconcile against follow-up `capture.status` polls before final notice state to reduce stale transport-state drift.
 
 ## Renderer UI State (Creator Studio)

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -97,6 +97,7 @@ Playback transport hardening (current):
 - `permissions.openInputMonitoringSettings`
 - `sources.list`
 - `capture.startDisplay`
+- `capture.startCurrentWindow`
 - `capture.startWindow`
 - `capture.stop`
 - `recording.start`
@@ -139,9 +140,14 @@ Protocol compatibility policy for `capture.status`:
 Capture start requests support runtime capture cadence selection:
 
 - `capture.startDisplay.params.captureFps` (`24 | 30 | 60`, default `30`)
+- `capture.startCurrentWindow.params.captureFps` (`24 | 30 | 60`, default `30`)
 - `capture.startWindow.params.captureFps` (`24 | 30 | 60`, default `30`)
 
 Capture FPS is independent from export preset FPS. Export cadence remains defined by the selected export preset.
+
+Current-window semantics:
+
+- `capture.startCurrentWindow` is resolved engine-side against the frontmost shareable window, reducing shell-side fallback heuristics.
 
 ## Why This Split
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -58,7 +58,10 @@ Playback transport hardening (current):
 - Mutating methods (capture/recording start-stop, export run, project writes) are not auto-retried to avoid duplicate side effects.
 - Renderer picker flows (`open project`, `save as`, export target selection) use a single host RPC (`ggPickPath`) with explicit modes: `openProject`, `saveProjectAs`, `export`.
 - `openProject` selections are constrained to `.gglassproj` package paths.
-- `saveProjectAs` prefers a native save dialog when the host runtime exposes one; otherwise it falls back to folder picking and host-side package-path resolution (`*.gglassproj`).
+- macOS build hooks patch generated `Info.plist` entries to register `.gglassproj` using `UTExportedTypeDeclarations` (custom UTI) and `CFBundleDocumentTypes` (`LSItemContentTypes` + `LSTypeIsPackage`) so Finder treats projects as single package items by default.
+- `saveProjectAs` prefers a native save dialog when the host runtime exposes one; otherwise it falls back to an open picker that accepts either a target `*.gglassproj` file or a directory (resolved to `<directory>/<default-name>.gglassproj`).
+- Save/Save As/Export pickers default to the platform Videos/Movies directory (`Utils.paths.videos`) and fall back to Documents when unavailable.
+- Save path collisions can trigger a host confirmation message before replacing an existing `*.gglassproj` target.
 - Renderer picker flows treat host RPC timeout responses as recoverable interruptions and show workflow guidance instead of a sticky fatal error state.
 - Renderer save flows surface the resolved target path before write confirmation.
 - Transport mutations (`start/stop preview`, record toggles) reconcile against follow-up `capture.status` polls before final notice state to reduce stale transport-state drift.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -27,6 +27,7 @@ Creator Studio tracking checklist (current repo):
 - [x] Add layout persistence (pane sizes/collapse/workspace restore)
 - [x] Add capture telemetry row (record state, duration, dropped frames, audio level, health)
 - [x] Keep core shell actions wired to engine protocol (`record`, `open/save`, `export`)
+- [x] Route `Current Window` recording through engine-side frontmost window resolution (`capture.startCurrentWindow`) instead of renderer-side source-order inference
 - [x] Handle host-dialog RPC timeouts as recoverable workflow interruptions with guidance copy
 - [x] Keep core keyboard shortcuts (`record`, `play/pause`, `trim in/out`, `save`, `export`)
 - [x] Keep degraded-mode messaging visible near preview/recording context
@@ -116,6 +117,7 @@ Progress (current repo)
 - [x] Display capture preview (ScreenCaptureKit)
 - [x] Mic capture skeleton (permission + AVAudioEngine tap)
 - [x] Window capture UI + preview
+- [x] Engine-side frontmost current-window capture command (`capture.startCurrentWindow`)
 - [x] Trim + export
 - [x] Project schema + store (save/load on disk)
 - [x] Protocol-based project open/save flow in desktop shell

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -231,6 +231,9 @@ Creator Studio implementation requirements:
   - open existing project
   - save/save as
   - preserve project state for repeat exports
+  - Open Project picker targets `.gglassproj` packages (project container contract).
+  - Save As resolves and validates target package paths in host shell code; renderer receives the final path.
+  - Save As uses a native save panel when available in the host runtime, with a folder-picker fallback that still resolves to a `*.gglassproj` path.
 - Project utility panel must provide:
   - active project metadata (name/path, capture metadata, URLs, duration)
   - recent projects list with one-action reopen from the utility rail

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -70,7 +70,8 @@ Guerilla Glass should feel like a professional creator tool:
 - **Protocol contract:** Zod (TypeScript) + Swift line-based wire codec + shared Rust protocol crate
   - `capture.status` telemetry emits machine-stable reason codes (`engine_error`, `high_dropped_frame_rate`, `elevated_dropped_frame_rate`, `low_microphone_level`); renderer localizes these codes for UI.
   - `capture.status` telemetry includes aggregate and channel-specific performance metrics (`sourceDroppedFrames`, `writerDroppedFrames`, `writerBackpressureDrops`, `achievedFps`) for capture diagnostics.
-  - `capture.startDisplay` and `capture.startWindow` accept `captureFps` (`24 | 30 | 60`, default `30`) and this is decoupled from export preset FPS.
+  - `capture.startDisplay`, `capture.startCurrentWindow`, and `capture.startWindow` accept `captureFps` (`24 | 30 | 60`, default `30`) and this is decoupled from export preset FPS.
+  - `capture.startCurrentWindow` resolves the active frontmost shareable window in the engine, so renderer menu actions do not have to infer "current" from cached source ordering.
   - `capture.status` includes `captureMetadata` (with optional window identity for window captures) so shell status surfaces can reflect the active source from engine state rather than only form intent.
   - Additive protocol evolution rule: new response fields should be optional or renderer-derivable so older engines remain compatible during rollout.
 - **Native engines (per platform):**

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -234,7 +234,10 @@ Creator Studio implementation requirements:
   - preserve project state for repeat exports
   - Open Project picker targets `.gglassproj` packages (project container contract).
   - Save As resolves and validates target package paths in host shell code; renderer receives the final path.
-  - Save As uses a native save panel when available in the host runtime, with a folder-picker fallback that still resolves to a `*.gglassproj` path.
+  - Save As uses a native save panel when available in the host runtime.
+  - Save As fallback uses an open picker that accepts either a `*.gglassproj` file path or a directory, then resolves to a final `*.gglassproj` target path in host shell code.
+  - Save path collisions may require explicit host confirmation before replacing an existing project package.
+  - Save/Save As/Export picker defaults should start in platform Videos/Movies directories, with Documents as a host fallback.
 - Project utility panel must provide:
   - active project metadata (name/path, capture metadata, URLs, duration)
   - recent projects list with one-action reopen from the utility rail
@@ -348,6 +351,7 @@ Project container:
 
 - File extension: `.gglassproj`
 - macOS: treated as a **package** (single file in Finder, directory on disk)
+- Desktop shell build hooks register `.gglassproj` as a package document type on macOS by writing `UTExportedTypeDeclarations` (custom project UTI) and `CFBundleDocumentTypes` (`LSItemContentTypes` + `LSTypeIsPackage`) into generated `Info.plist`.
 - Cross‑platform: other OSes see a folder with the same contents
 
 Project directory contents:

--- a/engines/macos-swift/EngineService+CaptureRecording.swift
+++ b/engines/macos-swift/EngineService+CaptureRecording.swift
@@ -111,6 +111,27 @@ extension EngineService {
         }
     }
 
+    func startCurrentWindowResponse(id: String, params: [String: JSONValue]) async -> EngineResponse {
+        let enableMic = params["enableMic"]?.boolValue ?? false
+        guard let captureFps = resolveCaptureFrameRate(from: params) else {
+            return .failure(
+                id: id,
+                code: "invalid_params",
+                message: captureFrameRateValidationMessage()
+            )
+        }
+
+        do {
+            try await captureEngine.startCurrentWindowCapture(
+                enableMic: enableMic,
+                targetFrameRate: captureFps
+            )
+            return captureStatusResponse(id: id)
+        } catch {
+            return .failure(id: id, code: "runtime_error", message: error.localizedDescription)
+        }
+    }
+
     func stopCaptureResponse(id: String) async -> EngineResponse {
         await captureEngine.stopCapture()
         await stopInputTrackingIfNeeded()

--- a/engines/macos-swift/EngineService+Sources.swift
+++ b/engines/macos-swift/EngineService+Sources.swift
@@ -54,14 +54,11 @@ extension EngineService {
 
     func filteredWindows(from windows: [SCWindow]) -> [SCWindow] {
         windows.filter { window in
-            guard window.isOnScreen else { return false }
-            guard window.frame.width > 1, window.frame.height > 1 else { return false }
-            guard let app = window.owningApplication else { return false }
-            let bundleID = app.bundleIdentifier
-            if bundleID == "com.apple.WindowServer" || bundleID == "com.apple.dock" {
-                return false
-            }
-            return true
+            ShareableWindowFilter.shouldInclude(
+                bundleIdentifier: window.owningApplication?.bundleIdentifier,
+                frame: window.frame,
+                isOnScreen: window.isOnScreen
+            )
         }
     }
 }

--- a/engines/macos-swift/EngineService.swift
+++ b/engines/macos-swift/EngineService.swift
@@ -40,6 +40,9 @@ final class EngineService {
             "permissions.openInputMonitoringSettings": { id, _ in self.permissionsOpenInputMonitoringSettings(id: id) },
             "sources.list": { id, _ in await self.sourcesListResponse(id: id) },
             "capture.startDisplay": { id, params in await self.startDisplayResponse(id: id, params: params) },
+            "capture.startCurrentWindow": { id, params in
+                await self.startCurrentWindowResponse(id: id, params: params)
+            },
             "capture.startWindow": { id, params in await self.startWindowResponse(id: id, params: params) },
             "capture.stop": { id, _ in await self.stopCaptureResponse(id: id) },
             "recording.start": { id, params in await self.startRecordingResponse(id: id, params: params) },

--- a/engines/macos-swift/modules/capture/CaptureEngine.swift
+++ b/engines/macos-swift/modules/capture/CaptureEngine.swift
@@ -162,6 +162,18 @@ public final class CaptureEngine: NSObject, ObservableObject {
         }
     }
 
+    public func startCurrentWindowCapture(
+        enableMic: Bool = false,
+        targetFrameRate: Int = 30
+    ) async throws {
+        let frontmostWindow = try await resolveFrontmostWindow()
+        try await startWindowCapture(
+            windowID: frontmostWindow.windowID,
+            enableMic: enableMic,
+            targetFrameRate: targetFrameRate
+        )
+    }
+
     @available(macOS 14.0, *)
     public func startCaptureUsingPicker(
         style: SCShareableContentStyle? = nil,

--- a/engines/macos-swift/modules/capture/ShareableWindow.swift
+++ b/engines/macos-swift/modules/capture/ShareableWindow.swift
@@ -46,3 +46,25 @@ public struct ShareableWindow: Identifiable, Hashable {
         }
     }
 }
+
+/// Shared inclusion policy for ScreenCaptureKit shareable windows across engine surfaces.
+public enum ShareableWindowFilter {
+    public static let excludedBundleIdentifiers: Set<String> = [
+        "com.apple.WindowServer",
+        "com.apple.dock",
+        "com.apple.controlcenter",
+        "com.apple.systemuiserver",
+        "com.apple.notificationcenterui"
+    ]
+
+    public static func shouldInclude(
+        bundleIdentifier: String?,
+        frame: CGRect,
+        isOnScreen: Bool
+    ) -> Bool {
+        guard isOnScreen else { return false }
+        guard frame.width > 1, frame.height > 1 else { return false }
+        guard let bundleIdentifier else { return false }
+        return !excludedBundleIdentifiers.contains(bundleIdentifier)
+    }
+}

--- a/engines/native-foundation/src/lib.rs
+++ b/engines/native-foundation/src/lib.rs
@@ -271,6 +271,20 @@ fn handle_request(platform: &str, state: &mut State, request: &EngineRequest) ->
             }));
             success(&request.id, state.capture_status())
         }
+        EngineMethod::CaptureStartCurrentWindow => {
+            state.is_running = true;
+            state.capture_metadata = Some(json!({
+                "window": {
+                    "id": 101,
+                    "title": "Desktop",
+                    "appName": "System",
+                },
+                "source": "window",
+                "contentRect": { "x": 0, "y": 0, "width": 1280, "height": 720 },
+                "pixelScale": 1,
+            }));
+            success(&request.id, state.capture_status())
+        }
         EngineMethod::CaptureStartWindow => {
             let window_id = params
                 .get("windowId")

--- a/engines/stub-common/stubEngine.ts
+++ b/engines/stub-common/stubEngine.ts
@@ -232,6 +232,21 @@ function handleRequest(platform: string, request: Request): Response {
       };
       return success(request.id, statusResult());
 
+    case "capture.startCurrentWindow":
+      state.isRunning = true;
+      state.lastError = null;
+      state.captureMetadata = {
+        window: {
+          id: 101,
+          title: "Stub Window",
+          appName: "StubApp",
+        },
+        source: "window",
+        contentRect: { x: 0, y: 0, width: 1280, height: 720 },
+        pixelScale: 1,
+      };
+      return success(request.id, statusResult());
+
     case "capture.startWindow": {
       const requestedWindowId =
         typeof params.windowId === "number" && Number.isFinite(params.windowId)

--- a/packages/engine-protocol/src/index.ts
+++ b/packages/engine-protocol/src/index.ts
@@ -305,6 +305,15 @@ export const captureStartDisplayRequestSchema = requestBaseSchema.extend({
   }),
 });
 
+/** Engine protocol schema for captureStartCurrentWindowRequestSchema. */
+export const captureStartCurrentWindowRequestSchema = requestBaseSchema.extend({
+  method: z.literal(engineMethods.CaptureStartCurrentWindow),
+  params: z.object({
+    enableMic: z.boolean().optional().default(false),
+    captureFps: captureFrameRateSchema.optional().default(defaultCaptureFrameRate),
+  }),
+});
+
 /** Engine protocol schema for captureStartWindowRequestSchema. */
 export const captureStartWindowRequestSchema = requestBaseSchema.extend({
   method: z.literal(engineMethods.CaptureStartWindow),
@@ -403,6 +412,7 @@ export const engineRequestSchema = z.discriminatedUnion("method", [
   permissionsOpenInputSettingsRequestSchema,
   sourcesListRequestSchema,
   captureStartDisplayRequestSchema,
+  captureStartCurrentWindowRequestSchema,
   captureStartWindowRequestSchema,
   captureStopRequestSchema,
   recordingStartRequestSchema,

--- a/packages/engine-protocol/src/methods.ts
+++ b/packages/engine-protocol/src/methods.ts
@@ -9,6 +9,7 @@ export const engineMethods = {
   PermissionsOpenInputMonitoringSettings: "permissions.openInputMonitoringSettings",
   SourcesList: "sources.list",
   CaptureStartDisplay: "capture.startDisplay",
+  CaptureStartCurrentWindow: "capture.startCurrentWindow",
   CaptureStartWindow: "capture.startWindow",
   CaptureStop: "capture.stop",
   RecordingStart: "recording.start",

--- a/packages/localization/src/studio/de.ts
+++ b/packages/localization/src/studio/de.ts
@@ -25,6 +25,7 @@ export const deDE: StudioMessages = {
     exportMissingPreset: "Kein Export-Preset ausgewählt.",
     exportComplete: (outputURL: string) => `Export abgeschlossen: ${outputURL}`,
     projectOpened: "Projekt geöffnet.",
+    projectSaveTarget: (path: string) => `Projekt wird gespeichert unter ${path}...`,
     projectSaved: (path: string) => `Projekt gespeichert unter ${path}`,
     selectWindowFirst: "Wähle vor dem Start der Aufnahme ein Fenster aus.",
     screenPermissionRequired:
@@ -60,6 +61,8 @@ export const deDE: StudioMessages = {
     stopPreview: "Vorschau stoppen",
     startRecording: "Aufzeichnung starten",
     stopRecording: "Aufzeichnung stoppen",
+    recordCurrentWindow: "Aktuelles Fenster",
+    recordChooseWindow: "Fenster waehlen...",
     exportNow: "Exportieren",
     openProject: "Projekt öffnen",
     saveProject: "Projekt speichern",

--- a/packages/localization/src/studio/en.ts
+++ b/packages/localization/src/studio/en.ts
@@ -22,6 +22,7 @@ export const enUS = {
     exportMissingPreset: "No export preset selected.",
     exportComplete: (outputURL: string) => `Export complete: ${outputURL}`,
     projectOpened: "Project opened.",
+    projectSaveTarget: (path: string) => `Saving project to ${path}...`,
     projectSaved: (path: string) => `Project saved to ${path}`,
     selectWindowFirst: "Select a window before starting capture.",
     screenPermissionRequired:
@@ -57,6 +58,8 @@ export const enUS = {
     stopPreview: "Stop Preview",
     startRecording: "Start Recording",
     stopRecording: "Stop Recording",
+    recordCurrentWindow: "Current Window",
+    recordChooseWindow: "Choose Window...",
     exportNow: "Export",
     openProject: "Open Project",
     saveProject: "Save Project",


### PR DESCRIPTION
# Summary
- Hardened desktop Save/Save As path handling so `saveProjectAs` prefers native save dialogs, falls back safely, supports overwrite confirmation, and defaults picker roots to Videos/Movies with Documents fallback.
- Added stronger host path-picker behavior and regression coverage for cancellation, fallback resolution, overwrite checks, and parent-folder derivation.
- Registered `.gglassproj` as a macOS package document type in build outputs via Electrobun hooks and a plist upsert/validate script.
- Added comprehensive script tests for registration/idempotency/no-op modes/env validation/wrapper path handling/legacy replacement.
- Prior branch commits included in this PR: system picker capture + frontmost window routing, capture route aspect-ratio update, studio header divider fix, and route lazy-loading/perf chunk tuning.
- Updated docs and desktop README to reflect project-package registration behavior and save-flow architecture.

# Checklist
- [x] Ran `bun run gate`
- [ ] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
- [ ] UI changes include screenshots
- [x] Updated docs/templates if architecture or workflows changed

# Testing (optional)
- [x] swift test
- [x] bun run desktop:test:coverage (required when touching `apps/desktop-electrobun` or `packages/engine-protocol`)
