### PR TITLE
Studio: improve inspector context switching

### DIFF
--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/InspectorPanel.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/InspectorPanel.tsx
@@ -1,13 +1,22 @@
 import { MonitorCog } from "lucide-react";
 import { useMemo } from "react";
 import { useStudio } from "../state/StudioProvider";
-import { resolveInspectorView, type StudioMode } from "../model/inspectorSelectionModel";
+import {
+  resolveInspectorView,
+  type InspectorView,
+  type StudioMode,
+} from "../model/inspectorSelectionModel";
 import {
   CaptureInspectorContent,
   DeliverInspectorContent,
   EditInspectorContent,
 } from "./inspector/InspectorModeContent";
-import { SelectionDetails } from "./inspector/SelectionDetails";
+import {
+  SelectionDetailsCaptureWindow,
+  SelectionDetailsExportPreset,
+  SelectionDetailsTimelineClip,
+  SelectionDetailsTimelineMarker,
+} from "./inspector/SelectionDetails";
 import {
   StudioPane,
   StudioPaneBody,
@@ -19,6 +28,51 @@ import {
 type InspectorPanelProps = {
   mode: StudioMode;
 };
+
+function renderInspectorContent(params: {
+  view: InspectorView;
+  selection: ReturnType<typeof useStudio>["inspectorSelection"];
+  studio: ReturnType<typeof useStudio>;
+}) {
+  const { view, selection, studio } = params;
+
+  switch (view.id) {
+    case "captureDefault":
+      return <CaptureInspectorContent studio={studio} />;
+    case "editDefault":
+      return <EditInspectorContent studio={studio} />;
+    case "deliverDefault":
+      return <DeliverInspectorContent studio={studio} />;
+    case "timelineClipVideo":
+    case "timelineClipAudio":
+      return selection.kind === "timelineClip" ? (
+        <SelectionDetailsTimelineClip selection={selection} studio={studio} />
+      ) : null;
+    case "timelineMarker":
+      return selection.kind === "timelineMarker" ? (
+        <SelectionDetailsTimelineMarker selection={selection} studio={studio} />
+      ) : null;
+    case "captureWindow":
+      return selection.kind === "captureWindow" ? (
+        <>
+          <SelectionDetailsCaptureWindow selection={selection} studio={studio} />
+          <CaptureInspectorContent studio={studio} />
+        </>
+      ) : null;
+    case "exportPreset":
+      return selection.kind === "exportPreset" ? (
+        <>
+          <SelectionDetailsExportPreset selection={selection} studio={studio} />
+          <DeliverInspectorContent studio={studio} />
+        </>
+      ) : null;
+    default: {
+      const _exhaustiveCheck: never = view.id;
+      void _exhaustiveCheck;
+      return null;
+    }
+  }
+}
 
 export function InspectorPanel({ mode }: InspectorPanelProps) {
   const studio = useStudio();
@@ -35,13 +89,7 @@ export function InspectorPanel({ mode }: InspectorPanelProps) {
         <StudioPaneSubtitle>{viewText.subtitle}</StudioPaneSubtitle>
       </StudioPaneHeader>
       <StudioPaneBody className="gg-inspector-pane-body gg-copy-compact">
-        {selection.kind !== "none" ? (
-          <SelectionDetails selection={selection} studio={studio} />
-        ) : null}
-
-        {mode === "capture" ? <CaptureInspectorContent studio={studio} /> : null}
-        {mode === "edit" ? <EditInspectorContent selection={selection} studio={studio} /> : null}
-        {mode === "deliver" ? <DeliverInspectorContent studio={studio} /> : null}
+        {renderInspectorContent({ view, selection, studio })}
       </StudioPaneBody>
     </StudioPane>
   );

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineDock.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineDock.tsx
@@ -240,6 +240,7 @@ export function TimelineDock() {
               onToggleLaneLocked={(laneId) => studio.toggleLaneControl(laneId, "locked")}
               onToggleLaneMuted={(laneId) => studio.toggleLaneControl(laneId, "muted")}
               onToggleLaneSolo={(laneId) => studio.toggleLaneControl(laneId, "solo")}
+              onClearSelection={studio.clearInspectorSelection}
               selectedClip={
                 studio.inspectorSelection.kind === "timelineClip" ? studio.inspectorSelection : null
               }

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineSurface.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineSurface.tsx
@@ -62,6 +62,7 @@ type TimelineSurfaceProps = {
   onToggleLaneLocked: (laneId: "video" | "audio") => void;
   onToggleLaneMuted: (laneId: "video" | "audio") => void;
   onToggleLaneSolo: (laneId: "video" | "audio") => void;
+  onClearSelection: () => void;
   selectedClip: TimelineSelectedClip;
   selectedMarkerId: string | null;
   onSelectClip: (params: {
@@ -245,10 +246,12 @@ function useTimelineDragController(params: {
   onSetPlayheadSeconds: (seconds: number) => void;
   onSetTrimStartSeconds: (seconds: number) => void;
   onSetTrimEndSeconds: (seconds: number) => void;
+  onClearSelection: () => void;
 }) {
   const {
     durationSeconds,
     trackOverlayRef,
+    onClearSelection,
     onSetPlayheadSeconds,
     onSetTrimStartSeconds,
     onSetTrimEndSeconds,
@@ -321,9 +324,10 @@ function useTimelineDragController(params: {
       if (!trackRect || event.clientX < trackRect.left || event.clientX > trackRect.right) {
         return;
       }
+      onClearSelection();
       beginDrag(event, "playhead");
     },
-    [beginDrag, trackOverlayRef],
+    [beginDrag, onClearSelection, trackOverlayRef],
   );
 
   const onSurfacePointerMove = useCallback(
@@ -649,6 +653,7 @@ export function TimelineSurface({
   onToggleLaneLocked,
   onToggleLaneMuted,
   onToggleLaneSolo,
+  onClearSelection,
   selectedClip,
   selectedMarkerId,
   onSelectClip,
@@ -667,6 +672,7 @@ export function TimelineSurface({
     onSetPlayheadSeconds,
     onSetTrimStartSeconds,
     onSetTrimEndSeconds,
+    onClearSelection,
   });
 
   const effectiveTrimEnd = trimEndSeconds > 0 ? trimEndSeconds : durationSeconds;
@@ -710,6 +716,9 @@ export function TimelineSurface({
             } else if (event.key === "ArrowRight") {
               event.preventDefault();
               onNudgePlayheadSeconds(event.shiftKey ? 1 : 0.1);
+            } else if (event.key === "Escape") {
+              event.preventDefault();
+              onClearSelection();
             }
           }}
           onPointerDown={onSurfacePointerDown}

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorModeContent.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorModeContent.tsx
@@ -1,11 +1,9 @@
 import { Keyboard, Mic, MousePointer, Sparkles } from "lucide-react";
 import type { ReactNode } from "react";
 import { captureFrameRates } from "@guerillaglass/engine-protocol";
-import { Button } from "@/components/ui/button";
 import { Field, FieldContent, FieldLabel } from "@/components/ui/field";
 import { Slider } from "@/components/ui/slider";
 import { buildCaptureTelemetryPresentation } from "../../model/captureTelemetryViewModel";
-import type { InspectorSelection } from "../../model/inspectorSelectionModel";
 import type { StudioController } from "../../hooks/core/useStudioController";
 import {
   AudioMixerChannel,
@@ -259,50 +257,11 @@ export function CaptureInspectorContent({ studio }: { studio: InspectorModeStudi
   );
 }
 
-export function EditInspectorContent({
-  selection,
-  studio,
-}: {
-  selection: InspectorSelection;
-  studio: InspectorModeStudio;
-}) {
+export function EditInspectorContent({ studio }: { studio: InspectorModeStudio }) {
   return (
     <>
       <InspectorSection title={studio.ui.inspectorTabs.project.toUpperCase()}>
-        {selection.kind === "timelineClip" ? (
-          <div className="flex flex-wrap gap-1.5">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => studio.setTrimStartSeconds(selection.startSeconds)}
-            >
-              {studio.ui.inspector.actions.setTrimInToClipStart}
-            </Button>
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => studio.setTrimEndSeconds(selection.endSeconds)}
-            >
-              {studio.ui.inspector.actions.setTrimOutToClipEnd}
-            </Button>
-          </div>
-        ) : null}
-
-        {selection.kind === "timelineMarker" ? (
-          <div className="flex flex-wrap gap-1.5">
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => studio.setPlayheadSeconds(selection.timestampSeconds)}
-            >
-              {studio.ui.inspector.actions.jumpPlayheadToMarker}
-            </Button>
-          </div>
-        ) : null}
-
-        {selection.kind === "none" ? (
-          <p className="gg-copy-meta">{studio.ui.helper.activePreviewBody}</p>
-        ) : null}
+        <p className="gg-copy-meta">{studio.ui.helper.activePreviewBody}</p>
       </InspectorSection>
 
       <InspectorSection title={studio.ui.inspectorTabs.effects.toUpperCase()}>

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorPrimitives.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorPrimitives.tsx
@@ -21,13 +21,15 @@ export function InspectorSection({
   title,
   children,
   className,
+  defaultOpen = false,
 }: {
   title: string;
   children: ReactNode;
   className?: string;
+  defaultOpen?: boolean;
 }) {
   return (
-    <Collapsible defaultOpen={false} className={cn("gg-inspector-section", className)}>
+    <Collapsible defaultOpen={defaultOpen} className={cn("gg-inspector-section", className)}>
       <CollapsibleTrigger className="gg-inspector-section-trigger">
         <ChevronRight className="gg-inspector-section-chevron" />
         <h3 className="gg-inspector-section-header border-0 pb-0">{title}</h3>

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/SelectionDetails.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/SelectionDetails.tsx
@@ -1,8 +1,12 @@
 import type { StudioController } from "../../hooks/core/useStudioController";
 import type { InspectorSelection } from "../../model/inspectorSelectionModel";
+import { Button } from "@/components/ui/button";
 import { InspectorDetailRows, InspectorSection } from "./InspectorPrimitives";
 
-type SelectionDetailsStudio = Pick<StudioController, "ui" | "formatDecimal">;
+type SelectionDetailsStudio = Pick<
+  StudioController,
+  "formatDecimal" | "setPlayheadSeconds" | "setTrimEndSeconds" | "setTrimStartSeconds" | "ui"
+>;
 
 type TimelineClipSelection = Extract<InspectorSelection, { kind: "timelineClip" }>;
 type TimelineMarkerSelection = Extract<InspectorSelection, { kind: "timelineMarker" }>;
@@ -29,7 +33,7 @@ function localizeTimelineMarkerKind(
   return studio.ui.labels.timelineMarkerMove;
 }
 
-function SelectionDetailsTimelineClip({
+export function SelectionDetailsTimelineClip({
   selection,
   studio,
 }: {
@@ -37,30 +41,48 @@ function SelectionDetailsTimelineClip({
   studio: SelectionDetailsStudio;
 }) {
   return (
-    <InspectorSection title={studio.ui.inspector.cards.selectedClip}>
-      <InspectorDetailRows
-        rows={[
-          {
-            value: `${studio.ui.inspector.fields.lane}: ${localizeTimelineLaneId(selection.laneId, studio)}`,
-          },
-          {
-            value: `${studio.ui.inspector.fields.start}: ${studio.formatDecimal(selection.startSeconds)}s`,
-          },
-          {
-            value: `${studio.ui.inspector.fields.end}: ${studio.formatDecimal(selection.endSeconds)}s`,
-          },
-          {
-            value: `${studio.ui.inspector.fields.duration}: ${studio.formatDecimal(
-              Math.max(0, selection.endSeconds - selection.startSeconds),
-            )}s`,
-          },
-        ]}
-      />
+    <InspectorSection title={studio.ui.inspector.cards.selectedClip} defaultOpen>
+      <div className="space-y-2">
+        <InspectorDetailRows
+          rows={[
+            {
+              value: `${studio.ui.inspector.fields.lane}: ${localizeTimelineLaneId(selection.laneId, studio)}`,
+            },
+            {
+              value: `${studio.ui.inspector.fields.start}: ${studio.formatDecimal(selection.startSeconds)}s`,
+            },
+            {
+              value: `${studio.ui.inspector.fields.end}: ${studio.formatDecimal(selection.endSeconds)}s`,
+            },
+            {
+              value: `${studio.ui.inspector.fields.duration}: ${studio.formatDecimal(
+                Math.max(0, selection.endSeconds - selection.startSeconds),
+              )}s`,
+            },
+          ]}
+        />
+        <div className="flex flex-wrap gap-1.5">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => studio.setTrimStartSeconds(selection.startSeconds)}
+          >
+            {studio.ui.inspector.actions.setTrimInToClipStart}
+          </Button>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => studio.setTrimEndSeconds(selection.endSeconds)}
+          >
+            {studio.ui.inspector.actions.setTrimOutToClipEnd}
+          </Button>
+        </div>
+      </div>
     </InspectorSection>
   );
 }
 
-function SelectionDetailsTimelineMarker({
+export function SelectionDetailsTimelineMarker({
   selection,
   studio,
 }: {
@@ -68,23 +90,34 @@ function SelectionDetailsTimelineMarker({
   studio: SelectionDetailsStudio;
 }) {
   return (
-    <InspectorSection title={studio.ui.inspector.cards.selectedEventMarker}>
-      <InspectorDetailRows
-        rows={[
-          {
-            value: `${studio.ui.inspector.fields.type}: ${localizeTimelineMarkerKind(selection.markerKind, studio)}`,
-          },
-          {
-            value: `${studio.ui.inspector.fields.time}: ${studio.formatDecimal(selection.timestampSeconds)}s`,
-          },
-          { value: `${studio.ui.inspector.fields.density}: ${selection.density}` },
-        ]}
-      />
+    <InspectorSection title={studio.ui.inspector.cards.selectedEventMarker} defaultOpen>
+      <div className="space-y-2">
+        <InspectorDetailRows
+          rows={[
+            {
+              value: `${studio.ui.inspector.fields.type}: ${localizeTimelineMarkerKind(selection.markerKind, studio)}`,
+            },
+            {
+              value: `${studio.ui.inspector.fields.time}: ${studio.formatDecimal(selection.timestampSeconds)}s`,
+            },
+            { value: `${studio.ui.inspector.fields.density}: ${selection.density}` },
+          ]}
+        />
+        <div className="flex flex-wrap gap-1.5">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => studio.setPlayheadSeconds(selection.timestampSeconds)}
+          >
+            {studio.ui.inspector.actions.jumpPlayheadToMarker}
+          </Button>
+        </div>
+      </div>
     </InspectorSection>
   );
 }
 
-function SelectionDetailsCaptureWindow({
+export function SelectionDetailsCaptureWindow({
   selection,
   studio,
 }: {
@@ -92,7 +125,7 @@ function SelectionDetailsCaptureWindow({
   studio: SelectionDetailsStudio;
 }) {
   return (
-    <InspectorSection title={studio.ui.inspector.cards.selectedWindow}>
+    <InspectorSection title={studio.ui.inspector.cards.selectedWindow} defaultOpen>
       <InspectorDetailRows
         rows={[
           { value: `${studio.ui.inspector.fields.app}: ${selection.appName}` },
@@ -107,7 +140,7 @@ function SelectionDetailsCaptureWindow({
   );
 }
 
-function SelectionDetailsExportPreset({
+export function SelectionDetailsExportPreset({
   selection,
   studio,
 }: {
@@ -115,7 +148,7 @@ function SelectionDetailsExportPreset({
   studio: SelectionDetailsStudio;
 }) {
   return (
-    <InspectorSection title={studio.ui.inspector.cards.selectedPreset}>
+    <InspectorSection title={studio.ui.inspector.cards.selectedPreset} defaultOpen>
       <InspectorDetailRows
         rows={[
           { value: selection.name },
@@ -125,32 +158,4 @@ function SelectionDetailsExportPreset({
       />
     </InspectorSection>
   );
-}
-
-export function SelectionDetails({
-  selection,
-  studio,
-}: {
-  selection: InspectorSelection;
-  studio: SelectionDetailsStudio;
-}) {
-  if (selection.kind === "none") {
-    return null;
-  }
-
-  switch (selection.kind) {
-    case "timelineClip":
-      return <SelectionDetailsTimelineClip selection={selection} studio={studio} />;
-    case "timelineMarker":
-      return <SelectionDetailsTimelineMarker selection={selection} studio={studio} />;
-    case "captureWindow":
-      return <SelectionDetailsCaptureWindow selection={selection} studio={studio} />;
-    case "exportPreset":
-      return <SelectionDetailsExportPreset selection={selection} studio={studio} />;
-    default: {
-      const _exhaustiveCheck: never = selection;
-      void _exhaustiveCheck;
-      return null;
-    }
-  }
 }

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -78,7 +78,12 @@ Creator Studio pro-UI parity backlog (next pass):
     - Audio lanes render waveform bars using decoded media when available, with input-event-derived fallback waveform generation.
     - Playback transport now uses dual clocks: a smooth display clock for playhead rendering and a frame-quantized edit clock for trim/blade/snap actions.
     - Edit-route media sync uses `requestVideoFrameCallback` (with `requestAnimationFrame` fallback) instead of coarse `timeupdate` playhead stepping.
-  - [ ] Improve inspector context switching so clip/marker/source selection immediately swaps to specific controls with minimal generic scaffolding.
+  - [x] Improve inspector context switching so clip/marker/source selection immediately swaps to specific controls with minimal generic scaffolding.
+  - Implementation notes:
+    - Inspector body rendering now routes from a single `resolveInspectorView(...).id` dispatch path, keeping header/body view mapping in sync.
+    - Timeline clip and marker selections render dedicated control blocks (timing details + direct actions) without default mode scaffolding.
+    - Capture-window and export-preset selections keep their selection-specific details while retaining core mode controls for continuity.
+    - Timeline empty-track pointer-down and `Escape` clear inspector selection and return to mode-default inspector content.
   - [ ] Add a persistent technical feedback strip (dropped frames, CPU, memory, bitrate/audio level, recording health) with OBS-style immediate visibility.
 - Phase C — Docking architecture
   - [ ] Implement true docking (tear-off/floating panels, drag/snap docking zones, saved workspace presets: `Edit`, `Color`, `Audio`, `Stream`).


### PR DESCRIPTION
## Summary
- centralize inspector content routing behind `resolveInspectorView(...).id` so header/body mapping stays in sync
- render selection-specific clip/marker controls without fallback scaffolding, while keeping mode controls for capture-window and export-preset selections
- preserve and wire timeline selection clearing (`empty track click` and `Escape`) with inspector reset behavior
- expand inspector panel tests for clip, preset+deliver continuity, and capture-window+capture continuity
- document implementation notes under the roadmap checklist item

## Testing
- bun test apps/desktop-electrobun/tests/inspector-panel.test.tsx
- bun run gate
