### PR TITLE
feat(desktop): add timeline drag move interactions

### DIFF
--- a/.github/workflows/full_gate.yml
+++ b/.github/workflows/full_gate.yml
@@ -89,8 +89,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install Swift tools
-        run: brew install swiftformat swiftlint
+      - name: Install pinned SwiftFormat and SwiftLint
+        run: |
+          curl --fail --location --silent --show-error \
+            https://github.com/nicklockwood/SwiftFormat/releases/download/0.62.1/swiftformat.zip \
+            --output /tmp/swiftformat.zip
+          unzip -q /tmp/swiftformat.zip -d /tmp/swiftformat
+          sudo install /tmp/swiftformat/swiftformat /usr/local/bin/swiftformat
+          brew install swiftlint
+          swiftformat --version
 
       - name: Remove temporary experiments
         run: rm -rf .tmp

--- a/apps/desktop-electrobun/src/mainview/app/studio/domain/timelineCommands.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/domain/timelineCommands.ts
@@ -21,6 +21,7 @@ type MoveTimelineItemsOptions =
   | {
       ripple: false;
       destinationGapId: string;
+      destinationOffsetSeconds?: number;
     };
 
 function defaultTimelineIdFactory(): string {
@@ -289,19 +290,9 @@ export function moveTimelineItems(
     };
   }
 
-  const lifted = liftTimelineItems(timeline, selectedItemIds, idFactory);
-  if (!lifted.changed) {
-    return lifted;
-  }
-
-  const destinationIndex = lifted.timeline.items.findIndex(
+  const destinationGap = timeline.items.find(
     (item) => item.kind === "gap" && item.id === options.destinationGapId,
   );
-  if (destinationIndex === -1) {
-    return { timeline, changed: false };
-  }
-
-  const destinationGap = lifted.timeline.items[destinationIndex];
   if (!destinationGap || destinationGap.kind !== "gap") {
     return { timeline, changed: false };
   }
@@ -310,25 +301,58 @@ export function moveTimelineItems(
     (sum, item) => sum + timelineItemDurationSeconds(item),
     0,
   );
-  if (movingDurationSeconds > destinationGap.durationSeconds + Number.EPSILON) {
+  const availableOffsetSeconds = destinationGap.durationSeconds - movingDurationSeconds;
+  if (availableOffsetSeconds < -Number.EPSILON) {
     return { timeline, changed: false };
   }
 
-  const gapRemainderSeconds = destinationGap.durationSeconds - movingDurationSeconds;
-  const replacementItems: TimelineItem[] = [...movingItems];
-  if (gapRemainderSeconds > Number.EPSILON) {
-    replacementItems.push({
-      kind: "gap",
-      id: destinationGap.id,
-      durationSeconds: gapRemainderSeconds,
-    });
+  const requestedOffsetSeconds = options.destinationOffsetSeconds ?? 0;
+  if (!Number.isFinite(requestedOffsetSeconds)) {
+    return { timeline, changed: false };
+  }
+  const destinationOffsetSeconds = Math.min(
+    Math.max(requestedOffsetSeconds, 0),
+    Math.max(availableOffsetSeconds, 0),
+  );
+  const trailingGapSeconds = Math.max(
+    0,
+    destinationGap.durationSeconds - destinationOffsetSeconds - movingDurationSeconds,
+  );
+
+  const nextItems: TimelineItem[] = [];
+  for (const item of timeline.items) {
+    if (selectedSet.has(item.id)) {
+      nextItems.push({
+        kind: "gap",
+        id: idFactory(),
+        durationSeconds: timelineItemDurationSeconds(item),
+      });
+      continue;
+    }
+    if (item.id !== destinationGap.id) {
+      nextItems.push(item);
+      continue;
+    }
+
+    if (destinationOffsetSeconds > Number.EPSILON) {
+      nextItems.push({
+        kind: "gap",
+        id: destinationGap.id,
+        durationSeconds: destinationOffsetSeconds,
+      });
+    }
+    nextItems.push(...movingItems);
+    if (trailingGapSeconds > Number.EPSILON) {
+      nextItems.push({
+        kind: "gap",
+        id: destinationOffsetSeconds > Number.EPSILON ? idFactory() : destinationGap.id,
+        durationSeconds: trailingGapSeconds,
+      });
+    }
   }
 
   return {
-    timeline: normalizeTimelineDocument({
-      version: 2,
-      items: replaceItemRange(lifted.timeline.items, destinationIndex, 1, replacementItems),
-    }),
+    timeline: normalizeTimelineDocument({ version: 2, items: nextItems }),
     changed: true,
   };
 }

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
@@ -44,6 +44,7 @@ import {
   selectionFromPreset,
 } from "../../domain/inspectorSelectionModel";
 import {
+  compileTimelineItems,
   createEmptyTimelineDocument,
   createSingleSegmentTimelineDocument,
 } from "../../domain/timelineDomainModel";
@@ -714,6 +715,43 @@ export function useStudioController() {
     updateTimelineDocument,
   ]);
 
+  const moveTimelineClipByDrop = useCallback(
+    (
+      params:
+        | { clipId: string; destinationIndex: number }
+        | { clipId: string; destinationGapId: string },
+    ) => {
+      let didChange = false;
+      let destinationSeconds: number | null = null;
+      updateTimelineDocument((currentTimeline) => {
+        const result =
+          "destinationGapId" in params
+            ? moveTimelineItems(currentTimeline, [params.clipId], {
+                ripple: false,
+                destinationGapId: params.destinationGapId,
+              })
+            : moveTimelineItems(currentTimeline, [params.clipId], {
+                ripple: true,
+                destinationIndex: params.destinationIndex,
+              });
+        didChange = result.changed;
+        if (result.changed) {
+          destinationSeconds =
+            compileTimelineItems(result.timeline).find((item) => item.id === params.clipId)
+              ?.programStartSeconds ?? null;
+        }
+        return result.timeline;
+      });
+      if (didChange) {
+        clearInspectorSelection();
+        if (destinationSeconds != null) {
+          setPlayheadSecondsClamped(destinationSeconds);
+        }
+      }
+    },
+    [clearInspectorSelection, setPlayheadSecondsClamped, updateTimelineDocument],
+  );
+
   const pickPathSafely = useCallback(
     async (params: { mode: HostPathPickerMode; startingFolder?: string }): Promise<string | null> =>
       await desktopApi.pickPath(params),
@@ -1109,6 +1147,7 @@ export function useStudioController() {
     liftSelectedTimelineClip,
     moveSelectedTimelineClipEarlier,
     moveSelectedTimelineClipLater,
+    moveTimelineClipByDrop,
     timelineDuration,
     timelineLanes,
     timelineDocument,

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
@@ -315,20 +315,20 @@ export function useStudioController() {
     timelineDraftState?.sourceSignature === baselineTimelineSignature
       ? timelineDraftState.draft
       : baselineTimelineDocument;
+  const timelineDocumentRef = useRef(timelineDocument);
+  useEffect(() => {
+    timelineDocumentRef.current = timelineDocument;
+  }, [timelineDocument]);
   const updateTimelineDocument = useCallback(
     (updater: (currentTimeline: TimelineDocument) => TimelineDocument) => {
-      setTimelineDraftState((currentDraftState) => {
-        const currentTimeline =
-          currentDraftState?.sourceSignature === baselineTimelineSignature
-            ? currentDraftState.draft
-            : baselineTimelineDocument;
-        return {
-          draft: updater(currentTimeline),
-          sourceSignature: baselineTimelineSignature,
-        };
+      const nextTimeline = updater(timelineDocumentRef.current);
+      timelineDocumentRef.current = nextTimeline;
+      setTimelineDraftState({
+        draft: nextTimeline,
+        sourceSignature: baselineTimelineSignature,
       });
     },
-    [baselineTimelineDocument, baselineTimelineSignature],
+    [baselineTimelineSignature],
   );
 
   const selectedDisplayId = useMemo(() => {
@@ -719,34 +719,34 @@ export function useStudioController() {
     (
       params:
         | { clipId: string; destinationIndex: number }
-        | { clipId: string; destinationGapId: string },
+        | {
+            clipId: string;
+            destinationGapId: string;
+            destinationOffsetSeconds: number;
+          },
     ) => {
-      let didChange = false;
-      let destinationSeconds: number | null = null;
-      updateTimelineDocument((currentTimeline) => {
-        const result =
-          "destinationGapId" in params
-            ? moveTimelineItems(currentTimeline, [params.clipId], {
-                ripple: false,
-                destinationGapId: params.destinationGapId,
-              })
-            : moveTimelineItems(currentTimeline, [params.clipId], {
-                ripple: true,
-                destinationIndex: params.destinationIndex,
-              });
-        didChange = result.changed;
-        if (result.changed) {
-          destinationSeconds =
-            compileTimelineItems(result.timeline).find((item) => item.id === params.clipId)
-              ?.programStartSeconds ?? null;
-        }
-        return result.timeline;
-      });
-      if (didChange) {
-        clearInspectorSelection();
-        if (destinationSeconds != null) {
-          setPlayheadSecondsClamped(destinationSeconds);
-        }
+      const result =
+        "destinationGapId" in params
+          ? moveTimelineItems(timelineDocumentRef.current, [params.clipId], {
+              ripple: false,
+              destinationGapId: params.destinationGapId,
+              destinationOffsetSeconds: params.destinationOffsetSeconds,
+            })
+          : moveTimelineItems(timelineDocumentRef.current, [params.clipId], {
+              ripple: true,
+              destinationIndex: params.destinationIndex,
+            });
+      if (!result.changed) {
+        return;
+      }
+
+      updateTimelineDocument(() => result.timeline);
+      clearInspectorSelection();
+      const destinationSeconds = compileTimelineItems(result.timeline).find(
+        (item) => item.id === params.clipId,
+      )?.programStartSeconds;
+      if (destinationSeconds != null) {
+        setPlayheadSecondsClamped(destinationSeconds);
       }
     },
     [clearInspectorSelection, setPlayheadSecondsClamped, updateTimelineDocument],

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/useVideoPlaybackSync.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/useVideoPlaybackSync.ts
@@ -207,6 +207,7 @@ export function useVideoPlaybackSync({
         );
         if (boundaryResolution.kind === "gap") {
           media.pause();
+          media.style.visibility = "hidden";
           setPlayheadSecondsFromMedia(boundarySeconds);
           return true;
         }
@@ -324,6 +325,50 @@ export function useVideoPlaybackSync({
       );
     };
     const handleEnded = () => {
+      const resolution = resolveTimelinePlaybackAtProgramTime(
+        timelineItems,
+        playheadSecondsRef.current,
+      );
+      if (resolution.kind === "gap") {
+        media.pause();
+        media.style.visibility = "hidden";
+        return;
+      }
+      if (resolution.kind === "clip") {
+        const queuedBoundaryClip = timelineItems.find(
+          (item) =>
+            item.kind === "clip" &&
+            Math.abs(item.programEndSeconds - playheadSecondsRef.current) <= 0.02,
+        );
+        const endedClip =
+          queuedBoundaryClip?.kind === "clip" ? queuedBoundaryClip : resolution.item;
+        const boundarySeconds = endedClip.programEndSeconds;
+        const boundaryResolution = resolveTimelinePlaybackAtProgramTime(
+          timelineItems,
+          boundarySeconds,
+        );
+        if (boundaryResolution.kind === "gap") {
+          media.pause();
+          media.style.visibility = "hidden";
+          setPlayheadSecondsFromMedia(boundarySeconds);
+          return;
+        }
+
+        const nextClip = findNextPlayableClipAfterProgramTime(timelineItems, boundarySeconds);
+        if (nextClip) {
+          try {
+            media.currentTime = nextClip.sourceStartSeconds;
+            media.style.visibility = "";
+            setPlayheadSecondsFromMedia(nextClip.programStartSeconds);
+            void media.play().catch(() => setTimelinePlaybackActive(false));
+            return;
+          } catch {
+            setTimelinePlaybackActive(false);
+            return;
+          }
+        }
+      }
+
       setTimelinePlaybackActive(false);
       const duration = timelineDurationSeconds(timelineItems);
       if (duration > 0) {

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineDock.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineDock.tsx
@@ -257,12 +257,14 @@ export function TimelineDock() {
               labels={studio.ui.labels}
               timelineTool={studio.timelineTool}
               timelineSnapEnabled={studio.timelineSnapEnabled}
+              timelineRippleEnabled={studio.timelineRippleEnabled}
               zoomPercent={studio.timelineZoomPercent}
               onSetPlayheadSeconds={studio.setPlayheadSeconds}
               onSetTrimStartSeconds={trimEnabled ? studio.setTrimStartSeconds : undefined}
               onSetTrimEndSeconds={trimEnabled ? studio.setTrimEndSeconds : undefined}
               onNudgePlayheadSeconds={studio.nudgePlayheadSeconds}
               onBladeClipAtSeconds={studio.splitTimelineClipAtSeconds}
+              onMoveClipDrop={studio.moveTimelineClipByDrop}
               onToggleLaneLocked={(laneId) => studio.toggleLaneControl(laneId, "locked")}
               onToggleLaneMuted={(laneId) => studio.toggleLaneControl(laneId, "muted")}
               onToggleLaneSolo={(laneId) => studio.toggleLaneControl(laneId, "solo")}

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineSurface.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineSurface.tsx
@@ -37,6 +37,7 @@ type TimelineSurfaceLabels = {
   timelineMarkerClick: string;
   timelineMarkerMixed: string;
   timelineClipAria: (laneLabel: string, startSeconds: number, endSeconds: number) => string;
+  timelineGapAria: (laneLabel: string, startSeconds: number, endSeconds: number) => string;
   timelineMarkerAria: (markerKindLabel: string, timestampSeconds: number) => string;
 };
 
@@ -53,7 +54,7 @@ type TimelineSelectedClip = { laneId: "video" | "audio"; clipId: string } | null
 
 type MoveTimelineClipDropParams =
   | { clipId: string; destinationIndex: number }
-  | { clipId: string; destinationGapId: string };
+  | { clipId: string; destinationGapId: string; destinationOffsetSeconds: number };
 
 type TimelineSurfaceProps = {
   durationSeconds: number;
@@ -98,12 +99,19 @@ type TimelineClipDragState = {
   clipId: string;
   laneId: "video" | "audio";
   originClientX: number;
+  grabOffsetSeconds: number;
   isDragging: boolean;
 };
 type TimelineClipDropTarget =
   | { kind: "none" }
   | { kind: "insert"; destinationIndex: number; boundarySeconds: number }
-  | { kind: "gap"; gapId: string };
+  | {
+      kind: "gap";
+      gapId: string;
+      destinationOffsetSeconds: number;
+      placementStartSeconds: number;
+      placementEndSeconds: number;
+    };
 type TrimDragMode = Exclude<DragMode, "playhead">;
 
 type TimelineLanesLayerProps = {
@@ -116,6 +124,7 @@ type TimelineLanesLayerProps = {
   onToggleLaneLocked: (laneId: "video" | "audio") => void;
   onToggleLaneMuted: (laneId: "video" | "audio") => void;
   onToggleLaneSolo: (laneId: "video" | "audio") => void;
+  onClearSelection: () => void;
   onSelectClip: (params: {
     laneId: "video" | "audio";
     clipId: string;
@@ -135,6 +144,8 @@ type TimelineLanesLayerProps = {
       laneId: "video" | "audio";
       laneLocked: boolean;
       semantic: TimelineClipSemantic;
+      startSeconds: number;
+      endSeconds: number;
     },
     event: ReactPointerEvent<HTMLElement>,
   ) => void;
@@ -270,6 +281,8 @@ function resolveTimelineClipDropTarget(params: {
   durationSeconds: number;
   lanes: TimelineLane[];
   timelineRippleEnabled: boolean;
+  draggedClipId: string;
+  draggedClipGrabOffsetSeconds: number;
   trackOverlayRef: RefObject<HTMLDivElement | null>;
 }): TimelineClipDropTarget {
   const rect = params.trackOverlayRef.current?.getBoundingClientRect();
@@ -277,7 +290,12 @@ function resolveTimelineClipDropTarget(params: {
     return { kind: "none" };
   }
 
-  const seconds = pixelsToSeconds(params.clientX - rect.left, params.durationSeconds, rect.width);
+  const pointerSeconds = pixelsToSeconds(
+    params.clientX - rect.left,
+    params.durationSeconds,
+    rect.width,
+  );
+  const placementSeconds = pointerSeconds - params.draggedClipGrabOffsetSeconds;
   const boundarySnapSeconds = pixelsToSeconds(8, params.durationSeconds, rect.width);
   const videoLane = params.lanes.find((lane) => lane.id === "video");
   if (!videoLane) {
@@ -285,28 +303,54 @@ function resolveTimelineClipDropTarget(params: {
   }
 
   if (!params.timelineRippleEnabled) {
-    const targetGap = videoLane.clips.find(
-      (clip) =>
-        clip.semantic === "gap" && seconds >= clip.startSeconds && seconds < clip.endSeconds,
+    const draggedClip = videoLane.clips.find(
+      (clip) => clip.id === params.draggedClipId && clip.semantic !== "gap",
     );
-    if (targetGap) {
-      return { kind: "gap", gapId: targetGap.id };
+    if (!draggedClip) {
+      return { kind: "none" };
     }
-
-    const boundaryGap = videoLane.clips.find(
+    const draggedDurationSeconds = draggedClip.endSeconds - draggedClip.startSeconds;
+    const eligibleGaps = videoLane.clips.filter(
       (clip) =>
         clip.semantic === "gap" &&
-        (Math.abs(seconds - clip.startSeconds) <= boundarySnapSeconds ||
-          Math.abs(seconds - clip.endSeconds) <= boundarySnapSeconds),
+        clip.endSeconds - clip.startSeconds + Number.EPSILON >= draggedDurationSeconds,
     );
-    return boundaryGap ? { kind: "gap", gapId: boundaryGap.id } : { kind: "none" };
+    const targetGap = eligibleGaps.find(
+      (clip) => placementSeconds >= clip.startSeconds && placementSeconds < clip.endSeconds,
+    );
+    const boundaryGap =
+      targetGap ??
+      eligibleGaps.find(
+        (clip) =>
+          Math.abs(placementSeconds - clip.startSeconds) <= boundarySnapSeconds ||
+          Math.abs(placementSeconds - clip.endSeconds) <= boundarySnapSeconds,
+      );
+    if (!boundaryGap) {
+      return { kind: "none" };
+    }
+
+    const availableOffsetSeconds =
+      boundaryGap.endSeconds - boundaryGap.startSeconds - draggedDurationSeconds;
+    const destinationOffsetSeconds = Math.min(
+      Math.max(placementSeconds - boundaryGap.startSeconds, 0),
+      Math.max(availableOffsetSeconds, 0),
+    );
+    const placementStartSeconds = boundaryGap.startSeconds + destinationOffsetSeconds;
+    return {
+      kind: "gap",
+      gapId: boundaryGap.id,
+      destinationOffsetSeconds,
+      placementStartSeconds,
+      placementEndSeconds: placementStartSeconds + draggedDurationSeconds,
+    };
   }
 
   const destinationIndex = videoLane.clips.findIndex((clip) => {
     const midpoint = clip.startSeconds + (clip.endSeconds - clip.startSeconds) / 2;
-    return seconds < midpoint;
+    return pointerSeconds < midpoint;
   });
-  const resolvedDestinationIndex = destinationIndex === -1 ? videoLane.clips.length : destinationIndex;
+  const resolvedDestinationIndex =
+    destinationIndex === -1 ? videoLane.clips.length : destinationIndex;
   const destinationClip = videoLane.clips[resolvedDestinationIndex];
   const lastClip = videoLane.clips[videoLane.clips.length - 1];
   return {
@@ -420,6 +464,8 @@ function useTimelineDragController(params: {
         durationSeconds,
         lanes,
         timelineRippleEnabled,
+        draggedClipId: clipDragRef.current?.clipId ?? "",
+        draggedClipGrabOffsetSeconds: clipDragRef.current?.grabOffsetSeconds ?? 0,
         trackOverlayRef,
       });
       clipDropTargetRef.current = target;
@@ -508,7 +554,11 @@ function useTimelineDragController(params: {
               destinationIndex: target.destinationIndex,
             });
           } else if (target.kind === "gap") {
-            onMoveClipDrop?.({ clipId: dragState.clipId, destinationGapId: target.gapId });
+            onMoveClipDrop?.({
+              clipId: dragState.clipId,
+              destinationGapId: target.gapId,
+              destinationOffsetSeconds: target.destinationOffsetSeconds,
+            });
           }
         }
         const captureTarget = clipPointerCaptureTargetRef.current;
@@ -573,6 +623,8 @@ function useTimelineDragController(params: {
         laneId: "video" | "audio";
         laneLocked: boolean;
         semantic: TimelineClipSemantic;
+        startSeconds: number;
+        endSeconds: number;
       },
       event: ReactPointerEvent<HTMLElement>,
     ) => {
@@ -585,10 +637,17 @@ function useTimelineDragController(params: {
       ) {
         return;
       }
+      const clipRect = event.currentTarget.getBoundingClientRect();
+      const clipDurationSeconds = Math.max(0, params.endSeconds - params.startSeconds);
+      const grabRatio =
+        clipRect.width > 0
+          ? clampSeconds((event.clientX - clipRect.left) / clipRect.width, 0, 1)
+          : 0;
       clipDragRef.current = {
         clipId: params.clipId,
         laneId: params.laneId,
         originClientX: event.clientX,
+        grabOffsetSeconds: grabRatio * clipDurationSeconds,
         isDragging: false,
       };
       clipDropTargetRef.current = { kind: "none" };
@@ -740,6 +799,7 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
   onToggleLaneLocked,
   onToggleLaneMuted,
   onToggleLaneSolo,
+  onClearSelection,
   onSelectClip,
   onSelectMarker,
   onBladeClipAtSeconds,
@@ -818,11 +878,11 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
                       data-timeline-selectable="true"
                       className={`gg-timeline-clip gg-timeline-entity-button gg-timeline-clip-${lane.id} gg-timeline-clip-semantic-${clip.semantic}${isSelected ? " gg-timeline-clip-selected" : ""}`}
                       style={{ left: `${left}%`, width: `${Math.max(width, 0)}%` }}
-                      aria-label={labels.timelineClipAria(
-                        lane.label,
-                        clip.startSeconds,
-                        clip.endSeconds,
-                      )}
+                      aria-label={
+                        clip.semantic === "gap"
+                          ? labels.timelineGapAria(lane.label, clip.startSeconds, clip.endSeconds)
+                          : labels.timelineClipAria(lane.label, clip.startSeconds, clip.endSeconds)
+                      }
                       aria-pressed={isSelected}
                       disabled={laneLocked}
                       onPointerDown={(event) =>
@@ -832,6 +892,8 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
                             laneId: lane.id,
                             laneLocked,
                             semantic: clip.semantic,
+                            startSeconds: clip.startSeconds,
+                            endSeconds: clip.endSeconds,
                           },
                           event,
                         )
@@ -840,11 +902,11 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
                         if (shouldSuppressClipClick(clip.id)) {
                           return;
                         }
-                        if (
-                          timelineTool === "blade" &&
-                          clip.semantic !== "gap" &&
-                          onBladeClipAtSeconds
-                        ) {
+                        if (clip.semantic === "gap") {
+                          onClearSelection();
+                          return;
+                        }
+                        if (timelineTool === "blade" && onBladeClipAtSeconds) {
                           const rect = event.currentTarget.getBoundingClientRect();
                           const pointerRatio =
                             rect.width > 0
@@ -963,15 +1025,17 @@ function TimelineClipDropAffordance({
     );
   }
 
-  const gap = lanes
+  const gapExists = lanes
     .find((lane) => lane.id === "video")
-    ?.clips.find((clip) => clip.id === target.gapId && clip.semantic === "gap");
-  if (!gap) {
+    ?.clips.some((clip) => clip.id === target.gapId && clip.semantic === "gap");
+  if (!gapExists) {
     return null;
   }
 
-  const left = toPercent(gap.startSeconds, durationSeconds);
-  const width = toPercent(gap.endSeconds, durationSeconds) - left;
+  const left = toPercent(target.placementStartSeconds, durationSeconds);
+  const width =
+    toPercent(target.placementEndSeconds, durationSeconds) -
+    toPercent(target.placementStartSeconds, durationSeconds);
   return (
     <div
       className="gg-timeline-drop-gap"
@@ -1096,6 +1160,7 @@ export function TimelineSurface({
             onToggleLaneLocked={onToggleLaneLocked}
             onToggleLaneMuted={onToggleLaneMuted}
             onToggleLaneSolo={onToggleLaneSolo}
+            onClearSelection={onClearSelection}
             onSelectClip={onSelectClip}
             onSelectMarker={onSelectMarker}
             onBladeClipAtSeconds={onBladeClipAtSeconds}

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineSurface.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/TimelineSurface.tsx
@@ -3,6 +3,7 @@ import {
   useCallback,
   useMemo,
   useRef,
+  useState,
   type ComponentType,
   type PointerEvent as ReactPointerEvent,
   type RefObject,
@@ -12,7 +13,12 @@ import { AudioLines, Headphones, Lock, Video, VolumeX } from "lucide-react";
 import { Button } from "@guerillaglass/ui/components/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@guerillaglass/ui/components/tooltip";
 import { useStudioPlaybackValue } from "../state/StudioProvider";
-import type { TimelineClip, TimelineLane, TimelineWaveform } from "../domain/timelineDomainModel";
+import type {
+  TimelineClip,
+  TimelineClipSemantic,
+  TimelineLane,
+  TimelineWaveform,
+} from "../domain/timelineDomainModel";
 import { clampSeconds, pixelsToSeconds } from "../domain/timelineDomainModel";
 import { studioToggleToneClass, type StudioSemanticState } from "../view-model/studioSemanticTone";
 
@@ -45,6 +51,10 @@ type TimelineLaneControls = Record<
 
 type TimelineSelectedClip = { laneId: "video" | "audio"; clipId: string } | null;
 
+type MoveTimelineClipDropParams =
+  | { clipId: string; destinationIndex: number }
+  | { clipId: string; destinationGapId: string };
+
 type TimelineSurfaceProps = {
   durationSeconds: number;
   trimEnabled?: boolean;
@@ -53,6 +63,7 @@ type TimelineSurfaceProps = {
   zoomPercent: number;
   timelineTool: "select" | "trim" | "blade";
   timelineSnapEnabled: boolean;
+  timelineRippleEnabled: boolean;
   lanes: TimelineLane[];
   laneControls: TimelineLaneControls;
   labels: TimelineSurfaceLabels;
@@ -65,6 +76,7 @@ type TimelineSurfaceProps = {
   onToggleLaneSolo: (laneId: "video" | "audio") => void;
   onClearSelection: () => void;
   onBladeClipAtSeconds?: (seconds: number) => void;
+  onMoveClipDrop?: (params: MoveTimelineClipDropParams) => void;
   selectedClip: TimelineSelectedClip;
   selectedMarkerId: string | null;
   onSelectClip: (params: {
@@ -82,6 +94,16 @@ type TimelineSurfaceProps = {
 };
 
 type DragMode = "playhead" | "trimStart" | "trimEnd";
+type TimelineClipDragState = {
+  clipId: string;
+  laneId: "video" | "audio";
+  originClientX: number;
+  isDragging: boolean;
+};
+type TimelineClipDropTarget =
+  | { kind: "none" }
+  | { kind: "insert"; destinationIndex: number; boundarySeconds: number }
+  | { kind: "gap"; gapId: string };
 type TrimDragMode = Exclude<DragMode, "playhead">;
 
 type TimelineLanesLayerProps = {
@@ -107,6 +129,16 @@ type TimelineLanesLayerProps = {
     timestampSeconds: number;
   }) => void;
   onBladeClipAtSeconds?: (seconds: number) => void;
+  onClipPointerDown: (
+    params: {
+      clipId: string;
+      laneId: "video" | "audio";
+      laneLocked: boolean;
+      semantic: TimelineClipSemantic;
+    },
+    event: ReactPointerEvent<HTMLElement>,
+  ) => void;
+  shouldSuppressClipClick: (clipId: string) => boolean;
   timelineTool: "select" | "trim" | "blade";
 };
 
@@ -124,6 +156,9 @@ type TimelineOverlayProps = {
   onSetTrimStartSeconds?: (seconds: number) => void;
   onSetTrimEndSeconds?: (seconds: number) => void;
   onTrimHandlePointerDown?: (mode: TrimDragMode, event: ReactPointerEvent<HTMLElement>) => void;
+  clipDropTarget: TimelineClipDropTarget;
+  isClipDragging: boolean;
+  lanes: TimelineLane[];
 };
 
 type TrimHandleProps = {
@@ -230,6 +265,58 @@ function pickWaveformBars(params: {
   });
 }
 
+function resolveTimelineClipDropTarget(params: {
+  clientX: number;
+  durationSeconds: number;
+  lanes: TimelineLane[];
+  timelineRippleEnabled: boolean;
+  trackOverlayRef: RefObject<HTMLDivElement | null>;
+}): TimelineClipDropTarget {
+  const rect = params.trackOverlayRef.current?.getBoundingClientRect();
+  if (!rect || rect.width <= 0) {
+    return { kind: "none" };
+  }
+
+  const seconds = pixelsToSeconds(params.clientX - rect.left, params.durationSeconds, rect.width);
+  const boundarySnapSeconds = pixelsToSeconds(8, params.durationSeconds, rect.width);
+  const videoLane = params.lanes.find((lane) => lane.id === "video");
+  if (!videoLane) {
+    return { kind: "none" };
+  }
+
+  if (!params.timelineRippleEnabled) {
+    const targetGap = videoLane.clips.find(
+      (clip) =>
+        clip.semantic === "gap" && seconds >= clip.startSeconds && seconds < clip.endSeconds,
+    );
+    if (targetGap) {
+      return { kind: "gap", gapId: targetGap.id };
+    }
+
+    const boundaryGap = videoLane.clips.find(
+      (clip) =>
+        clip.semantic === "gap" &&
+        (Math.abs(seconds - clip.startSeconds) <= boundarySnapSeconds ||
+          Math.abs(seconds - clip.endSeconds) <= boundarySnapSeconds),
+    );
+    return boundaryGap ? { kind: "gap", gapId: boundaryGap.id } : { kind: "none" };
+  }
+
+  const destinationIndex = videoLane.clips.findIndex((clip) => {
+    const midpoint = clip.startSeconds + (clip.endSeconds - clip.startSeconds) / 2;
+    return seconds < midpoint;
+  });
+  const resolvedDestinationIndex = destinationIndex === -1 ? videoLane.clips.length : destinationIndex;
+  const destinationClip = videoLane.clips[resolvedDestinationIndex];
+  const lastClip = videoLane.clips[videoLane.clips.length - 1];
+  return {
+    kind: "insert",
+    destinationIndex: resolvedDestinationIndex,
+    boundarySeconds:
+      destinationClip?.startSeconds ?? lastClip?.endSeconds ?? params.durationSeconds,
+  };
+}
+
 function readRulerTicks(durationSeconds: number): {
   id: string;
   isMajor: boolean;
@@ -253,21 +340,35 @@ function readRulerTicks(durationSeconds: number): {
 
 function useTimelineDragController(params: {
   durationSeconds: number;
+  lanes: TimelineLane[];
+  timelineRippleEnabled: boolean;
+  timelineTool: "select" | "trim" | "blade";
   trackOverlayRef: RefObject<HTMLDivElement | null>;
   onSetPlayheadSeconds: (seconds: number) => void;
   onSetTrimStartSeconds?: (seconds: number) => void;
   onSetTrimEndSeconds?: (seconds: number) => void;
   onClearSelection: () => void;
+  onMoveClipDrop?: (params: MoveTimelineClipDropParams) => void;
 }) {
   const {
     durationSeconds,
+    lanes,
+    timelineRippleEnabled,
+    timelineTool,
     trackOverlayRef,
     onClearSelection,
+    onMoveClipDrop,
     onSetPlayheadSeconds,
     onSetTrimStartSeconds,
     onSetTrimEndSeconds,
   } = params;
   const dragModeRef = useRef<DragMode | null>(null);
+  const clipDragRef = useRef<TimelineClipDragState | null>(null);
+  const clipDropTargetRef = useRef<TimelineClipDropTarget>({ kind: "none" });
+  const clipPointerCaptureTargetRef = useRef<HTMLElement | null>(null);
+  const suppressedClickClipIdRef = useRef<string | null>(null);
+  const [clipDropTarget, setClipDropTarget] = useState<TimelineClipDropTarget>({ kind: "none" });
+  const [isClipDragging, setIsClipDragging] = useState(false);
 
   const timeFromClientX = useCallback(
     (clientX: number): number => {
@@ -312,6 +413,33 @@ function useTimelineDragController(params: {
     () => null,
   );
 
+  const updateClipDropTarget = useCallback(
+    (clientX: number) => {
+      const target = resolveTimelineClipDropTarget({
+        clientX,
+        durationSeconds,
+        lanes,
+        timelineRippleEnabled,
+        trackOverlayRef,
+      });
+      clipDropTargetRef.current = target;
+      setClipDropTarget(target);
+    },
+    [durationSeconds, lanes, timelineRippleEnabled, trackOverlayRef],
+  );
+
+  const clipDragThrottler = useThrottler(
+    (clientX: number) => {
+      updateClipDropTarget(clientX);
+    },
+    {
+      leading: true,
+      trailing: true,
+      wait: 16,
+    },
+    () => null,
+  );
+
   const beginDrag = useCallback(
     (event: ReactPointerEvent<HTMLElement>, mode: DragMode) => {
       if (durationSeconds <= 0) {
@@ -343,16 +471,58 @@ function useTimelineDragController(params: {
 
   const onSurfacePointerMove = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
+      if (clipDragRef.current) {
+        const dragState = clipDragRef.current;
+        if (!dragState.isDragging && Math.abs(event.clientX - dragState.originClientX) < 4) {
+          return;
+        }
+        if (!dragState.isDragging) {
+          setIsClipDragging(true);
+        }
+        dragState.isDragging = true;
+        clipDragThrottler.maybeExecute(event.clientX);
+        return;
+      }
+
       if (!dragModeRef.current) {
         return;
       }
       pointerDragThrottler.maybeExecute(event.clientX);
     },
-    [pointerDragThrottler],
+    [clipDragThrottler, pointerDragThrottler],
   );
 
   const onSurfacePointerUp = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
+      if (clipDragRef.current) {
+        const dragState = clipDragRef.current;
+        clipDragThrottler.maybeExecute(event.clientX);
+        clipDragThrottler.flush();
+        clipDragThrottler.cancel();
+        if (dragState.isDragging) {
+          suppressedClickClipIdRef.current = dragState.clipId;
+          const target = clipDropTargetRef.current;
+          if (target.kind === "insert") {
+            onMoveClipDrop?.({
+              clipId: dragState.clipId,
+              destinationIndex: target.destinationIndex,
+            });
+          } else if (target.kind === "gap") {
+            onMoveClipDrop?.({ clipId: dragState.clipId, destinationGapId: target.gapId });
+          }
+        }
+        const captureTarget = clipPointerCaptureTargetRef.current;
+        if (captureTarget?.hasPointerCapture(event.pointerId)) {
+          captureTarget.releasePointerCapture(event.pointerId);
+        }
+        clipDropTargetRef.current = { kind: "none" };
+        clipPointerCaptureTargetRef.current = null;
+        clipDragRef.current = null;
+        setClipDropTarget({ kind: "none" });
+        setIsClipDragging(false);
+        return;
+      }
+
       if (!dragModeRef.current) {
         return;
       }
@@ -366,18 +536,27 @@ function useTimelineDragController(params: {
       }
       dragModeRef.current = null;
     },
-    [pointerDragThrottler],
+    [clipDragThrottler, onMoveClipDrop, pointerDragThrottler],
   );
 
   const onSurfacePointerCancel = useCallback(
     (event: React.PointerEvent<HTMLDivElement>) => {
       pointerDragThrottler.cancel();
-      if (event.currentTarget.hasPointerCapture(event.pointerId)) {
+      clipDragThrottler.cancel();
+      const captureTarget = clipPointerCaptureTargetRef.current;
+      if (captureTarget?.hasPointerCapture(event.pointerId)) {
+        captureTarget.releasePointerCapture(event.pointerId);
+      } else if (event.currentTarget.hasPointerCapture(event.pointerId)) {
         event.currentTarget.releasePointerCapture(event.pointerId);
       }
       dragModeRef.current = null;
+      clipDropTargetRef.current = { kind: "none" };
+      clipPointerCaptureTargetRef.current = null;
+      clipDragRef.current = null;
+      setClipDropTarget({ kind: "none" });
+      setIsClipDragging(false);
     },
-    [pointerDragThrottler],
+    [clipDragThrottler, pointerDragThrottler],
   );
 
   const onTrimHandlePointerDown = useCallback(
@@ -387,12 +566,59 @@ function useTimelineDragController(params: {
     [beginDrag],
   );
 
+  const onClipPointerDown = useCallback(
+    (
+      params: {
+        clipId: string;
+        laneId: "video" | "audio";
+        laneLocked: boolean;
+        semantic: TimelineClipSemantic;
+      },
+      event: ReactPointerEvent<HTMLElement>,
+    ) => {
+      if (
+        params.laneLocked ||
+        params.semantic === "gap" ||
+        timelineTool !== "select" ||
+        durationSeconds <= 0 ||
+        !onMoveClipDrop
+      ) {
+        return;
+      }
+      clipDragRef.current = {
+        clipId: params.clipId,
+        laneId: params.laneId,
+        originClientX: event.clientX,
+        isDragging: false,
+      };
+      clipDropTargetRef.current = { kind: "none" };
+      setClipDropTarget({ kind: "none" });
+      setIsClipDragging(false);
+      clipDragThrottler.cancel();
+      clipPointerCaptureTargetRef.current = event.currentTarget;
+      event.currentTarget.setPointerCapture(event.pointerId);
+    },
+    [clipDragThrottler, durationSeconds, onMoveClipDrop, timelineTool],
+  );
+
+  const shouldSuppressClipClick = useCallback((clipId: string): boolean => {
+    if (suppressedClickClipIdRef.current !== clipId) {
+      return false;
+    }
+    suppressedClickClipIdRef.current = null;
+    return true;
+  }, []);
+
   return {
     onSurfacePointerCancel,
     onSurfacePointerDown,
     onSurfacePointerMove,
     onSurfacePointerUp,
+    onClipPointerDown,
     onTrimHandlePointerDown,
+    shouldSuppressClipClick,
+    clipDropTarget,
+    isClipDragging,
   };
 }
 
@@ -455,9 +681,18 @@ function TimelineOverlay({
   onSetTrimStartSeconds,
   onSetTrimEndSeconds,
   onTrimHandlePointerDown,
+  clipDropTarget,
+  isClipDragging,
+  lanes,
 }: TimelineOverlayProps) {
   return (
     <div ref={trackOverlayRef} className="gg-timeline-track-overlay">
+      <TimelineClipDropAffordance
+        durationSeconds={durationSeconds}
+        isDragging={isClipDragging}
+        lanes={lanes}
+        target={clipDropTarget}
+      />
       <TimelinePlayhead durationSeconds={durationSeconds} />
       {trimEnabled &&
       trimStartPercent != null &&
@@ -508,6 +743,8 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
   onSelectClip,
   onSelectMarker,
   onBladeClipAtSeconds,
+  onClipPointerDown,
+  shouldSuppressClipClick,
   timelineTool,
 }: TimelineLanesLayerProps) {
   return (
@@ -579,7 +816,7 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
                       variant="ghost"
                       size="sm"
                       data-timeline-selectable="true"
-                      className={`gg-timeline-clip gg-timeline-entity-button gg-timeline-clip-${lane.id}${isSelected ? " gg-timeline-clip-selected" : ""}`}
+                      className={`gg-timeline-clip gg-timeline-entity-button gg-timeline-clip-${lane.id} gg-timeline-clip-semantic-${clip.semantic}${isSelected ? " gg-timeline-clip-selected" : ""}`}
                       style={{ left: `${left}%`, width: `${Math.max(width, 0)}%` }}
                       aria-label={labels.timelineClipAria(
                         lane.label,
@@ -588,7 +825,21 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
                       )}
                       aria-pressed={isSelected}
                       disabled={laneLocked}
+                      onPointerDown={(event) =>
+                        onClipPointerDown(
+                          {
+                            clipId: clip.id,
+                            laneId: lane.id,
+                            laneLocked,
+                            semantic: clip.semantic,
+                          },
+                          event,
+                        )
+                      }
                       onClick={(event) => {
+                        if (shouldSuppressClipClick(clip.id)) {
+                          return;
+                        }
                         if (
                           timelineTool === "blade" &&
                           clip.semantic !== "gap" &&
@@ -687,6 +938,49 @@ const TimelineLanesLayer = memo(function TimelineLanesLayer({
   );
 });
 
+function TimelineClipDropAffordance({
+  durationSeconds,
+  isDragging,
+  lanes,
+  target,
+}: {
+  durationSeconds: number;
+  isDragging: boolean;
+  lanes: TimelineLane[];
+  target: TimelineClipDropTarget;
+}) {
+  if (!isDragging || target.kind === "none") {
+    return null;
+  }
+
+  if (target.kind === "insert") {
+    return (
+      <div
+        className="gg-timeline-drop-insert"
+        data-testid="timeline-drop-insert"
+        style={{ left: `${toPercent(target.boundarySeconds, durationSeconds)}%` }}
+      />
+    );
+  }
+
+  const gap = lanes
+    .find((lane) => lane.id === "video")
+    ?.clips.find((clip) => clip.id === target.gapId && clip.semantic === "gap");
+  if (!gap) {
+    return null;
+  }
+
+  const left = toPercent(gap.startSeconds, durationSeconds);
+  const width = toPercent(gap.endSeconds, durationSeconds) - left;
+  return (
+    <div
+      className="gg-timeline-drop-gap"
+      data-testid="timeline-drop-gap"
+      style={{ left: `${left}%`, width: `${Math.max(width, 0)}%` }}
+    />
+  );
+}
+
 export function TimelineSurface({
   durationSeconds,
   trimEnabled = false,
@@ -695,6 +989,7 @@ export function TimelineSurface({
   zoomPercent,
   timelineTool,
   timelineSnapEnabled,
+  timelineRippleEnabled,
   lanes,
   laneControls,
   labels,
@@ -707,6 +1002,7 @@ export function TimelineSurface({
   onToggleLaneSolo,
   onClearSelection,
   onBladeClipAtSeconds,
+  onMoveClipDrop,
   selectedClip,
   selectedMarkerId,
   onSelectClip,
@@ -718,14 +1014,22 @@ export function TimelineSurface({
     onSurfacePointerDown,
     onSurfacePointerMove,
     onSurfacePointerUp,
+    onClipPointerDown,
     onTrimHandlePointerDown,
+    shouldSuppressClipClick,
+    clipDropTarget,
+    isClipDragging,
   } = useTimelineDragController({
     durationSeconds,
+    lanes,
+    timelineRippleEnabled,
+    timelineTool,
     trackOverlayRef,
     onSetPlayheadSeconds,
     onSetTrimStartSeconds,
     onSetTrimEndSeconds,
     onClearSelection,
+    onMoveClipDrop,
   });
 
   const effectiveTrimStart = trimEnabled ? (trimStartSeconds ?? 0) : 0;
@@ -758,7 +1062,9 @@ export function TimelineSurface({
 
       <div className="gg-timeline-scroll">
         <div
-          className={`gg-timeline-surface gg-timeline-tool-${timelineTool}`}
+          className={`gg-timeline-surface gg-timeline-tool-${timelineTool}${
+            isClipDragging && clipDropTarget.kind === "none" ? " gg-timeline-drop-invalid" : ""
+          }`}
           style={{ minWidth: `${Math.max(100, zoomPercent)}%` }}
           tabIndex={0}
           role="group"
@@ -793,6 +1099,8 @@ export function TimelineSurface({
             onSelectClip={onSelectClip}
             onSelectMarker={onSelectMarker}
             onBladeClipAtSeconds={onBladeClipAtSeconds}
+            onClipPointerDown={onClipPointerDown}
+            shouldSuppressClipClick={shouldSuppressClipClick}
             timelineTool={timelineTool}
           />
           <TimelineOverlay
@@ -809,6 +1117,9 @@ export function TimelineSurface({
             onSetTrimStartSeconds={onSetTrimStartSeconds}
             onSetTrimEndSeconds={onSetTrimEndSeconds}
             onTrimHandlePointerDown={trimEnabled ? onTrimHandlePointerDown : undefined}
+            clipDropTarget={clipDropTarget}
+            isClipDragging={isClipDragging}
+            lanes={lanes}
           />
         </div>
       </div>

--- a/apps/desktop-electrobun/src/mainview/index.css
+++ b/apps/desktop-electrobun/src/mainview/index.css
@@ -569,6 +569,23 @@
     right: 0;
   }
 
+  .gg-timeline-drop-invalid {
+    box-shadow: inset 0 0 0 1px color-mix(in oklab, var(--destructive) 42%, transparent);
+  }
+
+  .gg-timeline-drop-insert {
+    @apply pointer-events-none absolute inset-y-0 z-30 w-0.5 rounded-full;
+    background-color: color-mix(in oklab, var(--primary) 86%, white 8%);
+    box-shadow: 0 0 0 3px color-mix(in oklab, var(--primary) 18%, transparent);
+    transform: translateX(-50%);
+  }
+
+  .gg-timeline-drop-gap {
+    @apply pointer-events-none absolute inset-y-0 z-20 rounded-md;
+    background-color: color-mix(in oklab, var(--primary) 18%, transparent);
+    box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--primary) 72%, transparent);
+  }
+
   .gg-timeline-lane-label-group {
     @apply flex h-full items-center justify-between gap-2 px-3 py-1;
     background-color: color-mix(in oklab, var(--gg-surface-1) 24%, transparent);
@@ -642,6 +659,25 @@
       color-mix(in oklab, var(--gg-tone-selected-alt) 44%, transparent),
       color-mix(in oklab, var(--gg-tone-selected-alt) 30%, black 14%)
     );
+  }
+
+  .gg-timeline-clip-semantic-gap {
+    border: 1px dashed color-mix(in oklab, var(--foreground) 20%, transparent);
+    background: repeating-linear-gradient(
+      135deg,
+      color-mix(in oklab, var(--foreground) 6%, transparent) 0,
+      color-mix(in oklab, var(--foreground) 6%, transparent) 6px,
+      color-mix(in oklab, var(--gg-surface-0) 72%, transparent) 6px,
+      color-mix(in oklab, var(--gg-surface-0) 72%, transparent) 12px
+    );
+  }
+
+  .gg-timeline-clip-semantic-gap .gg-timeline-clip-content {
+    opacity: 0.72;
+  }
+
+  .gg-timeline-clip:not(.gg-timeline-clip-semantic-gap):active {
+    cursor: grabbing;
   }
 
   .gg-timeline-clip-content {

--- a/apps/desktop-electrobun/src/shared/localization.ts
+++ b/apps/desktop-electrobun/src/shared/localization.ts
@@ -217,6 +217,11 @@ export function getStudioMessages(locale: string | null | undefined) {
           { laneLabel, startSeconds: startSeconds.toFixed(2), endSeconds: endSeconds.toFixed(2) },
           options,
         ),
+      timelineGapAria: (laneLabel: string, startSeconds: number, endSeconds: number) =>
+        m.studio_labels_timelineGapAria(
+          { laneLabel, startSeconds: startSeconds.toFixed(2), endSeconds: endSeconds.toFixed(2) },
+          options,
+        ),
       timelineMarkerAria: (markerKindLabel: string, timestampSeconds: number) =>
         m.studio_labels_timelineMarkerAria(
           { markerKindLabel, timestampSeconds: timestampSeconds.toFixed(2) },

--- a/apps/desktop-electrobun/tests/playback-clock-source.test.ts
+++ b/apps/desktop-electrobun/tests/playback-clock-source.test.ts
@@ -27,7 +27,7 @@ describe("video playback clock source", () => {
     const source = await readFile(playbackSyncPath, "utf8");
 
     expect(source).toContain(
-      'if (boundaryResolution.kind === "gap") {\n          media.pause();\n          setPlayheadSecondsFromMedia(boundarySeconds);',
+      'if (boundaryResolution.kind === "gap") {\n          media.pause();\n          media.style.visibility = "hidden";\n          setPlayheadSecondsFromMedia(boundarySeconds);',
     );
   });
 });

--- a/apps/desktop-electrobun/tests/timeline-commands.test.ts
+++ b/apps/desktop-electrobun/tests/timeline-commands.test.ts
@@ -289,6 +289,122 @@ describe("timeline commands", () => {
     ]);
   });
 
+  test("non-ripple move into an adjacent gap preserves timing and the destination", () => {
+    const timeline = makeTimeline([
+      {
+        kind: "clip",
+        id: "clip-a",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 1,
+      },
+      { kind: "gap", id: "gap-target", durationSeconds: 2 },
+      {
+        kind: "clip",
+        id: "clip-b",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 1,
+        sourceEndSeconds: 2,
+      },
+    ]);
+
+    const result = moveTimelineItems(
+      timeline,
+      ["clip-a"],
+      {
+        ripple: false,
+        destinationGapId: "gap-target",
+        destinationOffsetSeconds: 1,
+      },
+      makeIdFactory(["gap-source", "gap-tail"]),
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.timeline.items).toEqual([
+      { kind: "gap", id: "gap-source", durationSeconds: 2 },
+      timeline.items[0],
+      timeline.items[2],
+    ]);
+  });
+
+  test("non-ripple move left into an adjacent gap preserves the source space", () => {
+    const timeline = makeTimeline([
+      {
+        kind: "clip",
+        id: "clip-a",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 1,
+      },
+      { kind: "gap", id: "gap-target", durationSeconds: 2 },
+      {
+        kind: "clip",
+        id: "clip-b",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 1,
+        sourceEndSeconds: 2,
+      },
+    ]);
+
+    const result = moveTimelineItems(
+      timeline,
+      ["clip-b"],
+      {
+        ripple: false,
+        destinationGapId: "gap-target",
+        destinationOffsetSeconds: 0,
+      },
+      makeIdFactory(["gap-source"]),
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.timeline.items).toEqual([
+      timeline.items[0],
+      timeline.items[2],
+      { kind: "gap", id: "gap-target", durationSeconds: 2 },
+    ]);
+  });
+
+  test("non-ripple move splits a destination gap around the moved clip", () => {
+    const timeline = makeTimeline([
+      {
+        kind: "clip",
+        id: "clip-a",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 1,
+      },
+      {
+        kind: "clip",
+        id: "clip-b",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 1,
+        sourceEndSeconds: 2,
+      },
+      { kind: "gap", id: "gap-target", durationSeconds: 3 },
+    ]);
+
+    const result = moveTimelineItems(
+      timeline,
+      ["clip-a"],
+      {
+        ripple: false,
+        destinationGapId: "gap-target",
+        destinationOffsetSeconds: 1,
+      },
+      makeIdFactory(["gap-source", "gap-tail"]),
+    );
+
+    expect(result.changed).toBe(true);
+    expect(result.timeline.items).toEqual([
+      { kind: "gap", id: "gap-source", durationSeconds: 1 },
+      timeline.items[1],
+      { kind: "gap", id: "gap-target", durationSeconds: 1 },
+      timeline.items[0],
+      { kind: "gap", id: "gap-tail", durationSeconds: 1 },
+    ]);
+  });
+
   test("non-ripple move no-ops when the destination gap is missing", () => {
     const timeline = makeTimeline([
       {

--- a/apps/desktop-electrobun/tests/timeline-commands.test.ts
+++ b/apps/desktop-electrobun/tests/timeline-commands.test.ts
@@ -200,6 +200,45 @@ describe("timeline commands", () => {
     expect(result.timeline.items.map((item) => item.id)).toEqual(["clip-b", "clip-c", "clip-a"]);
   });
 
+  test("ripple move can drop before the first item and after the last item", () => {
+    const timeline = makeTimeline([
+      {
+        kind: "clip",
+        id: "clip-a",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 1,
+      },
+      {
+        kind: "clip",
+        id: "clip-b",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 1,
+        sourceEndSeconds: 2,
+      },
+      {
+        kind: "clip",
+        id: "clip-c",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 2,
+        sourceEndSeconds: 3,
+      },
+    ]);
+
+    expect(
+      moveTimelineItems(timeline, ["clip-c"], {
+        ripple: true,
+        destinationIndex: 0,
+      }).timeline.items.map((item) => item.id),
+    ).toEqual(["clip-c", "clip-a", "clip-b"]);
+    expect(
+      moveTimelineItems(timeline, ["clip-a"], {
+        ripple: true,
+        destinationIndex: 3,
+      }).timeline.items.map((item) => item.id),
+    ).toEqual(["clip-b", "clip-c", "clip-a"]);
+  });
+
   test("non-ripple move consumes destination gap and leaves source timing behind", () => {
     const timeline = makeTimeline([
       {
@@ -248,5 +287,57 @@ describe("timeline commands", () => {
         durationSeconds: 1,
       },
     ]);
+  });
+
+  test("non-ripple move no-ops when the destination gap is missing", () => {
+    const timeline = makeTimeline([
+      {
+        kind: "clip",
+        id: "clip-a",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 1,
+      },
+      {
+        kind: "clip",
+        id: "clip-b",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 1,
+        sourceEndSeconds: 2,
+      },
+    ]);
+
+    const result = moveTimelineItems(timeline, ["clip-a"], {
+      ripple: false,
+      destinationGapId: "missing-gap",
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.timeline).toBe(timeline);
+  });
+
+  test("non-ripple move no-ops when the destination gap is too small", () => {
+    const timeline = makeTimeline([
+      {
+        kind: "clip",
+        id: "clip-a",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 3,
+      },
+      {
+        kind: "gap",
+        id: "gap-target",
+        durationSeconds: 1,
+      },
+    ]);
+
+    const result = moveTimelineItems(timeline, ["clip-a"], {
+      ripple: false,
+      destinationGapId: "gap-target",
+    });
+
+    expect(result.changed).toBe(false);
+    expect(result.timeline).toBe(timeline);
   });
 });

--- a/apps/desktop-electrobun/tests/ui/editor-export-timeline.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/editor-export-timeline.browser.test.tsx
@@ -162,6 +162,106 @@ afterEach(() => {
 });
 
 describe("editor timeline export integration", () => {
+  test("drag-drop ripple move commits order, clears selection, moves playhead, and exports", async () => {
+    await waitFor(() =>
+      expect(latestStudio?.timelineDocument.items).toEqual(initialTimeline.items),
+    );
+    await applyStudioAction((studio) => studio.splitTimelineClipAtSeconds(1));
+    await waitFor(() => expect(latestStudio?.timelineDocument.items).toHaveLength(2));
+
+    const movedClip = latestStudio!.timelineDocument.items[0];
+    expect(movedClip?.kind).toBe("clip");
+    await applyStudioAction((studio) => {
+      studio.selectTimelineClip({
+        laneId: "video",
+        clipId: movedClip.id,
+        startSeconds: 0,
+        endSeconds: 1,
+      });
+    });
+    await waitFor(() => expect(latestStudio?.inspectorSelection).not.toBeNull());
+    await applyStudioAction((studio) =>
+      studio.moveTimelineClipByDrop({ clipId: movedClip.id, destinationIndex: 2 }),
+    );
+
+    await waitFor(() => {
+      expect(latestStudio?.timelineDocument.items.map((item) => item.id)).toEqual([
+        expect.not.stringMatching(movedClip.id),
+        movedClip.id,
+      ]);
+      expect(latestStudio?.inspectorSelection).toEqual({ kind: "none" });
+      expect(latestStudio?.playbackStore.getSnapshot().playheadSeconds).toBe(3);
+    });
+
+    await applyStudioAction(async (studio) => studio.exportMutation.mutateAsync());
+    expect((capturedExportParams as { timeline: TimelineDocument }).timeline).toEqual(
+      latestStudio!.timelineDocument,
+    );
+  });
+
+  test("drag-drop non-ripple move splits gaps and synchronizes selection and playhead", async () => {
+    await waitFor(() =>
+      expect(latestStudio?.timelineDocument.items).toEqual(initialTimeline.items),
+    );
+    await applyStudioAction((studio) => studio.splitTimelineClipAtSeconds(1));
+    await waitFor(() => expect(latestStudio?.timelineDocument.items).toHaveLength(2));
+
+    const liftedClip = latestStudio!.timelineDocument.items[1];
+    await applyStudioAction((studio) => {
+      studio.selectTimelineClip({
+        laneId: "video",
+        clipId: liftedClip.id,
+        startSeconds: 1,
+        endSeconds: 4,
+      });
+    });
+    await applyStudioAction((studio) => studio.liftSelectedTimelineClip());
+    await waitFor(() =>
+      expect(latestStudio?.timelineDocument.items.map((item) => item.kind)).toEqual([
+        "clip",
+        "gap",
+      ]),
+    );
+    await applyStudioAction((studio) => studio.splitTimelineClipAtSeconds(0.5));
+    await waitFor(() => expect(latestStudio?.timelineDocument.items).toHaveLength(3));
+
+    const movedClip = latestStudio!.timelineDocument.items[1];
+    const destinationGap = latestStudio!.timelineDocument.items[2];
+    expect(movedClip?.kind).toBe("clip");
+    expect(destinationGap?.kind).toBe("gap");
+    await applyStudioAction((studio) => {
+      studio.selectTimelineClip({
+        laneId: "video",
+        clipId: movedClip.id,
+        startSeconds: 0.5,
+        endSeconds: 1,
+      });
+    });
+    await applyStudioAction((studio) =>
+      studio.moveTimelineClipByDrop({
+        clipId: movedClip.id,
+        destinationGapId: destinationGap.id,
+        destinationOffsetSeconds: 1,
+      }),
+    );
+
+    await waitFor(() => {
+      expect(latestStudio?.timelineDocument.items.map((item) => item.kind)).toEqual([
+        "clip",
+        "gap",
+        "clip",
+        "gap",
+      ]);
+      expect(latestStudio?.inspectorSelection).toEqual({ kind: "none" });
+      expect(latestStudio?.playbackStore.getSnapshot().playheadSeconds).toBe(2);
+    });
+
+    await applyStudioAction(async (studio) => studio.exportMutation.mutateAsync());
+    expect((capturedExportParams as { timeline: TimelineDocument }).timeline).toEqual(
+      latestStudio!.timelineDocument,
+    );
+  });
+
   test("exports the timeline produced by split, lift, move, and delete controller actions", async () => {
     await waitFor(() => {
       expect(latestStudio?.timelineDocument.items).toEqual(initialTimeline.items);

--- a/apps/desktop-electrobun/tests/ui/timeline-drag-move.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/timeline-drag-move.browser.test.tsx
@@ -27,12 +27,14 @@ const labels = {
   timelineMarkerMixed: "Mixed",
   timelineClipAria: (laneLabel: string, startSeconds: number, endSeconds: number) =>
     `${laneLabel} clip ${startSeconds}-${endSeconds}`,
+  timelineGapAria: (laneLabel: string, startSeconds: number, endSeconds: number) =>
+    `${laneLabel} gap ${startSeconds}-${endSeconds}`,
   timelineMarkerAria: (markerKindLabel: string, timestampSeconds: number) =>
     `${markerKindLabel} marker ${timestampSeconds}`,
 };
 
-function makeLanes(): TimelineLane[] {
-  const clips = [
+function makeLanes(clips?: TimelineLane["clips"]): TimelineLane[] {
+  const resolvedClips = clips ?? [
     {
       id: "clip-a",
       startSeconds: 0,
@@ -62,11 +64,14 @@ function makeLanes(): TimelineLane[] {
     },
   ];
   return [
-    { id: "video", label: "Video", clips, markers: [] },
+    { id: "video", label: "Video", clips: resolvedClips, markers: [] },
     {
       id: "audio",
       label: "Audio",
-      clips: clips.map((clip) => ({ ...clip, semantic: clip.semantic === "gap" ? "gap" : "mix" })),
+      clips: resolvedClips.map((clip) => ({
+        ...clip,
+        semantic: clip.semantic === "gap" ? "gap" : "mix",
+      })),
       markers: [],
     },
     { id: "events", label: "Events", clips: [], markers: [] },
@@ -92,6 +97,8 @@ function renderSurface(
   options?: {
     laneLocked?: boolean;
     timelineTool?: "select" | "trim" | "blade";
+    lanes?: TimelineLane[];
+    onClearSelection?: () => void;
     onSelectClip?: () => void;
   },
 ) {
@@ -106,7 +113,7 @@ function renderSurface(
           timelineTool={options?.timelineTool ?? "select"}
           timelineSnapEnabled={true}
           timelineRippleEnabled={timelineRippleEnabled}
-          lanes={makeLanes()}
+          lanes={options?.lanes ?? makeLanes()}
           laneControls={{
             video: { locked: options?.laneLocked ?? false, muted: false, solo: false },
             audio: { locked: false, muted: false, solo: false },
@@ -117,7 +124,7 @@ function renderSurface(
           onToggleLaneLocked={() => {}}
           onToggleLaneMuted={() => {}}
           onToggleLaneSolo={() => {}}
-          onClearSelection={() => {}}
+          onClearSelection={options?.onClearSelection ?? (() => {})}
           onMoveClipDrop={(params) => {
             receivedDrop = params;
           }}
@@ -199,15 +206,110 @@ describe("timeline clip drag move", () => {
 
     dragFirstVideoClip(120, 520);
 
-    expect(receivedDrop).toEqual({ clipId: "clip-a", destinationGapId: "gap-a" });
+    expect(receivedDrop).toEqual({
+      clipId: "clip-a",
+      destinationGapId: "gap-a",
+      destinationOffsetSeconds: 0,
+    });
   });
 
   test("non-ripple drag resolves a nearby gap boundary", () => {
     renderSurface(false);
 
-    dragFirstVideoClip(120, 402);
+    dragFirstVideoClip(100, 402);
 
-    expect(receivedDrop).toEqual({ clipId: "clip-a", destinationGapId: "gap-a" });
+    expect(receivedDrop).toEqual({
+      clipId: "clip-a",
+      destinationGapId: "gap-a",
+      destinationOffsetSeconds: 0,
+    });
+  });
+
+  test("non-ripple drag preserves the drop offset inside a larger gap", () => {
+    renderSurface(false, {
+      lanes: makeLanes([
+        {
+          id: "clip-a",
+          startSeconds: 0,
+          endSeconds: 0.5,
+          sourceStartSeconds: 0,
+          sourceEndSeconds: 0.5,
+          semantic: "screen",
+          waveform: null,
+        },
+        {
+          id: "gap-a",
+          startSeconds: 0.5,
+          endSeconds: 2.5,
+          sourceStartSeconds: 0,
+          sourceEndSeconds: 0,
+          semantic: "gap",
+          waveform: null,
+        },
+        {
+          id: "clip-b",
+          startSeconds: 2.5,
+          endSeconds: 3,
+          sourceStartSeconds: 0.5,
+          sourceEndSeconds: 1,
+          semantic: "screen",
+          waveform: null,
+        },
+      ]),
+    });
+
+    dragFirstVideoClip(120, 550);
+
+    expect(receivedDrop).toMatchObject({
+      clipId: "clip-a",
+      destinationGapId: "gap-a",
+    });
+    expect(
+      (receivedDrop as Extract<MoveDropParams, { destinationGapId: string }>)
+        .destinationOffsetSeconds,
+    ).toBeCloseTo(0.967, 3);
+  });
+
+  test("a too-small gap renders an invalid target and does not dispatch", () => {
+    renderSurface(false, {
+      lanes: makeLanes([
+        {
+          id: "clip-a",
+          startSeconds: 0,
+          endSeconds: 1.5,
+          sourceStartSeconds: 0,
+          sourceEndSeconds: 1.5,
+          semantic: "screen",
+          waveform: null,
+        },
+        {
+          id: "gap-a",
+          startSeconds: 1.5,
+          endSeconds: 2,
+          sourceStartSeconds: 0,
+          sourceEndSeconds: 0,
+          semantic: "gap",
+          waveform: null,
+        },
+        {
+          id: "clip-b",
+          startSeconds: 2,
+          endSeconds: 3,
+          sourceStartSeconds: 1.5,
+          sourceEndSeconds: 2.5,
+          semantic: "screen",
+          waveform: null,
+        },
+      ]),
+    });
+
+    moveFirstVideoClipWithoutRelease(120, 600);
+
+    expect(document.querySelector(".gg-timeline-drop-invalid")).not.toBeNull();
+    act(() => {
+      document.querySelector(".gg-timeline-surface")?.dispatchEvent(pointer("pointerup", 600));
+    });
+    expect(receivedDrop).toBeNull();
   });
 
   test("non-ripple drag outside gaps is invalid and does not move", () => {
@@ -245,6 +347,37 @@ describe("timeline clip drag move", () => {
     });
 
     expect(receivedDrop).toBeNull();
+  });
+
+  test("Blade and Select gap clicks clear selection without selecting or splitting", () => {
+    let clearedCount = 0;
+    let selectedCount = 0;
+    for (const timelineTool of ["blade", "select"] as const) {
+      renderSurface(false, {
+        timelineTool,
+        onClearSelection: () => {
+          clearedCount += 1;
+        },
+        onSelectClip: () => {
+          selectedCount += 1;
+        },
+      });
+      const gap = document.querySelector(".gg-timeline-clip-video.gg-timeline-clip-semantic-gap");
+      act(() => {
+        gap?.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+      });
+    }
+
+    expect(clearedCount).toBe(2);
+    expect(selectedCount).toBe(0);
+  });
+
+  test("gap accessibility text identifies the item as a gap", () => {
+    renderSurface(false);
+
+    expect(
+      document.querySelector(".gg-timeline-clip-video.gg-timeline-clip-semantic-gap"),
+    ).toHaveAttribute("aria-label", "Video gap 1-2");
   });
 
   test("dragging suppresses the follow-up clip click", () => {

--- a/apps/desktop-electrobun/tests/ui/timeline-drag-move.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/timeline-drag-move.browser.test.tsx
@@ -1,0 +1,279 @@
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import type { TimelineLane } from "../../src/mainview/app/studio/domain/timelineDomainModel";
+import { createPlaybackTransportStore } from "../../src/mainview/app/studio/hooks/timeline/usePlaybackTransport";
+import type { StudioController } from "../../src/mainview/app/studio/hooks/core/useStudioController";
+import { StudioProvider } from "../../src/mainview/app/studio/state/StudioProvider";
+import { TimelineSurface } from "../../src/mainview/app/studio/panels/TimelineSurface";
+
+type MoveDropParams = Parameters<
+  NonNullable<Parameters<typeof TimelineSurface>[0]["onMoveClipDrop"]>
+>[0];
+
+const labels = {
+  playhead: "Playhead",
+  trimInSeconds: "Trim in",
+  trimOutSeconds: "Trim out",
+  timelineTools: "Timeline tools",
+  timelineSnap: "Snap",
+  timelineRipple: "Ripple",
+  timelineZoom: "Zoom",
+  timelineLaneLock: "Lock lane",
+  timelineLaneMute: "Mute lane",
+  timelineLaneSolo: "Solo lane",
+  timelineMarkerMove: "Move",
+  timelineMarkerClick: "Click",
+  timelineMarkerMixed: "Mixed",
+  timelineClipAria: (laneLabel: string, startSeconds: number, endSeconds: number) =>
+    `${laneLabel} clip ${startSeconds}-${endSeconds}`,
+  timelineMarkerAria: (markerKindLabel: string, timestampSeconds: number) =>
+    `${markerKindLabel} marker ${timestampSeconds}`,
+};
+
+function makeLanes(): TimelineLane[] {
+  const clips = [
+    {
+      id: "clip-a",
+      startSeconds: 0,
+      endSeconds: 1,
+      sourceStartSeconds: 0,
+      sourceEndSeconds: 1,
+      semantic: "screen" as const,
+      waveform: null,
+    },
+    {
+      id: "gap-a",
+      startSeconds: 1,
+      endSeconds: 2,
+      sourceStartSeconds: 0,
+      sourceEndSeconds: 0,
+      semantic: "gap" as const,
+      waveform: null,
+    },
+    {
+      id: "clip-b",
+      startSeconds: 2,
+      endSeconds: 3,
+      sourceStartSeconds: 2,
+      sourceEndSeconds: 3,
+      semantic: "screen" as const,
+      waveform: null,
+    },
+  ];
+  return [
+    { id: "video", label: "Video", clips, markers: [] },
+    {
+      id: "audio",
+      label: "Audio",
+      clips: clips.map((clip) => ({ ...clip, semantic: clip.semantic === "gap" ? "gap" : "mix" })),
+      markers: [],
+    },
+    { id: "events", label: "Events", clips: [], markers: [] },
+  ];
+}
+
+function pointer(type: string, clientX: number): PointerEvent {
+  return new PointerEvent(type, {
+    bubbles: true,
+    cancelable: true,
+    clientX,
+    pointerId: 1,
+    pointerType: "mouse",
+  });
+}
+
+let root: Root | undefined;
+let receivedDrop: MoveDropParams | null = null;
+let originalGetBoundingClientRect: typeof Element.prototype.getBoundingClientRect;
+
+function renderSurface(
+  timelineRippleEnabled: boolean,
+  options?: {
+    laneLocked?: boolean;
+    timelineTool?: "select" | "trim" | "blade";
+    onSelectClip?: () => void;
+  },
+) {
+  const playbackStore = createPlaybackTransportStore({ durationSeconds: 3, frameRate: 30 });
+  const studio = { playbackStore } as unknown as StudioController;
+  act(() => {
+    root?.render(
+      <StudioProvider value={studio}>
+        <TimelineSurface
+          durationSeconds={3}
+          zoomPercent={100}
+          timelineTool={options?.timelineTool ?? "select"}
+          timelineSnapEnabled={true}
+          timelineRippleEnabled={timelineRippleEnabled}
+          lanes={makeLanes()}
+          laneControls={{
+            video: { locked: options?.laneLocked ?? false, muted: false, solo: false },
+            audio: { locked: false, muted: false, solo: false },
+          }}
+          labels={labels}
+          onSetPlayheadSeconds={() => {}}
+          onNudgePlayheadSeconds={() => {}}
+          onToggleLaneLocked={() => {}}
+          onToggleLaneMuted={() => {}}
+          onToggleLaneSolo={() => {}}
+          onClearSelection={() => {}}
+          onMoveClipDrop={(params) => {
+            receivedDrop = params;
+          }}
+          selectedClip={null}
+          selectedMarkerId={null}
+          onSelectClip={options?.onSelectClip ?? (() => {})}
+          onSelectMarker={() => {}}
+        />
+      </StudioProvider>,
+    );
+  });
+}
+
+function getTimelineDragElements() {
+  const rootElement = document.getElementById("root");
+  const surface = rootElement?.querySelector(".gg-timeline-surface");
+  const clip = rootElement?.querySelector(
+    ".gg-timeline-clip-video.gg-timeline-clip-semantic-screen",
+  );
+  if (!surface || !clip) {
+    throw new Error("Timeline drag fixture did not render");
+  }
+  return { clip, surface };
+}
+
+function dragFirstVideoClip(fromClientX: number, toClientX: number) {
+  const { clip, surface } = getTimelineDragElements();
+
+  act(() => {
+    clip.dispatchEvent(pointer("pointerdown", fromClientX));
+    surface.dispatchEvent(pointer("pointermove", toClientX));
+    surface.dispatchEvent(pointer("pointerup", toClientX));
+  });
+}
+
+function moveFirstVideoClipWithoutRelease(fromClientX: number, toClientX: number) {
+  const { clip, surface } = getTimelineDragElements();
+
+  act(() => {
+    clip.dispatchEvent(pointer("pointerdown", fromClientX));
+    surface.dispatchEvent(pointer("pointermove", toClientX));
+  });
+}
+
+beforeEach(() => {
+  receivedDrop = null;
+  document.body.innerHTML = '<div id="root"></div>';
+  root = createRoot(document.getElementById("root")!);
+  originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function () {
+    if ((this as Element).classList.contains("gg-timeline-track-overlay")) {
+      return DOMRect.fromRect({ x: 100, y: 0, width: 900, height: 120 });
+    }
+    if ((this as Element).classList.contains("gg-timeline-clip")) {
+      return DOMRect.fromRect({ x: 100, y: 0, width: 300, height: 48 });
+    }
+    return originalGetBoundingClientRect.call(this);
+  };
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+  document.body.innerHTML = "";
+});
+
+describe("timeline clip drag move", () => {
+  test("ripple drag resolves an insertion destination index", () => {
+    renderSurface(true);
+
+    dragFirstVideoClip(120, 980);
+
+    expect(receivedDrop).toEqual({ clipId: "clip-a", destinationIndex: 3 });
+  });
+
+  test("non-ripple drag resolves a destination gap", () => {
+    renderSurface(false);
+
+    dragFirstVideoClip(120, 520);
+
+    expect(receivedDrop).toEqual({ clipId: "clip-a", destinationGapId: "gap-a" });
+  });
+
+  test("non-ripple drag resolves a nearby gap boundary", () => {
+    renderSurface(false);
+
+    dragFirstVideoClip(120, 402);
+
+    expect(receivedDrop).toEqual({ clipId: "clip-a", destinationGapId: "gap-a" });
+  });
+
+  test("non-ripple drag outside gaps is invalid and does not move", () => {
+    renderSurface(false);
+
+    moveFirstVideoClipWithoutRelease(120, 850);
+
+    expect(document.querySelector(".gg-timeline-drop-invalid")).not.toBeNull();
+    act(() => {
+      document.querySelector(".gg-timeline-surface")?.dispatchEvent(pointer("pointerup", 850));
+    });
+    expect(receivedDrop).toBeNull();
+  });
+
+  test("locked lanes block clip drag", () => {
+    renderSurface(true, { laneLocked: true });
+
+    dragFirstVideoClip(120, 980);
+
+    expect(receivedDrop).toBeNull();
+  });
+
+  test("gap items are not draggable", () => {
+    renderSurface(true);
+    const surface = document.querySelector(".gg-timeline-surface");
+    const gap = document.querySelector(".gg-timeline-clip-video.gg-timeline-clip-semantic-gap");
+    if (!surface || !gap) {
+      throw new Error("Timeline gap drag fixture did not render");
+    }
+
+    act(() => {
+      gap.dispatchEvent(pointer("pointerdown", 420));
+      surface.dispatchEvent(pointer("pointermove", 980));
+      surface.dispatchEvent(pointer("pointerup", 980));
+    });
+
+    expect(receivedDrop).toBeNull();
+  });
+
+  test("dragging suppresses the follow-up clip click", () => {
+    let selectedCount = 0;
+    renderSurface(true, {
+      onSelectClip: () => {
+        selectedCount += 1;
+      },
+    });
+    const { clip } = getTimelineDragElements();
+
+    dragFirstVideoClip(120, 980);
+    act(() => {
+      clip.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    });
+
+    expect(receivedDrop).toEqual({ clipId: "clip-a", destinationIndex: 3 });
+    expect(selectedCount).toBe(0);
+  });
+
+  test("dragging renders drop affordances at the resolved insert boundary", () => {
+    renderSurface(true);
+
+    moveFirstVideoClipWithoutRelease(120, 980);
+
+    const insertAffordance = document.querySelector<HTMLElement>(
+      "[data-testid='timeline-drop-insert']",
+    );
+    expect(insertAffordance).not.toBeNull();
+    expect(insertAffordance?.style.left).toBe("100%");
+  });
+});

--- a/apps/desktop-electrobun/tests/ui/video-playback-gaps.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/video-playback-gaps.browser.test.tsx
@@ -1,0 +1,246 @@
+import { act, useRef } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { compileTimelineItems } from "../../src/mainview/app/studio/domain/timelineDomainModel";
+import { useVideoPlaybackSync } from "../../src/mainview/app/studio/hooks/useVideoPlaybackSync";
+import { createPlaybackTransportStore } from "../../src/mainview/app/studio/hooks/timeline/usePlaybackTransport";
+
+const timelineItems = compileTimelineItems({
+  version: 2,
+  items: [
+    { kind: "gap", id: "leading", durationSeconds: 0.5 },
+    {
+      kind: "clip",
+      id: "clip-a",
+      sourceAssetId: "recording",
+      sourceStartSeconds: 0,
+      sourceEndSeconds: 1,
+    },
+    { kind: "gap", id: "middle", durationSeconds: 1 },
+    {
+      kind: "clip",
+      id: "clip-b",
+      sourceAssetId: "recording",
+      sourceStartSeconds: 1,
+      sourceEndSeconds: 2,
+    },
+    { kind: "gap", id: "trailing", durationSeconds: 0.5 },
+  ],
+});
+const timelineDuration = 4;
+
+let root: Root | undefined;
+let now = 0;
+let nextFrame: FrameRequestCallback | null = null;
+const playbackStore = createPlaybackTransportStore({
+  durationSeconds: timelineDuration,
+  frameRate: 30,
+});
+
+function Harness({
+  items = timelineItems,
+  duration = timelineDuration,
+}: {
+  items?: typeof timelineItems;
+  duration?: number;
+}) {
+  const mediaRef = useRef<HTMLVideoElement>(null);
+  useVideoPlaybackSync({
+    mediaRef,
+    playbackStore,
+    recordingMediaSource: "recording",
+    timelineItems: items,
+    timelineDuration: duration,
+    setTimelinePlaybackActive: (active) => (active ? playbackStore.play() : playbackStore.pause()),
+    setDisplayPlayheadSecondsFromMedia: playbackStore.setDisplayTimeSeconds,
+    setPlayheadSecondsFromMedia: playbackStore.seek,
+  });
+  return <video ref={mediaRef} />;
+}
+
+function runFrame(atMs: number) {
+  const frame = nextFrame;
+  if (!frame) {
+    throw new Error("Playback frame was not scheduled");
+  }
+  nextFrame = null;
+  now = atMs;
+  act(() => frame(atMs));
+}
+
+beforeEach(() => {
+  (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  now = 0;
+  nextFrame = null;
+  playbackStore.pause();
+  playbackStore.updateConfig({ durationSeconds: timelineDuration, frameRate: 30 });
+  playbackStore.seek(0);
+  vi.spyOn(performance, "now").mockImplementation(() => now);
+  vi.stubGlobal("requestAnimationFrame", (callback: FrameRequestCallback) => {
+    nextFrame = callback;
+    return 1;
+  });
+  vi.stubGlobal("cancelAnimationFrame", () => {
+    nextFrame = null;
+  });
+  document.body.innerHTML = '<div id="root"></div>';
+  root = createRoot(document.getElementById("root")!);
+  act(() => root?.render(<Harness />));
+  const media = document.querySelector("video")!;
+  vi.spyOn(media, "play").mockResolvedValue(undefined);
+  vi.spyOn(media, "pause").mockImplementation(() => {});
+});
+
+afterEach(() => {
+  act(() => root?.unmount());
+  root = undefined;
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  document.body.innerHTML = "";
+});
+
+describe("timeline preview across gaps", () => {
+  test("paused seeks into a gap hide the media without remapping source time", () => {
+    const media = document.querySelector("video")!;
+    media.currentTime = 0.25;
+
+    act(() => playbackStore.seek(2));
+
+    expect(media.style.visibility).toBe("hidden");
+    expect(media.currentTime).toBe(0.25);
+  });
+
+  test("leading gap advances into a clip, seeks its source, and resumes preview", () => {
+    const media = document.querySelector("video")!;
+    act(() => playbackStore.play());
+
+    runFrame(600);
+    runFrame(600);
+
+    expect(playbackStore.getSnapshot().playheadSeconds).toBeCloseTo(0.6);
+    expect(media.currentTime).toBeCloseTo(0.1);
+    expect(media.style.visibility).toBe("");
+    expect(media.play).toHaveBeenCalled();
+  });
+
+  test("clip to interstitial gap hides media, then gap to clip seeks and resumes", () => {
+    const media = document.querySelector("video")!;
+    media.currentTime = 0.99;
+    act(() => {
+      playbackStore.seek(1.49);
+      playbackStore.play();
+    });
+
+    runFrame(20);
+    expect(playbackStore.getSnapshot().playheadSeconds).toBeCloseTo(1.5);
+    expect(media.style.visibility).toBe("hidden");
+
+    runFrame(1020);
+    runFrame(1020);
+    expect(playbackStore.getSnapshot().playheadSeconds).toBeCloseTo(2.5);
+    expect(media.currentTime).toBeCloseTo(1);
+    expect(media.style.visibility).toBe("");
+    expect(media.play).toHaveBeenCalled();
+  });
+
+  test("native source ended enters a remaining gap instead of ending the program", () => {
+    const media = document.querySelector("video")!;
+    act(() => playbackStore.seek(1.49));
+
+    act(() => media.dispatchEvent(new Event("ended")));
+
+    expect(playbackStore.getSnapshot().playheadSeconds).toBeCloseTo(1.5);
+    expect(playbackStore.getSnapshot().playheadSeconds).not.toBe(timelineDuration);
+    expect(media.style.visibility).toBe("hidden");
+  });
+
+  test("a queued native ended event at an exact gap boundary does not end the program", () => {
+    const media = document.querySelector("video")!;
+    act(() => playbackStore.seek(1.5));
+
+    act(() => media.dispatchEvent(new Event("ended")));
+
+    expect(playbackStore.getSnapshot().playheadSeconds).toBe(1.5);
+    expect(media.style.visibility).toBe("hidden");
+  });
+
+  test("native source ended seeks a following clip when no gap separates it", () => {
+    const directItems = compileTimelineItems({
+      version: 2,
+      items: [
+        {
+          kind: "clip",
+          id: "source-ending",
+          sourceAssetId: "recording",
+          sourceStartSeconds: 1,
+          sourceEndSeconds: 2,
+        },
+        {
+          kind: "clip",
+          id: "following",
+          sourceAssetId: "recording",
+          sourceStartSeconds: 0,
+          sourceEndSeconds: 1,
+        },
+      ],
+    });
+    playbackStore.updateConfig({ durationSeconds: 2, frameRate: 30 });
+    act(() => root?.render(<Harness items={directItems} duration={2} />));
+    const media = document.querySelector("video")!;
+    media.currentTime = 2;
+    act(() => playbackStore.seek(1));
+
+    act(() => media.dispatchEvent(new Event("ended")));
+
+    expect(playbackStore.getSnapshot().playheadSeconds).toBe(1);
+    expect(media.currentTime).toBe(0);
+    expect(media.play).toHaveBeenCalled();
+  });
+
+  test("a reordered timeline seeks paused preview through the recompiled source mapping", () => {
+    const reorderedItems = compileTimelineItems({
+      version: 2,
+      items: [
+        {
+          kind: "clip",
+          id: "second-source-first",
+          sourceAssetId: "recording",
+          sourceStartSeconds: 1,
+          sourceEndSeconds: 2,
+        },
+        {
+          kind: "clip",
+          id: "first-source-second",
+          sourceAssetId: "recording",
+          sourceStartSeconds: 0,
+          sourceEndSeconds: 1,
+        },
+      ],
+    });
+    playbackStore.updateConfig({ durationSeconds: 2, frameRate: 30 });
+    act(() => root?.render(<Harness items={reorderedItems} duration={2} />));
+    const media = document.querySelector("video")!;
+
+    act(() => playbackStore.seek(0.25));
+
+    expect(media.currentTime).toBeCloseTo(1.25);
+    expect(media.style.visibility).toBe("");
+  });
+
+  test("trailing gap advances for its full duration before playback stops", () => {
+    const media = document.querySelector("video")!;
+    media.currentTime = 1.99;
+    act(() => {
+      playbackStore.seek(3.49);
+      playbackStore.play();
+    });
+
+    runFrame(20);
+    expect(playbackStore.getSnapshot().playheadSeconds).toBeCloseTo(3.5);
+    expect(media.style.visibility).toBe("hidden");
+
+    runFrame(520);
+    expect(playbackStore.getSnapshot().playheadSeconds).toBe(4);
+    expect(playbackStore.getSnapshot().isPlaying).toBe(false);
+  });
+});

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -154,7 +154,12 @@ Editing depth checklist:
 - [x] Replace the synthetic single-clip timeline model with a real clip/gap item model.
 - [x] Implement pure clip split/delete/lift/move commands and make the ripple toggle behavior real in renderer state.
 - [x] Wire split/lift/delete/move inspector actions and Blade click-to-split to the timeline command layer.
-- [ ] Add drag-to-move timeline interactions with ripple-aware insert and conservative non-ripple gap/boundary moves.
+- [x] Add drag-to-move timeline interactions with ripple-aware insert and conservative non-ripple gap/boundary moves.
+  - Implementation notes:
+    - Timeline clips can be pointer-dragged in Select mode.
+    - Ripple-enabled drags resolve to insertion indexes and reuse the pure `moveTimelineItems` command path.
+    - Ripple-disabled drags are conservative and only resolve valid explicit gap destinations.
+    - Gap regions use a recessed dashed treatment so lift/non-ripple edit space is visible on the timeline.
 - [x] Make macOS export consume timeline v2 items so exported media matches editor split/delete/lift/move state.
   - Implementation notes:
     - macOS `export.run` parses `payload.timeline` v2 clip/gap items and builds an edited `AVMutableComposition` before export.
@@ -284,7 +289,7 @@ Progress (current repo)
 - [x] Pure split/delete/lift/move command layer implemented with unit coverage
 - [x] Inspector actions and Blade click-to-split wired to timeline commands
 - [x] macOS export applies timeline v2 edits, gaps, program-time trims, and camera-plan transforms
-- [ ] Drag-to-move timeline interaction implemented
+- [x] Drag-to-move timeline interaction implemented
 - [ ] Crop/reframe/redaction/highlight tools implemented
 - [ ] Transcript/caption editing baseline implemented
 - [ ] Windows native capture/audio/export parity milestones

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -158,8 +158,9 @@ Editing depth checklist:
   - Implementation notes:
     - Timeline clips can be pointer-dragged in Select mode.
     - Ripple-enabled drags resolve to insertion indexes and reuse the pure `moveTimelineItems` command path.
-    - Ripple-disabled drags are conservative and only resolve valid explicit gap destinations.
+    - Ripple-disabled drags resolve only gaps large enough for the clip, preserve the pointer grab offset, and split destination space around the moved clip.
     - Gap regions use a recessed dashed treatment so lift/non-ripple edit space is visible on the timeline.
+    - Browser coverage verifies leading, interstitial, and trailing gap preview; paused gap seeks; reordered source mapping; and native media-end transitions.
 - [x] Make macOS export consume timeline v2 items so exported media matches editor split/delete/lift/move state.
   - Implementation notes:
     - macOS `export.run` parses `payload.timeline` v2 clip/gap items and builds an edited `AVMutableComposition` before export.

--- a/engines/macos-swift/EngineMain.swift
+++ b/engines/macos-swift/EngineMain.swift
@@ -91,7 +91,9 @@ struct EngineHostOriginGuardMiddleware: ServerMiddleware {
 
     private func isAllowedOrigin(_ value: String?) -> Bool {
         guard let value, !value.isEmpty else { return true }
-        if value == "null" { return true }
+        if value == "null" {
+            return true
+        }
         guard let url = URL(string: value), url.scheme == "http" else { return false }
         let host = url.host(percentEncoded: false)?.lowercased()
         return host == "localhost" || host == "127.0.0.1" || host == "::1"

--- a/engines/macos-swift/EngineService+Agent.swift
+++ b/engines/macos-swift/EngineService+Agent.swift
@@ -171,9 +171,15 @@ extension EngineService {
         importedTranscriptPath: String?
     ) -> AgentPreflightEvaluation {
         var reasons: [Components.Schemas.AgentPreflightResult.blockingReasonsPayloadPayload] = []
-        if !(1 ... 10).contains(runtimeBudgetMinutes) { reasons.append(.invalid_runtime_budget) }
-        if currentProjectURL == nil { reasons.append(.missing_project) }
-        if availableAgentRecordingURL() == nil { reasons.append(.missing_recording) }
+        if !(1 ... 10).contains(runtimeBudgetMinutes) {
+            reasons.append(.invalid_runtime_budget)
+        }
+        if currentProjectURL == nil {
+            reasons.append(.missing_project)
+        }
+        if availableAgentRecordingURL() == nil {
+            reasons.append(.missing_recording)
+        }
         switch transcriptionProvider {
         case "imported_transcript":
             if importedTranscriptPath?.isEmpty ?? true {
@@ -292,10 +298,18 @@ extension EngineService {
         for coverage: AgentCoverage
     ) -> [Components.Schemas.AgentQAReport.missingBeatsPayloadPayload] {
         var missing: [Components.Schemas.AgentQAReport.missingBeatsPayloadPayload] = []
-        if !coverage.hook { missing.append(.hook) }
-        if !coverage.action { missing.append(.action) }
-        if !coverage.payoff { missing.append(.payoff) }
-        if !coverage.takeaway { missing.append(.takeaway) }
+        if !coverage.hook {
+            missing.append(.hook)
+        }
+        if !coverage.action {
+            missing.append(.action)
+        }
+        if !coverage.payoff {
+            missing.append(.payoff)
+        }
+        if !coverage.takeaway {
+            missing.append(.takeaway)
+        }
         return missing
     }
 }

--- a/engines/macos-swift/modules/automation/AttentionModel.swift
+++ b/engines/macos-swift/modules/automation/AttentionModel.swift
@@ -108,8 +108,12 @@ private func mergeSamples(_ first: AttentionSample, _ second: AttentionSample) -
 }
 
 private func samplePriority(_ sample: AttentionSample) -> Int {
-    if sample.isClick { return 2 }
-    if sample.isDwell { return 1 }
+    if sample.isClick {
+        return 2
+    }
+    if sample.isDwell {
+        return 1
+    }
     return 0
 }
 

--- a/engines/macos-swift/modules/automation/VirtualCameraPlanner.swift
+++ b/engines/macos-swift/modules/automation/VirtualCameraPlanner.swift
@@ -282,9 +282,15 @@ private func pickBestTarget(_ first: FocusTarget, _ second: FocusTarget) -> Focu
 }
 
 private func targetPriority(_ target: FocusTarget) -> Int {
-    if target.isAnchor { return 3 }
-    if target.isClick { return 2 }
-    if target.isDwell { return 1 }
+    if target.isAnchor {
+        return 3
+    }
+    if target.isClick {
+        return 2
+    }
+    if target.isDwell {
+        return 1
+    }
     return 0
 }
 

--- a/engines/macos-swift/modules/export/AssetWriter.swift
+++ b/engines/macos-swift/modules/export/AssetWriter.swift
@@ -144,7 +144,9 @@ private func rejectSymlinkIfExists(atPath path: String) throws {
         Darwin.lstat(fileSystemPath, &metadata)
     }
     if status != 0 {
-        if errno == ENOENT { return }
+        if errno == ENOENT {
+            return
+        }
         throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
     }
     if (metadata.st_mode & S_IFMT) == S_IFLNK {

--- a/engines/macos-swift/modules/export/ExportPipeline.swift
+++ b/engines/macos-swift/modules/export/ExportPipeline.swift
@@ -201,9 +201,13 @@ private func copyRegularFileNoFollow(from sourceURL: URL, to destinationURL: URL
         let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
             Darwin.read(sourceFd, rawBuffer.baseAddress, rawBuffer.count)
         }
-        if bytesRead == 0 { break }
+        if bytesRead == 0 {
+            break
+        }
         if bytesRead < 0 {
-            if errno == EINTR { continue }
+            if errno == EINTR {
+                continue
+            }
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
 
@@ -217,7 +221,9 @@ private func copyRegularFileNoFollow(from sourceURL: URL, to destinationURL: URL
                 )
             }
             if bytesWritten < 0 {
-                if errno == EINTR { continue }
+                if errno == EINTR {
+                    continue
+                }
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
             written += bytesWritten

--- a/engines/macos-swift/modules/inputTracking/InputEventLog.swift
+++ b/engines/macos-swift/modules/inputTracking/InputEventLog.swift
@@ -48,9 +48,13 @@ private func rejectSymlinkComponents(in url: URL) throws {
     var currentPath = isAbsolute ? "/" : ""
 
     for component in components {
-        if currentPath.isEmpty { currentPath = component }
-        else if currentPath == "/" { currentPath += component }
-        else { currentPath += "/\(component)" }
+        if currentPath.isEmpty {
+            currentPath = component
+        } else if currentPath == "/" {
+            currentPath += component
+        } else {
+            currentPath += "/\(component)"
+        }
         try rejectSymlinkIfExists(atPath: currentPath)
     }
 }
@@ -59,7 +63,9 @@ private func rejectSymlinkIfExists(atPath path: String) throws {
     var metadata = stat()
     let status = path.withCString { Darwin.lstat($0, &metadata) }
     if status != 0 {
-        if errno == ENOENT { return }
+        if errno == ENOENT {
+            return
+        }
         throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
     }
     if (metadata.st_mode & S_IFMT) == S_IFLNK {

--- a/engines/macos-swift/modules/inputTracking/InputTrackingMetricsStore.swift
+++ b/engines/macos-swift/modules/inputTracking/InputTrackingMetricsStore.swift
@@ -38,9 +38,13 @@ private func rejectSymlinkComponents(in url: URL) throws {
     var currentPath = isAbsolute ? "/" : ""
 
     for component in components {
-        if currentPath.isEmpty { currentPath = component }
-        else if currentPath == "/" { currentPath += component }
-        else { currentPath += "/\(component)" }
+        if currentPath.isEmpty {
+            currentPath = component
+        } else if currentPath == "/" {
+            currentPath += component
+        } else {
+            currentPath += "/\(component)"
+        }
         try rejectSymlinkIfExists(atPath: currentPath)
     }
 }
@@ -49,7 +53,9 @@ private func rejectSymlinkIfExists(atPath path: String) throws {
     var metadata = stat()
     let status = path.withCString { Darwin.lstat($0, &metadata) }
     if status != 0 {
-        if errno == ENOENT { return }
+        if errno == ENOENT {
+            return
+        }
         throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
     }
     if (metadata.st_mode & S_IFMT) == S_IFLNK {

--- a/engines/macos-swift/modules/project/ProjectLibraryStore.swift
+++ b/engines/macos-swift/modules/project/ProjectLibraryStore.swift
@@ -206,9 +206,13 @@ public final class ProjectLibraryStore {
         var currentPath = isAbsolute ? "/" : ""
 
         for component in components {
-            if currentPath.isEmpty { currentPath = component }
-            else if currentPath == "/" { currentPath += component }
-            else { currentPath += "/\(component)" }
+            if currentPath.isEmpty {
+                currentPath = component
+            } else if currentPath == "/" {
+                currentPath += component
+            } else {
+                currentPath += "/\(component)"
+            }
             try rejectSymlinkIfExists(atPath: currentPath)
         }
     }
@@ -217,7 +221,9 @@ public final class ProjectLibraryStore {
         var metadata = stat()
         let status = path.withCString { Darwin.lstat($0, &metadata) }
         if status != 0 {
-            if errno == ENOENT { return }
+            if errno == ENOENT {
+                return
+            }
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
         if (metadata.st_mode & S_IFMT) == S_IFLNK {

--- a/engines/macos-swift/modules/project/ProjectStore.swift
+++ b/engines/macos-swift/modules/project/ProjectStore.swift
@@ -237,9 +237,13 @@ public final class ProjectStore {
         var currentPath = isAbsolute ? "/" : ""
 
         for component in components {
-            if currentPath.isEmpty { currentPath = component }
-            else if currentPath == "/" { currentPath += component }
-            else { currentPath += "/\(component)" }
+            if currentPath.isEmpty {
+                currentPath = component
+            } else if currentPath == "/" {
+                currentPath += component
+            } else {
+                currentPath += "/\(component)"
+            }
             try rejectSymlinkIfExists(atPath: currentPath)
         }
     }
@@ -248,7 +252,9 @@ public final class ProjectStore {
         var metadata = stat()
         let status = path.withCString { Darwin.lstat($0, &metadata) }
         if status != 0 {
-            if errno == ENOENT { return }
+            if errno == ENOENT {
+                return
+            }
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
         if (metadata.st_mode & S_IFMT) == S_IFLNK {

--- a/engines/protocol-swift/Tests/EngineProtocolTests/EngineProtocolTests.swift
+++ b/engines/protocol-swift/Tests/EngineProtocolTests/EngineProtocolTests.swift
@@ -337,7 +337,9 @@ final class TestServerTransport: ServerTransport {
 
     func respond(method: HTTPRequest.Method, path: String, headers: HTTPFields = [:], body: HTTPBody? = nil) async throws -> (HTTPResponse, HTTPBody?) {
         guard let handler = handlers["\(method.rawValue) \(path)"] else {
-            if paths.contains(path) { return (HTTPResponse(status: .methodNotAllowed), nil) }
+            if paths.contains(path) {
+                return (HTTPResponse(status: .methodNotAllowed), nil)
+            }
             return (HTTPResponse(status: .notFound), nil)
         }
         let request = HTTPRequest(method: method, scheme: nil, authority: "127.0.0.1", path: path, headerFields: headers)

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -175,6 +175,7 @@
   "studio_labels_timelineMarkerClick": "Klick",
   "studio_labels_timelineMarkerMixed": "Gemischt",
   "studio_labels_timelineClipAria": "{laneLabel}-Clip {startSeconds} bis {endSeconds} Sekunden",
+  "studio_labels_timelineGapAria": "{laneLabel}-Lücke {startSeconds} bis {endSeconds} Sekunden",
   "studio_labels_timelineMarkerAria": "Ereignismarker {markerKindLabel} bei {timestampSeconds} Sekunden",
   "studio_labels_resizeTimeline": "Zeitleiste in der Größe ändern",
   "studio_labels_resizeLeftPane": "Linkes Panel in der Größe ändern",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -175,6 +175,7 @@
   "studio_labels_timelineMarkerClick": "click",
   "studio_labels_timelineMarkerMixed": "mixed",
   "studio_labels_timelineClipAria": "{laneLabel} clip {startSeconds} to {endSeconds} seconds",
+  "studio_labels_timelineGapAria": "{laneLabel} gap {startSeconds} to {endSeconds} seconds",
   "studio_labels_timelineMarkerAria": "Event marker {markerKindLabel} at {timestampSeconds} seconds",
   "studio_labels_resizeTimeline": "Resize timeline",
   "studio_labels_resizeLeftPane": "Resize left panel",


### PR DESCRIPTION
# Summary
- Add Select-mode timeline clip drag/drop for ripple insert moves and conservative non-ripple gap/boundary moves.
- Render drag drop affordances for insertion, target gaps, and invalid non-ripple drops.
- Move the playhead to the moved clip destination and expand pure/browser test coverage for invalid, locked-lane, gap, and click-suppression cases.

# Checklist
- [x] Ran `bun run gate`
- [x] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
- [ ] UI changes include screenshots
  - Not captured; behavior is covered by Vitest Browser pointer interaction tests.
- [x] Updated docs/templates if architecture or workflows changed

# Testing (optional)
- [ ] swift test
- [x] bun run desktop:test:coverage (required when touching `apps/desktop-electrobun` or `packages/engine-protocol`)

Additional validation:
- [x] `bun run desktop:typecheck`
- [x] `cd apps/desktop-electrobun && bunx vitest -c vitest.config.ts --run tests/timeline-commands.test.ts`
- [x] `cd apps/desktop-electrobun && bunx vitest -c vitest.browser.config.ts --run tests/ui/timeline-drag-move.browser.test.tsx`
- [x] `bun run js:lint:ci`
