### PR TITLE
chore(ui): share desktop panel primitives and polish scrollbars

### DIFF
--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/InspectorPanel.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/InspectorPanel.tsx
@@ -23,7 +23,7 @@ import {
   StudioPaneHeader,
   StudioPaneSubtitle,
   StudioPaneTitle,
-} from "../layout/StudioPanePrimitives";
+} from "@guerillaglass/ui/desktop/studio-pane";
 
 type InspectorPanelProps = {
   mode: StudioMode;

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/ProjectUtilityPanel.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/ProjectUtilityPanel.tsx
@@ -1,19 +1,14 @@
-import { ChevronRight, FolderClock, FolderOpen, Save } from "lucide-react";
-import { type ReactNode } from "react";
+import { FolderClock, FolderOpen, Save } from "lucide-react";
 import { Button } from "@guerillaglass/ui/components/button";
 import { ButtonGroup } from "@guerillaglass/ui/components/button-group";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@guerillaglass/ui/components/collapsible";
+import { DesktopPanelCard, DesktopPanelDetailRows } from "@guerillaglass/ui/desktop/panel-detail";
+import { DesktopPanelSection } from "@guerillaglass/ui/desktop/panel-section";
 import {
   Empty,
   EmptyDescription,
   EmptyHeader,
   EmptyTitle,
 } from "@guerillaglass/ui/components/empty";
-import { cn } from "@lib/utils";
 import { useStudio } from "../state/StudioProvider";
 
 function projectNameFromPath(projectPath: string | null): string {
@@ -55,27 +50,50 @@ export function ProjectUtilityPanel() {
       </div>
 
       <div className="gg-pane-body gg-copy-compact gg-inspector-pane-body">
-        <ProjectPanelSection title={studio.ui.labels.activeProject}>
-          <div className="gg-inspector-detail-list gg-numeric">
-            <div className="gg-inspector-detail-row">{`${studio.ui.labels.projectName}: ${projectNameFromPath(project?.projectPath ?? null)}`}</div>
-            <div className="gg-inspector-detail-row truncate">{`${studio.ui.labels.projectPath}: ${project?.projectPath ?? studio.ui.labels.notSaved}`}</div>
-            <div className="gg-inspector-detail-row truncate">{`${studio.ui.labels.recordingURL}: ${studio.recordingURL ?? "-"}`}</div>
-            <div className="gg-inspector-detail-row truncate">{`${studio.ui.labels.eventsURL}: ${project?.eventsURL ?? studio.captureStatusQuery.data?.eventsURL ?? "-"}`}</div>
-            <div className="gg-inspector-detail-row">{`${studio.ui.labels.duration}: ${studio.formatDuration(studio.captureStatusQuery.data?.recordingDurationSeconds ?? 0)}`}</div>
-            <div className="gg-inspector-detail-row">{`${studio.ui.labels.captureSourceMetadata}: ${captureMetadata?.source ?? "-"}`}</div>
-            <div className="gg-inspector-detail-row">
-              {`${studio.ui.labels.captureResolution}: ${
-                captureMetadata
+        <DesktopPanelSection title={studio.ui.labels.activeProject}>
+          <DesktopPanelDetailRows
+            rows={[
+              {
+                label: studio.ui.labels.projectName,
+                value: projectNameFromPath(project?.projectPath ?? null),
+              },
+              {
+                label: studio.ui.labels.projectPath,
+                value: project?.projectPath ?? studio.ui.labels.notSaved,
+                valueClassName: "truncate",
+              },
+              {
+                label: studio.ui.labels.recordingURL,
+                value: studio.recordingURL ?? "-",
+                valueClassName: "truncate",
+              },
+              {
+                label: studio.ui.labels.eventsURL,
+                value: project?.eventsURL ?? studio.captureStatusQuery.data?.eventsURL ?? "-",
+                valueClassName: "truncate",
+              },
+              {
+                label: studio.ui.labels.duration,
+                value: studio.formatDuration(
+                  studio.captureStatusQuery.data?.recordingDurationSeconds ?? 0,
+                ),
+              },
+              {
+                label: studio.ui.labels.captureSourceMetadata,
+                value: captureMetadata?.source ?? "-",
+              },
+              {
+                label: studio.ui.labels.captureResolution,
+                value: captureMetadata
                   ? `${studio.formatInteger(captureMetadata.contentRect.width)}x${studio.formatInteger(captureMetadata.contentRect.height)}`
-                  : "-"
-              }`}
-            </div>
-            <div className="gg-inspector-detail-row">
-              {`${studio.ui.labels.captureScale}: ${
-                captureMetadata ? studio.formatDecimal(captureMetadata.pixelScale) : "-"
-              }`}
-            </div>
-          </div>
+                  : "-",
+              },
+              {
+                label: studio.ui.labels.captureScale,
+                value: captureMetadata ? studio.formatDecimal(captureMetadata.pixelScale) : "-",
+              },
+            ]}
+          />
 
           <ButtonGroup className="flex-wrap gap-1.5 pt-1">
             <Button
@@ -103,26 +121,23 @@ export function ProjectUtilityPanel() {
               <Save className="mr-2 h-4 w-4" /> {studio.ui.actions.saveProjectAs}
             </Button>
           </ButtonGroup>
-        </ProjectPanelSection>
+        </DesktopPanelSection>
 
-        <ProjectPanelSection title={studio.ui.labels.mediaBin}>
+        <DesktopPanelSection title={studio.ui.labels.mediaBin}>
           <div className="space-y-1.5">
             {mediaBinItems.map((item) => (
-              <div
-                key={item.id}
-                className="space-y-0.5 rounded-sm border border-border/65 bg-background/25 px-2 py-1.5"
-              >
+              <DesktopPanelCard key={item.id} className="space-y-0.5 px-2 py-1.5">
                 <div className="gg-copy-strong">{item.label}</div>
                 <div className="gg-copy-meta truncate">{item.value}</div>
                 <div className="gg-copy-meta">
                   {item.available ? studio.ui.labels.mediaReady : studio.ui.labels.mediaMissing}
                 </div>
-              </div>
+              </DesktopPanelCard>
             ))}
           </div>
-        </ProjectPanelSection>
+        </DesktopPanelSection>
 
-        <ProjectPanelSection
+        <DesktopPanelSection
           title={
             <span className="inline-flex items-center gap-1">
               <FolderClock className="h-3.5 w-3.5" /> {studio.ui.labels.recentProjects}
@@ -149,10 +164,7 @@ export function ProjectUtilityPanel() {
 
           <div className="space-y-1.5">
             {recentProjects.map((item) => (
-              <div
-                key={item.projectPath}
-                className="space-y-0.5 rounded-sm border border-border/65 bg-background/25 px-2 py-1.5"
-              >
+              <DesktopPanelCard key={item.projectPath} className="space-y-0.5 px-2 py-1.5">
                 <div className="gg-copy-strong truncate">{item.displayName}</div>
                 <div className="gg-copy-meta truncate">{item.projectPath}</div>
                 <div className="gg-copy-meta">{`${studio.ui.labels.lastOpened}: ${studio.formatDateTime(item.lastOpenedAt)}`}</div>
@@ -167,33 +179,11 @@ export function ProjectUtilityPanel() {
                 >
                   <FolderOpen className="mr-2 h-4 w-4" /> {studio.ui.actions.openRecent}
                 </Button>
-              </div>
+              </DesktopPanelCard>
             ))}
           </div>
-        </ProjectPanelSection>
+        </DesktopPanelSection>
       </div>
     </>
-  );
-}
-
-function ProjectPanelSection({
-  title,
-  children,
-  className,
-}: {
-  title: ReactNode;
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <Collapsible defaultOpen={false} className={cn("gg-inspector-section", className)}>
-      <CollapsibleTrigger className="gg-inspector-section-trigger">
-        <ChevronRight className="gg-inspector-section-chevron" />
-        <h3 className="gg-inspector-section-header border-0 pb-0">{title}</h3>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="gg-inspector-section-content">
-        <div className="gg-inspector-section-body">{children}</div>
-      </CollapsibleContent>
-    </Collapsible>
   );
 }

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineDock.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineDock.tsx
@@ -24,7 +24,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@guerillaglass/ui/components/tooltip";
-import { cn } from "@lib/utils";
+import { cn } from "@guerillaglass/ui";
 import { useStudioRenderDiagnostics } from "@lib/studioDiagnostics";
 import { normalizeShortcutDisplayPlatform, studioShortcutDisplayTokens } from "@shared/shortcuts";
 import { useStudio, useStudioPlaybackValue } from "../state/StudioProvider";

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorPrimitives.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorPrimitives.tsx
@@ -1,4 +1,4 @@
-import { ChevronRight, Volume2, VolumeX } from "lucide-react";
+import { Volume2, VolumeX } from "lucide-react";
 import type { ReactNode } from "react";
 import {
   captureFrameRates,
@@ -6,11 +6,14 @@ import {
 } from "@guerillaglass/engine-contract/domains/sources";
 import { Button } from "@guerillaglass/ui/components/button";
 import { Checkbox } from "@guerillaglass/ui/components/checkbox";
+import { DesktopPanelSection } from "@guerillaglass/ui/desktop/panel-section";
 import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@guerillaglass/ui/components/collapsible";
+  DesktopPanelCard,
+  DesktopPanelCardHeader,
+  DesktopPanelDetailList,
+  DesktopPanelDetailRow,
+  DesktopPanelDetailRows,
+} from "@guerillaglass/ui/desktop/panel-detail";
 import {
   Field,
   FieldContent,
@@ -27,117 +30,13 @@ import {
   SelectValue,
 } from "@guerillaglass/ui/components/select";
 import { Slider } from "@guerillaglass/ui/components/slider";
-import { cn } from "@lib/utils";
 
-export function InspectorSection({
-  title,
-  children,
-  className,
-  defaultOpen = false,
-}: {
-  title: string;
-  children: ReactNode;
-  className?: string;
-  defaultOpen?: boolean;
-}) {
-  return (
-    <Collapsible defaultOpen={defaultOpen} className={cn("gg-inspector-section", className)}>
-      <CollapsibleTrigger className="gg-inspector-section-trigger">
-        <ChevronRight className="gg-inspector-section-chevron" />
-        <h3 className="gg-inspector-section-header border-0 pb-0">{title}</h3>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="gg-inspector-section-content">
-        <div className="gg-inspector-section-body">{children}</div>
-      </CollapsibleContent>
-    </Collapsible>
-  );
-}
-
-export function InspectorOptionCard({
-  children,
-  className,
-}: {
-  children: ReactNode;
-  className?: string;
-}) {
-  return <div className={cn("gg-inspector-option-card", className)}>{children}</div>;
-}
-
-export function InspectorOptionHeader({
-  icon,
-  title,
-  description,
-  trailing,
-}: {
-  icon?: ReactNode;
-  title: string;
-  description?: string;
-  trailing?: ReactNode;
-}) {
-  return (
-    <div className="flex items-start justify-between gap-3">
-      <div className="min-w-0 space-y-1">
-        <div className="flex items-center gap-2">
-          {icon ? <span className="text-muted-foreground">{icon}</span> : null}
-          <span className="gg-copy-strong">{title}</span>
-        </div>
-        {description ? <p className="gg-copy-meta">{description}</p> : null}
-      </div>
-      {trailing ? <div className="shrink-0">{trailing}</div> : null}
-    </div>
-  );
-}
-
-export function InspectorDetailList({ children }: { children: ReactNode }) {
-  return (
-    <InspectorOptionCard>
-      <div className="gg-inspector-detail-list gg-numeric">{children}</div>
-    </InspectorOptionCard>
-  );
-}
-
-export function InspectorDetailRow({
-  label,
-  value,
-  className,
-  valueClassName,
-}: {
-  label?: string;
-  value: string;
-  className?: string;
-  valueClassName?: string;
-}) {
-  return (
-    <div className={cn("gg-inspector-detail-row", className)}>
-      {label ? <span className="gg-copy-meta">{label}</span> : null}
-      <span
-        className={cn(label ? "gg-copy-strong text-right" : "text-foreground/90", valueClassName)}
-      >
-        {value}
-      </span>
-    </div>
-  );
-}
-
-export function InspectorDetailRows({
-  rows,
-}: {
-  rows: Array<{ label?: string; value: string; className?: string; valueClassName?: string }>;
-}) {
-  return (
-    <InspectorDetailList>
-      {rows.map((row) => (
-        <InspectorDetailRow
-          key={`${row.className ?? ""}:${row.label ?? ""}:${row.value}`}
-          label={row.label}
-          value={row.value}
-          className={row.className}
-          valueClassName={row.valueClassName}
-        />
-      ))}
-    </InspectorDetailList>
-  );
-}
+export const InspectorSection = DesktopPanelSection;
+export const InspectorOptionCard = DesktopPanelCard;
+export const InspectorOptionHeader = DesktopPanelCardHeader;
+export const InspectorDetailList = DesktopPanelDetailList;
+export const InspectorDetailRow = DesktopPanelDetailRow;
+export const InspectorDetailRows = DesktopPanelDetailRows;
 
 export function InspectorToggleField({
   icon,

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/ShortcutOverridesSection.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/ShortcutOverridesSection.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { Badge } from "@guerillaglass/ui/components/badge";
 import { Button } from "@guerillaglass/ui/components/button";
 import { Kbd, KbdGroup } from "@guerillaglass/ui/components/kbd";
-import { cn } from "@lib/utils";
+import { cn } from "@guerillaglass/ui";
 import {
   resolveStudioShortcutHotkey,
   studioHotkeyDisplayTokens,

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
@@ -1,12 +1,8 @@
-import { ChevronRight, ScreenShare, ShieldCheck } from "lucide-react";
-import { type ReactNode } from "react";
+import { ScreenShare, ShieldCheck } from "lucide-react";
 import { AspectRatio } from "@guerillaglass/ui/components/aspect-ratio";
 import { Button } from "@guerillaglass/ui/components/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@guerillaglass/ui/components/collapsible";
+import { DesktopPanelDetailRows } from "@guerillaglass/ui/desktop/panel-detail";
+import { DesktopPanelSection } from "@guerillaglass/ui/desktop/panel-section";
 import {
   Empty,
   EmptyDescription,
@@ -18,7 +14,7 @@ import { Label } from "@guerillaglass/ui/components/label";
 import { NativeSelect, NativeSelectOption } from "@guerillaglass/ui/components/native-select";
 import { RadioGroup, RadioGroupItem } from "@guerillaglass/ui/components/radio-group";
 import { engineApi } from "@lib/engine";
-import { cn } from "@lib/utils";
+import { cn } from "@guerillaglass/ui";
 import { useStudio } from "../state/StudioProvider";
 import { EditorWorkspace } from "../layout/EditorWorkspace";
 import { InspectorPanel } from "../panels/InspectorPanel";
@@ -33,7 +29,7 @@ import {
   StudioPaneHeader,
   StudioPaneSubtitle,
   StudioPaneTitle,
-} from "../layout/StudioPanePrimitives";
+} from "@guerillaglass/ui/desktop/studio-pane";
 
 function displayOptionLabel(
   displayItem: ReturnType<typeof useStudio>["displayChoices"][number],
@@ -70,12 +66,28 @@ export function CaptureRoute() {
             <StudioPaneSubtitle>{studio.ui.labels.inputMonitoring}</StudioPaneSubtitle>
           </StudioPaneHeader>
           <StudioPaneBody className="gg-copy-compact gg-inspector-pane-body">
-            <CaptureLeftSection title={studio.ui.labels.inputMonitoring}>
-              <div className="gg-inspector-detail-list">
-                <div className="gg-inspector-detail-row">{`${studio.ui.labels.screen}: ${studio.permissionsQuery.data?.screenRecordingGranted ? studio.ui.values.granted : studio.ui.values.notGranted}`}</div>
-                <div className="gg-inspector-detail-row">{`${studio.ui.labels.microphone}: ${studio.permissionsQuery.data?.microphoneGranted ? studio.ui.values.granted : studio.ui.values.notGranted}`}</div>
-                <div className="gg-inspector-detail-row">{`${studio.ui.labels.inputMonitoring}: ${studio.permissionsQuery.data?.inputMonitoring ?? studio.ui.values.unknown}`}</div>
-              </div>
+            <DesktopPanelSection title={studio.ui.labels.inputMonitoring}>
+              <DesktopPanelDetailRows
+                rows={[
+                  {
+                    label: studio.ui.labels.screen,
+                    value: studio.permissionsQuery.data?.screenRecordingGranted
+                      ? studio.ui.values.granted
+                      : studio.ui.values.notGranted,
+                  },
+                  {
+                    label: studio.ui.labels.microphone,
+                    value: studio.permissionsQuery.data?.microphoneGranted
+                      ? studio.ui.values.granted
+                      : studio.ui.values.notGranted,
+                  },
+                  {
+                    label: studio.ui.labels.inputMonitoring,
+                    value:
+                      studio.permissionsQuery.data?.inputMonitoring ?? studio.ui.values.unknown,
+                  },
+                ]}
+              />
 
               <div className="gg-left-rail-actions pt-1">
                 <Button
@@ -111,9 +123,9 @@ export function CaptureRoute() {
                   {studio.ui.actions.openSettings}
                 </Button>
               </div>
-            </CaptureLeftSection>
+            </DesktopPanelSection>
 
-            <CaptureLeftSection title={studio.ui.labels.captureSource}>
+            <DesktopPanelSection title={studio.ui.labels.captureSource}>
               <studio.settingsForm.Field name="captureSource">
                 {(field) => (
                   <Field>
@@ -232,7 +244,7 @@ export function CaptureRoute() {
                   )}
                 </studio.settingsForm.Field>
               ) : null}
-            </CaptureLeftSection>
+            </DesktopPanelSection>
           </StudioPaneBody>
         </StudioPane>
       }
@@ -309,27 +321,5 @@ export function CaptureRoute() {
       rightPane={<InspectorPanel mode="capture" />}
       bottomPane={null}
     />
-  );
-}
-
-function CaptureLeftSection({
-  title,
-  children,
-  className,
-}: {
-  title: ReactNode;
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <Collapsible defaultOpen={false} className={cn("gg-inspector-section", className)}>
-      <CollapsibleTrigger className="gg-inspector-section-trigger">
-        <ChevronRight className="gg-inspector-section-chevron" />
-        <h3 className="gg-inspector-section-header border-0 pb-0">{title}</h3>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="gg-inspector-section-content">
-        <div className="gg-inspector-section-body">{children}</div>
-      </CollapsibleContent>
-    </Collapsible>
   );
 }

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/DeliverRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/DeliverRoute.tsx
@@ -1,15 +1,10 @@
-import { ChevronRight, HardDriveDownload } from "lucide-react";
-import { type ReactNode } from "react";
+import { HardDriveDownload } from "lucide-react";
 import { Button } from "@guerillaglass/ui/components/button";
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@guerillaglass/ui/components/collapsible";
+import { DesktopPanelDetailRows } from "@guerillaglass/ui/desktop/panel-detail";
+import { DesktopPanelSection } from "@guerillaglass/ui/desktop/panel-section";
 import { Field, FieldContent, FieldLabel } from "@guerillaglass/ui/components/field";
 import { Input } from "@guerillaglass/ui/components/input";
 import { NativeSelect, NativeSelectOption } from "@guerillaglass/ui/components/native-select";
-import { cn } from "@lib/utils";
 import { useStudio } from "../state/StudioProvider";
 import { EditorWorkspace } from "../layout/EditorWorkspace";
 import { InspectorPanel } from "../panels/InspectorPanel";
@@ -20,7 +15,7 @@ import {
   StudioPaneHeader,
   StudioPaneSubtitle,
   StudioPaneTitle,
-} from "../layout/StudioPanePrimitives";
+} from "@guerillaglass/ui/desktop/studio-pane";
 
 export function DeliverRoute() {
   const studio = useStudio();
@@ -35,21 +30,40 @@ export function DeliverRoute() {
             <StudioPaneSubtitle>{studio.ui.workspace.deliverSummarySubtitle}</StudioPaneSubtitle>
           </StudioPaneHeader>
           <StudioPaneBody className="gg-copy-compact gg-inspector-pane-body">
-            <DeliverLeftSection title={studio.ui.inspectorTabs.project}>
-              <div className="gg-inspector-detail-list gg-numeric">
-                <div className="gg-inspector-detail-row truncate">{`${studio.ui.labels.projectPath}: ${studio.projectQuery.data?.projectPath ?? studio.ui.labels.notSaved}`}</div>
-                <div className="gg-inspector-detail-row truncate">{`${studio.ui.labels.recordingURL}: ${studio.recordingURL ?? "-"}`}</div>
-                <div className="gg-inspector-detail-row">{`${studio.ui.labels.duration}: ${studio.formatDuration(studio.captureStatusQuery.data?.recordingDurationSeconds ?? 0)}`}</div>
-              </div>
-            </DeliverLeftSection>
+            <DesktopPanelSection title={studio.ui.inspectorTabs.project}>
+              <DesktopPanelDetailRows
+                rows={[
+                  {
+                    label: studio.ui.labels.projectPath,
+                    value: studio.projectQuery.data?.projectPath ?? studio.ui.labels.notSaved,
+                    valueClassName: "truncate",
+                  },
+                  { label: studio.ui.labels.recordingURL, value: studio.recordingURL ?? "-" },
+                  {
+                    label: studio.ui.labels.duration,
+                    value: studio.formatDuration(
+                      studio.captureStatusQuery.data?.recordingDurationSeconds ?? 0,
+                    ),
+                  },
+                ]}
+              />
+            </DesktopPanelSection>
 
-            <DeliverLeftSection title={studio.ui.inspectorTabs.export}>
-              <div className="gg-inspector-detail-list gg-numeric">
-                <div className="gg-inspector-detail-row">{`${studio.ui.labels.trimInSeconds}: ${studio.formatDecimal(studio.exportForm.state.values.trimStartSeconds)}`}</div>
-                <div className="gg-inspector-detail-row">{`${studio.ui.labels.trimOutSeconds}: ${studio.formatDecimal(studio.exportForm.state.values.trimEndSeconds)}`}</div>
-                <div className="gg-inspector-detail-row">{`${studio.ui.labels.preset}: ${studio.selectedPreset?.name ?? "-"}`}</div>
-              </div>
-            </DeliverLeftSection>
+            <DesktopPanelSection title={studio.ui.inspectorTabs.export}>
+              <DesktopPanelDetailRows
+                rows={[
+                  {
+                    label: studio.ui.labels.trimInSeconds,
+                    value: studio.formatDecimal(studio.exportForm.state.values.trimStartSeconds),
+                  },
+                  {
+                    label: studio.ui.labels.trimOutSeconds,
+                    value: studio.formatDecimal(studio.exportForm.state.values.trimEndSeconds),
+                  },
+                  { label: studio.ui.labels.preset, value: studio.selectedPreset?.name ?? "-" },
+                ]}
+              />
+            </DesktopPanelSection>
           </StudioPaneBody>
         </StudioPane>
       }
@@ -163,27 +177,5 @@ export function DeliverRoute() {
       rightPane={<InspectorPanel mode="deliver" />}
       bottomPane={<TimelineDock />}
     />
-  );
-}
-
-function DeliverLeftSection({
-  title,
-  children,
-  className,
-}: {
-  title: ReactNode;
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <Collapsible defaultOpen={false} className={cn("gg-inspector-section", className)}>
-      <CollapsibleTrigger className="gg-inspector-section-trigger">
-        <ChevronRight className="gg-inspector-section-chevron" />
-        <h3 className="gg-inspector-section-header border-0 pb-0">{title}</h3>
-      </CollapsibleTrigger>
-      <CollapsibleContent className="gg-inspector-section-content">
-        <div className="gg-inspector-section-body">{children}</div>
-      </CollapsibleContent>
-    </Collapsible>
   );
 }

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/EditRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/EditRoute.tsx
@@ -23,7 +23,7 @@ import {
   StudioPaneHeader,
   StudioPaneSubtitle,
   StudioPaneTitle,
-} from "../layout/StudioPanePrimitives";
+} from "@guerillaglass/ui/desktop/studio-pane";
 
 export function EditRoute() {
   const studio = useStudio();

--- a/apps/desktop-electrobun/src/mainview/index.css
+++ b/apps/desktop-electrobun/src/mainview/index.css
@@ -251,6 +251,40 @@
 
   .gg-pane-body {
     @apply flex-1 min-h-0 min-w-0 overflow-y-auto p-3;
+    scrollbar-gutter: stable;
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--muted-foreground) 48%, transparent) transparent;
+  }
+
+  .gg-pane-body::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+    -webkit-appearance: none;
+    background: transparent !important;
+    background-color: transparent !important;
+  }
+
+  .gg-pane-body::-webkit-scrollbar-track,
+  .gg-pane-body::-webkit-scrollbar-track-piece {
+    background: transparent !important;
+  }
+
+  .gg-pane-body::-webkit-scrollbar-thumb {
+    min-height: 32px;
+    border: 3px solid transparent;
+    border-radius: 9999px;
+    background-clip: content-box;
+    background-color: color-mix(in oklab, var(--muted-foreground) 36%, transparent);
+  }
+
+  .gg-pane-body::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklab, var(--muted-foreground) 56%, transparent);
+  }
+
+  .gg-pane-body::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
   }
 
   .gg-left-rail-actions {

--- a/apps/desktop-electrobun/src/mainview/lib/utils.ts
+++ b/apps/desktop-electrobun/src/mainview/lib/utils.ts
@@ -1,6 +1,0 @@
-import { type ClassValue, clsx } from "clsx";
-import { twMerge } from "tailwind-merge";
-
-export function cn(...inputs: ClassValue[]): string {
-  return twMerge(clsx(inputs));
-}

--- a/apps/desktop-electrobun/tests/parity-e2e.test.ts
+++ b/apps/desktop-electrobun/tests/parity-e2e.test.ts
@@ -70,14 +70,12 @@ async function buildNativeEngine(manifestPath: string): Promise<void> {
 
 describe("engine HTTP parity e2e", () => {
   beforeAll(async () => {
-    await Promise.all([
-      buildNativeEngine(
-        path.resolve(import.meta.dirname, "../../../engines/windows-native/Cargo.toml"),
-      ),
-      buildNativeEngine(
-        path.resolve(import.meta.dirname, "../../../engines/linux-native/Cargo.toml"),
-      ),
-    ]);
+    await buildNativeEngine(
+      path.resolve(import.meta.dirname, "../../../engines/windows-native/Cargo.toml"),
+    );
+    await buildNativeEngine(
+      path.resolve(import.meta.dirname, "../../../engines/linux-native/Cargo.toml"),
+    );
   }, nativeEngineBuildTimeoutMs);
   for (const fixture of fixtures) {
     test(

--- a/apps/desktop-electrobun/tests/parity-e2e.test.ts
+++ b/apps/desktop-electrobun/tests/parity-e2e.test.ts
@@ -17,7 +17,7 @@ type EngineFixture = {
   expectedPlatform: "windows" | "linux";
 };
 
-const nativeEngineBuildTimeoutMs = 300_000;
+const nativeEngineBuildTimeoutMs = 600_000;
 const executableExtension = process.platform === "win32" ? ".exe" : "";
 
 const fixtures: EngineFixture[] = [

--- a/engines/native-foundation/Cargo.toml
+++ b/engines/native-foundation/Cargo.toml
@@ -11,7 +11,8 @@ path = "src/lib.rs"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 protocol-rust = { path = "../protocol-rust" }
-time = { version = "0.3", features = ["formatting"] }
+# Pin below 0.3.48 until cookie 0.18.x is compatible with newer time internals.
+time = { version = "=0.3.47", features = ["formatting"] }
 libc = "0.2"
 async-trait = "0.1"
 axum = "0.8"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "type": "module",
   "exports": {
+    ".": "./src/index.ts",
     "./styles.css": {
       "style": "./src/styles/globals.css",
       "default": "./src/styles/globals.css"

--- a/packages/ui/src/desktop/panel-detail.tsx
+++ b/packages/ui/src/desktop/panel-detail.tsx
@@ -1,0 +1,96 @@
+import type { ReactNode } from "react";
+
+import { Card } from "../components/card";
+import { cn } from "../lib/utils";
+
+function DesktopPanelCard({ children, className }: { children: ReactNode; className?: string }) {
+  return (
+    <Card size="sm" className={cn("gg-inspector-option-card py-3 shadow-none", className)}>
+      {children}
+    </Card>
+  );
+}
+
+function DesktopPanelCardHeader({
+  icon,
+  title,
+  description,
+  trailing,
+}: {
+  icon?: ReactNode;
+  title: string;
+  description?: string;
+  trailing?: ReactNode;
+}) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <div className="min-w-0 space-y-1">
+        <div className="flex items-center gap-2">
+          {icon ? <span className="text-muted-foreground">{icon}</span> : null}
+          <span className="gg-copy-strong">{title}</span>
+        </div>
+        {description ? <p className="gg-copy-meta">{description}</p> : null}
+      </div>
+      {trailing ? <div className="shrink-0">{trailing}</div> : null}
+    </div>
+  );
+}
+
+function DesktopPanelDetailList({ children }: { children: ReactNode }) {
+  return (
+    <DesktopPanelCard>
+      <div className="gg-inspector-detail-list gg-numeric">{children}</div>
+    </DesktopPanelCard>
+  );
+}
+
+function DesktopPanelDetailRow({
+  label,
+  value,
+  className,
+  valueClassName,
+}: {
+  label?: string;
+  value: string;
+  className?: string;
+  valueClassName?: string;
+}) {
+  return (
+    <div className={cn("gg-inspector-detail-row", className)}>
+      {label ? <span className="gg-copy-meta">{label}</span> : null}
+      <span
+        className={cn(label ? "gg-copy-strong text-right" : "text-foreground/90", valueClassName)}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function DesktopPanelDetailRows({
+  rows,
+}: {
+  rows: Array<{ label?: string; value: string; className?: string; valueClassName?: string }>;
+}) {
+  return (
+    <DesktopPanelDetailList>
+      {rows.map((row) => (
+        <DesktopPanelDetailRow
+          key={`${row.className ?? ""}:${row.label ?? ""}:${row.value}`}
+          label={row.label}
+          value={row.value}
+          className={row.className}
+          valueClassName={row.valueClassName}
+        />
+      ))}
+    </DesktopPanelDetailList>
+  );
+}
+
+export {
+  DesktopPanelCard,
+  DesktopPanelCardHeader,
+  DesktopPanelDetailList,
+  DesktopPanelDetailRow,
+  DesktopPanelDetailRows,
+};

--- a/packages/ui/src/desktop/panel-detail.tsx
+++ b/packages/ui/src/desktop/panel-detail.tsx
@@ -70,13 +70,19 @@ function DesktopPanelDetailRow({
 function DesktopPanelDetailRows({
   rows,
 }: {
-  rows: Array<{ label?: string; value: string; className?: string; valueClassName?: string }>;
+  rows: Array<{
+    id?: string;
+    label?: string;
+    value: string;
+    className?: string;
+    valueClassName?: string;
+  }>;
 }) {
   return (
     <DesktopPanelDetailList>
-      {rows.map((row) => (
+      {rows.map((row, index) => (
         <DesktopPanelDetailRow
-          key={`${row.className ?? ""}:${row.label ?? ""}:${row.value}`}
+          key={row.id ?? index}
           label={row.label}
           value={row.value}
           className={row.className}

--- a/packages/ui/src/desktop/panel-section.tsx
+++ b/packages/ui/src/desktop/panel-section.tsx
@@ -1,0 +1,34 @@
+import { ChevronRight } from "lucide-react";
+import type { ReactNode } from "react";
+
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "../components/collapsible";
+import { cn } from "../lib/utils";
+
+type DesktopPanelSectionProps = {
+  title: ReactNode;
+  children: ReactNode;
+  className?: string;
+  defaultOpen?: boolean;
+};
+
+function DesktopPanelSection({
+  title,
+  children,
+  className,
+  defaultOpen = false,
+}: DesktopPanelSectionProps) {
+  return (
+    <Collapsible defaultOpen={defaultOpen} className={cn("gg-inspector-section", className)}>
+      <CollapsibleTrigger className="gg-inspector-section-trigger">
+        <ChevronRight className="gg-inspector-section-chevron" />
+        <h3 className="gg-inspector-section-header border-0 pb-0">{title}</h3>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="gg-inspector-section-content">
+        <div className="gg-inspector-section-body">{children}</div>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+export { DesktopPanelSection };
+export type { DesktopPanelSectionProps };

--- a/packages/ui/src/desktop/studio-pane.tsx
+++ b/packages/ui/src/desktop/studio-pane.tsx
@@ -1,5 +1,6 @@
 import type { ComponentProps, ElementType, ReactNode } from "react";
-import { cn } from "@lib/utils";
+
+import { cn } from "../lib/utils";
 
 type StudioPaneProps<T extends ElementType> = {
   as?: T;
@@ -8,7 +9,7 @@ type StudioPaneProps<T extends ElementType> = {
   className?: string;
 } & Omit<ComponentProps<T>, "as" | "children" | "className">;
 
-export function StudioPane<T extends ElementType = "aside">({
+function StudioPane<T extends ElementType = "aside">({
   as,
   side,
   children,
@@ -32,18 +33,20 @@ export function StudioPane<T extends ElementType = "aside">({
   );
 }
 
-export function StudioPaneHeader({ className, ...props }: ComponentProps<"div">) {
+function StudioPaneHeader({ className, ...props }: ComponentProps<"div">) {
   return <div className={cn("gg-pane-header", className)} {...props} />;
 }
 
-export function StudioPaneTitle({ className, ...props }: ComponentProps<"h2">) {
+function StudioPaneTitle({ className, ...props }: ComponentProps<"h2">) {
   return <h2 className={cn("gg-pane-title", className)} {...props} />;
 }
 
-export function StudioPaneSubtitle({ className, ...props }: ComponentProps<"p">) {
+function StudioPaneSubtitle({ className, ...props }: ComponentProps<"p">) {
   return <p className={cn("gg-pane-subtitle", className)} {...props} />;
 }
 
-export function StudioPaneBody({ className, ...props }: ComponentProps<"div">) {
+function StudioPaneBody({ className, ...props }: ComponentProps<"div">) {
   return <div className={cn("gg-pane-body", className)} {...props} />;
 }
+
+export { StudioPane, StudioPaneBody, StudioPaneHeader, StudioPaneSubtitle, StudioPaneTitle };

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -188,29 +188,59 @@
     accent-color: var(--primary);
   }
 
-  * {
+  :where(html, body, [data-gg-scrollbar], .gg-scrollbar, [data-slot="scroll-area-viewport"]) {
     scrollbar-width: thin;
     scrollbar-color: color-mix(in oklab, var(--muted-foreground) 52%, transparent) transparent;
   }
 
-  *::-webkit-scrollbar {
+  :where(
+    html,
+    body,
+    [data-gg-scrollbar],
+    .gg-scrollbar,
+    [data-slot="scroll-area-viewport"]
+  )::-webkit-scrollbar {
     width: 8px;
     height: 8px;
     background: transparent !important;
   }
 
-  *::-webkit-scrollbar-track,
-  *::-webkit-scrollbar-track-piece {
+  :where(
+    html,
+    body,
+    [data-gg-scrollbar],
+    .gg-scrollbar,
+    [data-slot="scroll-area-viewport"]
+  )::-webkit-scrollbar-track,
+  :where(
+    html,
+    body,
+    [data-gg-scrollbar],
+    .gg-scrollbar,
+    [data-slot="scroll-area-viewport"]
+  )::-webkit-scrollbar-track-piece {
     background: transparent !important;
   }
 
-  *::-webkit-scrollbar-button {
+  :where(
+    html,
+    body,
+    [data-gg-scrollbar],
+    .gg-scrollbar,
+    [data-slot="scroll-area-viewport"]
+  )::-webkit-scrollbar-button {
     display: none;
     width: 0;
     height: 0;
   }
 
-  *::-webkit-scrollbar-thumb {
+  :where(
+    html,
+    body,
+    [data-gg-scrollbar],
+    .gg-scrollbar,
+    [data-slot="scroll-area-viewport"]
+  )::-webkit-scrollbar-thumb {
     min-height: 32px;
     border: 2px solid transparent;
     border-radius: 9999px;
@@ -218,11 +248,23 @@
     background-color: color-mix(in oklab, var(--muted-foreground) 42%, transparent);
   }
 
-  *::-webkit-scrollbar-thumb:hover {
+  :where(
+      html,
+      body,
+      [data-gg-scrollbar],
+      .gg-scrollbar,
+      [data-slot="scroll-area-viewport"]
+    )::-webkit-scrollbar-thumb:hover {
     background-color: color-mix(in oklab, var(--muted-foreground) 62%, transparent);
   }
 
-  *::-webkit-scrollbar-corner {
+  :where(
+    html,
+    body,
+    [data-gg-scrollbar],
+    .gg-scrollbar,
+    [data-slot="scroll-area-viewport"]
+  )::-webkit-scrollbar-corner {
     background: transparent;
   }
 }

--- a/packages/ui/src/styles/globals.css
+++ b/packages/ui/src/styles/globals.css
@@ -5,6 +5,7 @@
 @plugin "@tailwindcss/typography";
 
 :root {
+  color-scheme: light;
   --radius: 0.625rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.145 0 0);
@@ -56,6 +57,7 @@
 }
 
 .dark {
+  color-scheme: dark;
   --background: oklch(0.145 0 0);
   --foreground: oklch(0.985 0 0);
   --card: oklch(0.205 0 0);
@@ -184,5 +186,43 @@
 
   input[type="range"] {
     accent-color: var(--primary);
+  }
+
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: color-mix(in oklab, var(--muted-foreground) 52%, transparent) transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+    background: transparent !important;
+  }
+
+  *::-webkit-scrollbar-track,
+  *::-webkit-scrollbar-track-piece {
+    background: transparent !important;
+  }
+
+  *::-webkit-scrollbar-button {
+    display: none;
+    width: 0;
+    height: 0;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    min-height: 32px;
+    border: 2px solid transparent;
+    border-radius: 9999px;
+    background-clip: content-box;
+    background-color: color-mix(in oklab, var(--muted-foreground) 42%, transparent);
+  }
+
+  *::-webkit-scrollbar-thumb:hover {
+    background-color: color-mix(in oklab, var(--muted-foreground) 62%, transparent);
+  }
+
+  *::-webkit-scrollbar-corner {
+    background: transparent;
   }
 }


### PR DESCRIPTION
# Summary
- Move shared desktop pane, section, and detail/card primitives into `@guerillaglass/ui/desktop`.
- Update desktop side panels and inspector primitives to consume the shared UI building blocks.
- Polish native/WebKit scrollbar styling for desktop panes and shared UI defaults.

# Checklist
- [x] Ran `bun run gate`
- [x] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
- [x] UI changes include screenshots
  - `apps/desktop-electrobun/.tmp/ui-audit-screenshots/native-capture.png`
  - `apps/desktop-electrobun/.tmp/ui-audit-screenshots/native-edit.png`
  - `apps/desktop-electrobun/.tmp/ui-audit-screenshots/native-deliver.png`
- [ ] Updated docs/templates if architecture or workflows changed

# Testing (optional)
- [x] swift test
- [ ] bun run desktop:test:coverage (required when touching `apps/desktop-electrobun` or `packages/engine-protocol`)

Additional validation:
- `bun run gate` passed on branch `chore/desktop-ui-primitives-scrollbars`.
