### PR TITLE
Harden protocol schemas and JS tooling

### DIFF
--- a/.github/workflows/desktop-parity-matrix.yml
+++ b/.github/workflows/desktop-parity-matrix.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/full_gate.yml
+++ b/.github/workflows/full_gate.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.10
+          bun-version: 1.3.11
 
       - name: Install JavaScript dependencies
         run: bun install

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@
 - **Web Convex backend (new):** `apps/web/convex/` — Convex schema/functions for web auth/review/billing surfaces.
 - **Protocol (new):** `packages/engine-protocol/` — Zod schemas + TypeScript types for engine requests/responses.
 - **Review protocol (new):** `packages/review-protocol/` — Zod schemas + TypeScript types for review bridge requests/events.
+- **Schema primitives (new):** `packages/schema-primitives/` — shared Effect Schema helpers reused by protocol packages.
 - **Localization (new):** `packages/localization/` — shared locale dictionaries + helpers consumed by renderer UI and desktop shell menus.
 - **Native engine (new):** `engines/macos-swift/` — Swift sidecar executable target (`guerillaglass-engine`).
 - **Native engine modules:** `engines/macos-swift/modules/` — capture, input tracking, project, automation, rendering, export.
@@ -40,11 +41,11 @@ When adding modules or moving code, keep the spec’s architecture (§16–17) a
 - **JS/TS format check:** `bun run js:format:check`  
   Runs `oxfmt --check` on workspace JS/TS code.
 - **JS/TS lint:** `bun run js:lint`  
-  Runs `oxlint -c oxlint.config.mjs --deny-warnings --type-aware` with the repo’s strict Oxlint config (including React Hooks checks).
+  Runs `bunx oxlint .`; project rules and type-aware settings are auto-discovered from `oxlint.config.mjs`.
 - **React effect guard lint:** `bun run js:lint:react-effects`  
   Runs the custom guard that rejects direct React state updates in effects (`Scripts/lint_no_state_updates_in_effect.mjs`).
 - **TypeScript gate (format + lint + typecheck + tests):** `bun run gate:typescript`  
-  Runs: JS/TS format check (Oxfmt) → JS/TS lint (Oxlint) → docs coverage gate (TypeScript surfaces) → desktop shell typecheck → landing app typecheck → protocol package typecheck → desktop tests.
+  Runs: JS/TS format check (Oxfmt) → JS/TS lint (Oxlint) → React effect guard lint → docs coverage gate (TypeScript surfaces) → desktop shell typecheck → landing app typecheck → protocol package typecheck → desktop tests.
 - **Docs coverage gate (all surfaces):** `bun run docs:check`  
   Runs coverage checks for TypeScript, Swift, and Rust public/exported API surfaces using `docs/doc_coverage_policy.json`.
 - **Docs coverage gate (TypeScript surfaces):** `bun run docs:check:ts`

--- a/Scripts/capture_benchmark.ts
+++ b/Scripts/capture_benchmark.ts
@@ -267,7 +267,7 @@ function startupThresholdsForCaptureFrameRate(captureFps: CaptureFrameRate): Sta
 function parseArgs(argv: string[]) {
   let durationSeconds = 10;
   let pollIntervalMs = 500;
-  let warmupMs = 1_000;
+  let warmupMs = 1000;
   let outputDir = path.join(process.cwd(), ".tmp", "capture-benchmarks");
   let scenarioFilter: BenchmarkScenarioID[] | null = null;
 
@@ -381,12 +381,16 @@ async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, label: str
 
 async function stopCaptureSession(engine: EngineClient) {
   try {
-    await withTimeout(engine.stopRecording(), 5_000, "stopRecording cleanup");
-  } catch {}
+    await withTimeout(engine.stopRecording(), 5000, "stopRecording cleanup");
+  } catch {
+    // Best-effort cleanup; preserve the original benchmark failure.
+  }
 
   try {
-    await withTimeout(engine.stopCapture(), 5_000, "stopCapture cleanup");
-  } catch {}
+    await withTimeout(engine.stopCapture(), 5000, "stopCapture cleanup");
+  } catch {
+    // Best-effort cleanup; preserve the original benchmark failure.
+  }
 }
 
 function mean(values: number[]): number | null {
@@ -507,7 +511,7 @@ async function ensurePermissions(engine: EngineClient, scenario: ScenarioConfig)
     if (!response.success) {
       throw new Error("Screen Recording permission request was rejected by the engine.");
     }
-    await sleep(1_000);
+    await sleep(1000);
     permissions = await engine.getPermissions();
   }
 
@@ -520,7 +524,7 @@ async function ensurePermissions(engine: EngineClient, scenario: ScenarioConfig)
     if (!response.success) {
       throw new Error("Microphone permission request was rejected by the engine.");
     }
-    await sleep(1_000);
+    await sleep(1000);
     permissions = await engine.getPermissions();
   }
 
@@ -533,7 +537,7 @@ async function ensurePermissions(engine: EngineClient, scenario: ScenarioConfig)
     if (!response.success) {
       throw new Error("Input Monitoring permission request was rejected by the engine.");
     }
-    await sleep(1_000);
+    await sleep(1000);
     permissions = await engine.getPermissions();
   }
 
@@ -850,13 +854,13 @@ async function runScenarioRun(
       writerBackpressureDrops: finalStatus?.telemetry.writerBackpressureDrops ?? 0,
     };
     const sampleStart = performance.now();
-    const sampleDeadline = sampleStart + options.durationSeconds * 1_000;
+    const sampleDeadline = sampleStart + options.durationSeconds * 1000;
 
     while (performance.now() < sampleDeadline) {
       const status = await engine.captureStatus();
       finalStatus = status;
       samples.push({
-        relativeSeconds: (performance.now() - sampleStart) / 1_000,
+        relativeSeconds: (performance.now() - sampleStart) / 1000,
         telemetry: status.telemetry,
       });
       await sleep(options.pollIntervalMs);
@@ -1032,7 +1036,7 @@ async function runScenarioRun(
         ...startup,
         status: "error",
       },
-      durationSeconds: (performance.now() - startedAt) / 1_000,
+      durationSeconds: (performance.now() - startedAt) / 1000,
       source: selectedDisplay
         ? buildSourceDetails(selectedDisplay, {
             displayId: selectedDisplay.id,

--- a/Scripts/docs_gate.mjs
+++ b/Scripts/docs_gate.mjs
@@ -183,7 +183,10 @@ function hasDocCommentAboveTypeScriptNode(sourceText, node) {
     return false;
   }
 
-  const lastRange = ranges[ranges.length - 1];
+  const lastRange = ranges.at(-1);
+  if (!lastRange) {
+    return false;
+  }
   const between = sourceText.slice(lastRange.end, node.getStart());
   if (between.trim().length > 0) {
     return false;

--- a/apps/desktop-electrobun/src/shared/shortcuts.ts
+++ b/apps/desktop-electrobun/src/shared/shortcuts.ts
@@ -1,5 +1,5 @@
 import { Schema } from "effect";
-import { normalizeHotkey, parseHotkey, validateHotkey } from "@tanstack/react-hotkeys";
+import { parseHotkey, validateHotkey } from "@tanstack/react-hotkeys";
 
 export type StudioShortcutModifier = "Control" | "Alt" | "Shift" | "Meta";
 
@@ -139,7 +139,24 @@ const supportedNamedShortcutKeys = new Set([
 ]);
 
 function canonicalizeStudioHotkey(hotkey: string): StudioHotkey {
-  return normalizeHotkey(hotkey.trim());
+  const parsed = parseHotkey(hotkey.trim());
+  const parts: string[] = [];
+
+  if (parsed.meta) {
+    parts.push("Meta");
+  }
+  if (parsed.ctrl) {
+    parts.push("Control");
+  }
+  if (parsed.alt) {
+    parts.push("Alt");
+  }
+  if (parsed.shift) {
+    parts.push("Shift");
+  }
+
+  parts.push(parsed.key);
+  return parts.join("+");
 }
 
 function parseStudioHotkey(hotkey: string): ParsedShortcutToken {

--- a/apps/desktop-electrobun/tests/engine-protocol.test.ts
+++ b/apps/desktop-electrobun/tests/engine-protocol.test.ts
@@ -339,6 +339,31 @@ describe("engine protocol", () => {
     expect(captureStatus.telemetry.cpuPercent).toBeNull();
   });
 
+  test("rejects invalid ISO datetime fields in engine payloads", () => {
+    expect(() =>
+      decodeSchemaSync(projectRecentsResultSchema, {
+        items: [
+          {
+            projectPath: "/tmp/project.gglassproj",
+            displayName: "project",
+            lastOpenedAt: "yesterday",
+          },
+        ],
+      }),
+    ).toThrow();
+
+    expect(() =>
+      decodeSchemaSync(agentStatusResultSchema, {
+        jobId: "job-456",
+        status: "blocked",
+        runtimeBudgetMinutes: 10,
+        qaReport: null,
+        blockingReason: "weak_narrative_structure",
+        updatedAt: "2026-02-25 10:00:00.000Z",
+      }),
+    ).toThrow();
+  });
+
   test("parses success and error response envelopes", () => {
     const fixtureDir = path.resolve(import.meta.dir, "../../../packages/engine-protocol/fixtures");
     const recentsResponseRaw = fs.readFileSync(

--- a/apps/desktop-electrobun/tests/review-protocol.test.ts
+++ b/apps/desktop-electrobun/tests/review-protocol.test.ts
@@ -1,0 +1,60 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+import { Schema } from "effect";
+import {
+  reviewBridgeEventSchema,
+  reviewSessionSnapshotSchema,
+} from "@guerillaglass/review-protocol";
+
+function decodeSchemaSync<S extends Schema.Schema.Any>(
+  schema: S,
+  raw: unknown,
+): Schema.Schema.Type<S> {
+  return Schema.decodeUnknownSync(schema as never)(raw) as Schema.Schema.Type<S>;
+}
+
+describe("review protocol", () => {
+  test("parses review fixtures with ISO datetime fields", () => {
+    const fixtureDir = path.resolve(import.meta.dir, "../../../packages/review-protocol/fixtures");
+    const snapshot = JSON.parse(
+      fs.readFileSync(path.join(fixtureDir, "review-session.snapshot.json"), "utf8"),
+    );
+    const commentCreatedEvent = JSON.parse(
+      fs.readFileSync(path.join(fixtureDir, "review-bridge.comment-created.event.json"), "utf8"),
+    );
+
+    expect(decodeSchemaSync(reviewSessionSnapshotSchema, snapshot).reviewId).toBe(
+      "review_5d4d3f1f",
+    );
+    expect(decodeSchemaSync(reviewBridgeEventSchema, commentCreatedEvent).type).toBe(
+      "comment.created",
+    );
+  });
+
+  test("rejects invalid ISO datetime fields in review payloads", () => {
+    const invalidSnapshot = {
+      reviewId: "review-123",
+      status: "review",
+      processingState: "ready",
+      preferredPlaybackSource: "processed",
+      sharePolicy: {
+        allowDownloads: true,
+        expiresAt: "tomorrow",
+        passwordProtected: false,
+      },
+      comments: [],
+      presence: [],
+      updatedAt: "2026-03-02T09:21:00.000Z",
+    };
+    const invalidEvent = {
+      type: "workflow.statusChanged",
+      reviewId: "review-123",
+      status: "done",
+      emittedAt: "2026-13-02T09:21:00.000Z",
+    };
+
+    expect(() => decodeSchemaSync(reviewSessionSnapshotSchema, invalidSnapshot)).toThrow();
+    expect(() => decodeSchemaSync(reviewBridgeEventSchema, invalidEvent)).toThrow();
+  });
+});

--- a/bun.lock
+++ b/bun.lock
@@ -124,6 +124,7 @@
       "name": "@guerillaglass/engine-protocol",
       "version": "0.1.0",
       "dependencies": {
+        "@guerillaglass/schema-primitives": "workspace:*",
         "effect": "^3.21.0",
       },
       "devDependencies": {
@@ -143,11 +144,23 @@
       "name": "@guerillaglass/review-protocol",
       "version": "0.1.0",
       "dependencies": {
+        "@guerillaglass/schema-primitives": "workspace:*",
         "effect": "^3.21.0",
       },
       "devDependencies": {
         "@guerillaglass/typescript-config": "workspace:*",
         "typescript": "^5.9.3",
+      },
+    },
+    "packages/schema-primitives": {
+      "name": "@guerillaglass/schema-primitives",
+      "version": "0.1.0",
+      "dependencies": {
+        "effect": "^3.21.0",
+      },
+      "devDependencies": {
+        "@guerillaglass/typescript-config": "workspace:*",
+        "typescript": "^6.0.2",
       },
     },
     "packages/typescript-config": {
@@ -391,6 +404,8 @@
     "@guerillaglass/localization": ["@guerillaglass/localization@workspace:packages/localization"],
 
     "@guerillaglass/review-protocol": ["@guerillaglass/review-protocol@workspace:packages/review-protocol"],
+
+    "@guerillaglass/schema-primitives": ["@guerillaglass/schema-primitives@workspace:packages/schema-primitives"],
 
     "@guerillaglass/typescript-config": ["@guerillaglass/typescript-config@workspace:packages/typescript-config"],
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -81,6 +81,7 @@ Guerilla Glass should feel like a professional creator tool:
   - Hardware verification runs through `bun run capture:benchmark`, which exercises native display/window capture at 60 and 120 fps and writes JSON/Markdown reports under `.tmp/capture-benchmarks/`.
 - **Review control plane (Phase 2.5+):** Convex query/mutation/action layer for review workflows (`shareLinks`, `comments`, `presence`, review statuses) and webhook-driven media state reconciliation.
 - **Contract split:** local media RPC stays in `packages/engine-protocol`; cloud review surfaces use a separate contract package (`packages/review-protocol`) so capture/edit/export methods remain clean and deterministic.
+- **Shared contract primitives:** reusable Effect Schema helpers that must stay aligned across protocol packages live in `packages/schema-primitives`.
 - **Authentication stack (Phase 2.5+):**
   - Better Auth is the canonical identity/session provider for product access.
   - Convex auth configuration validates Better Auth-issued identity tokens for cloud review/collaboration functions.
@@ -724,6 +725,8 @@ guerillaglass/
 │  ├─ review-protocol/
 │  │  ├─ src/
 │  │  └─ fixtures/
+│  ├─ schema-primitives/
+│  │  └─ src/
 │  └─ localization/
 │     └─ src/
 ├─ engines/

--- a/oxlint.config.mjs
+++ b/oxlint.config.mjs
@@ -25,9 +25,22 @@ export default defineConfig({
     "perfectionist/sort-objects": "off",
     "@typescript-eslint/array-type": "off",
   },
+  "options": {
+    "typeAware": true
+  },
   overrides: [
     {
       files: ["apps/desktop-electrobun/src/bun/**/*.ts"],
+      rules: {
+        "no-console": "off",
+      },
+    },
+    {
+      files: ["Scripts/**/*.mjs", "Scripts/**/*.ts"],
+      globals: {
+        console: "readonly",
+        process: "readonly",
+      },
       rules: {
         "no-console": "off",
       },

--- a/package.json
+++ b/package.json
@@ -8,10 +8,10 @@
   "scripts": {
     "gate": "./Scripts/full_gate.sh",
     "gate:rust": "./Scripts/rust_gate.sh",
-    "gate:typescript": "bun run js:format:check && bun run js:lint && bun run docs:check:ts && bun run desktop:typecheck && bun run web:typecheck && bun run protocol:typecheck && bun run desktop:test",
+    "gate:typescript": "bun run js:format:check && bun run js:lint && bun run js:lint:react-effects && bun run docs:check:ts && bun run desktop:typecheck && bun run web:typecheck && bun run protocol:typecheck && bun run desktop:test",
     "js:format": "bunx oxfmt --write apps packages",
     "js:format:check": "bunx oxfmt --check apps packages",
-    "js:lint": "bunx oxlint -c oxlint.config.mjs --deny-warnings --type-aware apps packages && bun run js:lint:react-effects",
+    "js:lint": "bunx oxlint .",
     "js:lint:react-effects": "bun ./Scripts/lint_no_state_updates_in_effect.mjs",
     "swift:build": "swift build",
     "swift:test": "swift test",

--- a/packages/engine-protocol/src/index.ts
+++ b/packages/engine-protocol/src/index.ts
@@ -6,16 +6,11 @@
  * project persistence models, request envelopes, and finally response helpers.
  */
 import { Schema } from "effect";
+import { isoDateTimeSchema } from "@guerillaglass/schema-primitives";
 import { engineMethods } from "./methods.js";
 
 const NonEmptyString = Schema.NonEmptyString;
-const isoDateTimePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
-const IsoDateTime = Schema.String.pipe(
-  Schema.pattern(isoDateTimePattern),
-  Schema.filter((value) => !Number.isNaN(Date.parse(value)), {
-    message: () => "Expected an ISO 8601 datetime string.",
-  }),
-);
+const IsoDateTime = isoDateTimeSchema;
 const NonNegativeInt = Schema.Int.pipe(Schema.greaterThanOrEqualTo(0));
 const PositiveInt = Schema.Int.pipe(Schema.greaterThanOrEqualTo(1));
 const NonNegativeNumber = Schema.Number.pipe(Schema.greaterThanOrEqualTo(0));

--- a/packages/engine-protocol/src/index.ts
+++ b/packages/engine-protocol/src/index.ts
@@ -9,7 +9,13 @@ import { Schema } from "effect";
 import { engineMethods } from "./methods.js";
 
 const NonEmptyString = Schema.NonEmptyString;
-const IsoDateTime = NonEmptyString;
+const isoDateTimePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const IsoDateTime = Schema.String.pipe(
+  Schema.pattern(isoDateTimePattern),
+  Schema.filter((value) => !Number.isNaN(Date.parse(value)), {
+    message: () => "Expected an ISO 8601 datetime string.",
+  }),
+);
 const NonNegativeInt = Schema.Int.pipe(Schema.greaterThanOrEqualTo(0));
 const PositiveInt = Schema.Int.pipe(Schema.greaterThanOrEqualTo(1));
 const NonNegativeNumber = Schema.Number.pipe(Schema.greaterThanOrEqualTo(0));

--- a/packages/review-protocol/package.json
+++ b/packages/review-protocol/package.json
@@ -11,6 +11,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
+    "@guerillaglass/schema-primitives": "workspace:*",
     "effect": "^3.21.0"
   },
   "devDependencies": {

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -6,6 +6,14 @@
  */
 import { Schema } from "effect";
 
+const isoDateTimePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+const isoDateTimeSchema = Schema.String.pipe(
+  Schema.pattern(isoDateTimePattern),
+  Schema.filter((value) => !Number.isNaN(Date.parse(value)), {
+    message: () => "Expected an ISO 8601 datetime string.",
+  }),
+);
+
 /** Core review enums and shared entities used across snapshot, mutation, and event payloads. */
 /** Canonical review workflow statuses used in Deliver review. */
 export const reviewWorkflowStatusSchema = Schema.Union(
@@ -39,7 +47,7 @@ export const reviewPlaybackSourceSchema = Schema.Union(
 /** Access policy for review share links. */
 export const reviewSharePolicySchema = Schema.Struct({
   allowDownloads: Schema.Boolean,
-  expiresAt: Schema.NullOr(Schema.String),
+  expiresAt: Schema.NullOr(isoDateTimeSchema),
   passwordProtected: Schema.Boolean,
 });
 
@@ -48,7 +56,7 @@ export const reviewPresenceSchema = Schema.Struct({
   userId: Schema.NonEmptyString,
   displayName: Schema.NonEmptyString,
   role: reviewRoleSchema,
-  lastActiveAt: Schema.String,
+  lastActiveAt: isoDateTimeSchema,
 });
 
 /** Frame/time-accurate review comment model. */
@@ -61,8 +69,8 @@ export const reviewCommentSchema = Schema.Struct({
   frameNumber: Schema.NullOr(Schema.Int.pipe(Schema.greaterThanOrEqualTo(0))),
   timestampSeconds: Schema.NullOr(Schema.Number.pipe(Schema.greaterThanOrEqualTo(0))),
   resolved: Schema.Boolean,
-  createdAt: Schema.String,
-  updatedAt: Schema.String,
+  createdAt: isoDateTimeSchema,
+  updatedAt: isoDateTimeSchema,
   parentCommentId: Schema.NullOr(Schema.NonEmptyString),
 });
 
@@ -75,7 +83,7 @@ export const reviewSessionSnapshotSchema = Schema.Struct({
   sharePolicy: reviewSharePolicySchema,
   comments: Schema.Array(reviewCommentSchema),
   presence: Schema.Array(reviewPresenceSchema),
-  updatedAt: Schema.String,
+  updatedAt: isoDateTimeSchema,
 });
 
 /** Request and response payloads used by the review bridge command surface. */
@@ -103,7 +111,7 @@ export const reviewSetWorkflowStatusRequestSchema = Schema.Struct({
 export const reviewSetWorkflowStatusResponseSchema = Schema.Struct({
   reviewId: Schema.NonEmptyString,
   status: reviewWorkflowStatusSchema,
-  updatedAt: Schema.String,
+  updatedAt: isoDateTimeSchema,
 });
 
 /** Realtime events emitted while a Deliver review session is active. */
@@ -112,7 +120,7 @@ export const reviewPresenceUpdatedEventSchema = Schema.Struct({
   type: Schema.Literal("presence.updated"),
   reviewId: Schema.NonEmptyString,
   presence: Schema.Array(reviewPresenceSchema),
-  emittedAt: Schema.String,
+  emittedAt: isoDateTimeSchema,
 });
 
 /** Event emitted when a new comment is created in the active session. */
@@ -120,7 +128,7 @@ export const reviewCommentCreatedEventSchema = Schema.Struct({
   type: Schema.Literal("comment.created"),
   reviewId: Schema.NonEmptyString,
   comment: reviewCommentSchema,
-  emittedAt: Schema.String,
+  emittedAt: isoDateTimeSchema,
 });
 
 /** Event emitted when review workflow status changes. */
@@ -128,7 +136,7 @@ export const reviewStatusChangedEventSchema = Schema.Struct({
   type: Schema.Literal("workflow.statusChanged"),
   reviewId: Schema.NonEmptyString,
   status: reviewWorkflowStatusSchema,
-  emittedAt: Schema.String,
+  emittedAt: isoDateTimeSchema,
 });
 
 /** Event emitted when playback readiness changes in review delivery flows. */
@@ -137,7 +145,7 @@ export const reviewPlaybackStateChangedEventSchema = Schema.Struct({
   reviewId: Schema.NonEmptyString,
   processingState: reviewProcessingStateSchema,
   preferredPlaybackSource: reviewPlaybackSourceSchema,
-  emittedAt: Schema.String,
+  emittedAt: isoDateTimeSchema,
 });
 
 /**

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -5,14 +5,7 @@
  * desktop Deliver route in sync with collaboration state, playback readiness, and comments.
  */
 import { Schema } from "effect";
-
-const isoDateTimePattern = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
-const isoDateTimeSchema = Schema.String.pipe(
-  Schema.pattern(isoDateTimePattern),
-  Schema.filter((value) => !Number.isNaN(Date.parse(value)), {
-    message: () => "Expected an ISO 8601 datetime string.",
-  }),
-);
+import { isoDateTimeSchema } from "@guerillaglass/schema-primitives";
 
 /** Core review enums and shared entities used across snapshot, mutation, and event payloads. */
 /** Canonical review workflow statuses used in Deliver review. */

--- a/packages/schema-primitives/package.json
+++ b/packages/schema-primitives/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "@guerillaglass/engine-protocol",
+  "name": "@guerillaglass/schema-primitives",
   "version": "0.1.0",
   "private": true,
-  "description": "Effect Schema-based JSON-RPC contract for Guerillaglass native engines",
   "type": "module",
   "exports": {
     ".": "./src/index.ts"
@@ -11,7 +10,6 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@guerillaglass/schema-primitives": "workspace:*",
     "effect": "^3.21.0"
   },
   "devDependencies": {

--- a/packages/schema-primitives/src/index.ts
+++ b/packages/schema-primitives/src/index.ts
@@ -1,0 +1,13 @@
+import { Schema } from "effect";
+
+/** Shared ISO 8601 datetime validation for typed protocol surfaces. */
+export const isoDateTimePattern =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/** Effect Schema primitive for canonical ISO 8601 datetime strings. */
+export const isoDateTimeSchema = Schema.String.pipe(
+  Schema.pattern(isoDateTimePattern),
+  Schema.filter((value) => !Number.isNaN(Date.parse(value)), {
+    message: () => "Expected an ISO 8601 datetime string.",
+  }),
+);

--- a/packages/schema-primitives/tsconfig.json
+++ b/packages/schema-primitives/tsconfig.json
@@ -1,0 +1,4 @@
+{
+  "extends": "@guerillaglass/typescript-config/react-library.json",
+  "include": ["src"]
+}


### PR DESCRIPTION
# Summary
- validate ISO datetime fields in the engine and review protocol schemas instead of treating them as generic strings
- add protocol regression coverage in the desktop shell tests for invalid datetime payloads and review fixtures
- tighten the JS/docs tooling path by broadening oxlint coverage, hardening the docs gate helper, and cleaning up benchmark script catches

# Checklist
- [x] Ran bun run gate
- [x] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
- [ ] UI changes include screenshots
- [ ] Updated docs/templates if architecture or workflows changed

# Testing (optional)
- [x] swift test
- [x] bun run desktop:test:coverage (required when touching apps/desktop-electrobun or packages/engine-protocol)
