### PR TITLE
chore(devx): encode agent repository knowledge

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,26 @@
 # Summary
-- 
+
+-
 
 # Checklist
-- [ ] Ran `bun run gate`
-- [ ] Scoped to a single area (desktop shell, protocol, engine, docs, tooling)
-- [ ] UI changes include screenshots
-- [ ] Updated docs/templates if architecture or workflows changed
 
-# Testing (optional)
-- [ ] swift test
-- [ ] bun run desktop:test:coverage (required when touching `apps/desktop-electrobun` or `packages/engine-protocol`)
+- [ ] Read and applied `AGENTS.md`, the nearest nested agent guide, and `REVIEW.md`
+- [ ] Kept the change scoped to one roadmap slice or maintenance purpose
+- [ ] Ran `bun run repo:check`
+- [ ] Ran `bun run gate` or documented unsupported/deferred platform checks
+- [ ] Regenerated derived artifacts and verified determinism when changing contracts, or N/A
+- [ ] Updated roadmap/docs when architecture, workflow, or tracked status changed, or N/A
+- [ ] Added both `en-US` and `de-DE` messages for user-visible UI, or N/A
+- [ ] Included screenshots for material UI changes, or N/A
+
+# Validation evidence
+
+List commands actually run and checks left to CI or another platform:
+
+-
+
+# Cross-boundary review
+
+- [ ] Preview, persistence, and export remain aligned for editor-model changes, or N/A
+- [ ] Hosted services remain optional for local capture/edit/export, or N/A
+- [ ] New native capabilities are advertised only on implemented targets, or N/A

--- a/.github/workflows/full_gate.yml
+++ b/.github/workflows/full_gate.yml
@@ -24,9 +24,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Initialize Effect vendor submodule
-        run: git submodule update --init vendor/effect
-
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/full_gate.yml
+++ b/.github/workflows/full_gate.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
+      - name: Initialize Effect vendor submodule
+        run: git submodule update --init vendor/effect
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
@@ -136,11 +139,8 @@ jobs:
       - name: Install JavaScript dependencies
         run: bun install --frozen-lockfile
 
-      - name: Generate protocol bindings
-        run: bun run protocol:generate-bindings
-
-      - name: Format generated Rust bindings
-        run: cargo fmt --all
+      - name: Generate protocol bindings and verify deterministic inventory
+        run: bun run protocol:check-determinism
 
       - name: Assert generated files are current
         run: git diff --exit-code

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,120 @@
+# Guerilla Glass agent guide
+
+This file is the operational entry point for coding agents. Read it before changing code, then read the nearest nested `AGENTS.md` for the subsystem you touch.
+
+## Mission and current priority
+
+Guerilla Glass is a local-first recorder and polished demo editor with a separate hosted review plane. The product workflow is `Record -> Edit -> Deliver`.
+
+The current release-defining work is the **Phase 2 polished demo editor core** in `docs/ROADMAP.md`. Follow the ordered “Suggested Phase 2 PR slices”; do not let hosted delivery, Agent Mode, or broad platform expansion outrun the editor core unless the task explicitly targets those tracks.
+
+Normative product requirements live in `docs/SPEC.md`. Execution status and sequencing live in `docs/ROADMAP.md`. Keep roadmap checkboxes synchronized with merged implementation.
+
+## Start here
+
+| Need                        | Source of truth                     |
+| --------------------------- | ----------------------------------- |
+| Product requirements        | `docs/SPEC.md`                      |
+| Current work and PR order   | `docs/ROADMAP.md`                   |
+| System boundaries           | `docs/ARCHITECTURE.md`              |
+| Change propagation          | `docs/CHANGE_MAP.md`                |
+| Review expectations         | `REVIEW.md`                         |
+| Timeline semantics          | `docs/TIMELINE_EDITING_DESIGN.md`   |
+| Background framing v1       | `docs/BACKGROUND_FRAMING_DESIGN.md` |
+| Accessibility and shortcuts | `docs/DESKTOP_ACCESSIBILITY.md`     |
+| Release hardening           | `docs/RELEASE_HARDENING.md`         |
+
+Documents named `ENGINE_CONTRACT_V2_*` and `MIGRATION.md` preserve migration history. They are useful rationale, but are not the active backlog unless `docs/ROADMAP.md` references them.
+
+## Repository map
+
+- `apps/desktop-electrobun`: Electrobun Bun host and React Creator Studio.
+- `apps/web`: TanStack Start and Convex hosted review/auth shell.
+- `packages/engine-contract`: Effect Schema/`HttpApi` source of truth and generated OpenAPI.
+- `packages/engine-client`: Effect-native engine client and process launcher.
+- `packages/review-protocol`: hosted review DTOs and schemas.
+- `packages/ui`: shared UI primitives and styles.
+- `engines/macos-swift`: production macOS capture/export engine.
+- `engines/native-foundation`: shared Rust HTTP/native behavior.
+- `engines/linux-native`, `engines/windows-native`: parity shells; do not imply production media parity.
+- `engines/protocol-rust`, `engines/protocol-swift`: generated protocol bindings plus explicitly owned helpers/templates.
+- `messages` and `project.inlang`: localization sources.
+- `Scripts`: canonical generation, quality, coverage, and benchmark automation.
+- `vendor`: pinned upstream source; avoid editing unless the task explicitly updates or patches a vendor.
+
+## Non-negotiable architecture rules
+
+1. Local capture, editing, project IO, playback, and export must work without hosted services.
+2. Hosted auth, review, presence, and billing failures must fail open to local-only behavior.
+3. TypeScript Effect schemas and `HttpApi` own the engine wire contract.
+4. Native sidecars consume generated OpenAPI bindings; do not introduce Effect RPC internals into native engines.
+5. The Electrobun renderer does not receive raw local media paths. Playback uses tokenized loopback media URLs.
+6. Keep one scoped Effect runtime in the Bun host. Bridge request handlers are thin adapters, not a second application layer.
+7. Preview, persisted project state, and native export must agree on shipped timeline and visual-edit semantics. A contract-only slice may introduce backward-compatible fields before renderer support only when defaults preserve existing output and the immediately following roadmap slice owns the wiring.
+8. User-visible strings must use the shared localization source. Do not hand-edit generated `src/paraglide` output.
+9. Cross-platform shells must not claim capabilities that their native implementation does not provide.
+10. Prefer enforcing repeated review feedback with schemas, generators, lint rules, tests, or CI rather than prose alone.
+
+## Generated and owned files
+
+| Artifact                                                     | Edit source instead                                                | Regenerate                                              |
+| ------------------------------------------------------------ | ------------------------------------------------------------------ | ------------------------------------------------------- |
+| `packages/engine-contract/generated/engine.openapi.json`     | `packages/engine-contract/src/**`                                  | `bun run protocol:generate-bindings`                    |
+| `engines/protocol-swift/Sources/EngineProtocol/openapi.json` | engine contract                                                    | `bun run protocol:generate-bindings`                    |
+| generated Rust protocol sources                              | engine contract and generator config/templates                     | `bun run protocol:generate-bindings`                    |
+| `engines/protocol-rust/Cargo.toml` dependency defaults       | `engines/protocol-rust/openapi-generator-templates/Cargo.mustache` | `bun run protocol:generate-bindings`                    |
+| `apps/*/src/paraglide/**`                                    | `messages/*.json` and `project.inlang`                             | `bun run i18n:compile`                                  |
+| `apps/web/src/routeTree.gen.ts`                              | `apps/web/src/routes/**`                                           | generated by TanStack Router during typecheck/build/dev |
+| lockfiles                                                    | dependency manifests                                               | appropriate package manager resolver                    |
+
+After generation, inspect `git diff`; generated output must be deterministic. Do not “fix” generated output without fixing its source.
+
+## Change discipline
+
+- Keep changes scoped to one roadmap slice or maintenance purpose.
+- Read existing tests before changing semantics.
+- Preserve schema migration and backward compatibility for persisted projects.
+- Add the narrowest useful test at the layer where a regression originates, then add parity coverage when behavior crosses renderer/native boundaries.
+- If a reviewer identifies a repeatable class of problem, automate its prevention where practical.
+- Update `docs/ROADMAP.md` in the same change when a tracked item becomes complete or its sequencing changes.
+- Do not update historical migration status as if it were the active roadmap.
+
+See `docs/CHANGE_MAP.md` for change-specific paths and required checks.
+
+## Canonical commands
+
+```bash
+bun run bootstrap
+bun run repo:check
+bun run gate
+```
+
+Focused commands:
+
+```bash
+bun run gate:typescript
+bun run gate:rust
+bun run swift:test
+bun run desktop:typecheck
+bun run desktop:test
+bun run desktop:test:ui
+bun run web:typecheck
+bun run protocol:typecheck
+bun run protocol:generate-bindings
+bun run docs:check
+```
+
+The full gate requires macOS for the production Swift path. On another platform, run all supported focused gates and clearly report what was not run.
+
+## Completion checklist
+
+Before declaring work complete:
+
+- Run `bun run repo:check` and relevant focused tests.
+- Run `bun run gate` when the platform supports it.
+- Confirm generated files are current and deterministic for contract changes.
+- Confirm preview/export/persistence parity for editor-model changes.
+- Confirm new UI is localized, keyboard accessible, and covered by reduced-motion/focus conventions.
+- Check `git diff --check` and review the final diff for accidental generated or vendor changes.
+- Reconcile the roadmap and documentation.
+- Report validation commands and any platform checks that remain for CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,38 +3,50 @@
 Thanks for your interest in contributing. Guerilla Glass is a cross-platform creator recorder/editor with a hybrid setup: Electrobun desktop shell + native per-OS engines behind a shared protocol.
 
 ## Product direction
+
 - Professional creator workflow: `Record -> Edit -> Deliver`
 - Editor-first shell: transport, viewer, timeline, inspector
 - Cinematic defaults with manual overrides
 
 ## Development
+
 - Bun 1.3+
 - Rust toolchain
 - Swift 5.10+ (for macOS engine work)
 - macOS 13.0+ (required for full native macOS capture/export flow and full gate)
 
 ## Build
+
 ```bash
 bun run swift:build
 bun run desktop:build
 ```
 
 ## Run desktop shell
+
 ```
 bun run desktop:dev
 ```
 
 ## Build desktop shell bundle
+
 ```
 bun run desktop:build
 ```
 
 ## Permissions
+
 - Screen Recording is required to preview capture.
 - Microphone access is required when mic capture is enabled.
 
+## Repository guidance
+
+Read [`AGENTS.md`](AGENTS.md) for architecture and generated-file ownership, [`docs/CHANGE_MAP.md`](docs/CHANGE_MAP.md) for change propagation, and [`REVIEW.md`](REVIEW.md) before opening a pull request.
+
 ## Test
+
 ```bash
+bun run repo:check
 bun run gate
 ```
 
@@ -46,9 +58,11 @@ bun run desktop:test
 ```
 
 ## Style
+
 - SwiftFormat and SwiftLint configurations live at repo root.
 
 ## Pull requests (agent-friendly)
+
 - Use small, scoped PRs (UI, capture, export, docs, tooling).
 - Run `bun run gate` before opening a PR (format, lint, tests, build).
 - Include screenshots for UI changes.

--- a/README.md
+++ b/README.md
@@ -33,15 +33,19 @@ Important boundaries:
 - Bun 1.3+
 - Rust toolchain for Rust sidecars/protocol crates
 - Swift 5.10+ for macOS native engine work
+- SwiftFormat 0.62.1 and SwiftLint for the full local gate
+- Java for OpenAPI binding generation
 - macOS 13+ for the full macOS capture/export path and `bun run gate`
 
 ## Quick Start
 
 ```bash
-bun install
+# Initialize submodules, install frozen dependencies, compile localization,
+# and verify repository invariants.
+bun run bootstrap
 
-# Generate app-local Paraglide output used by typecheck/build/test
-bun run i18n:compile
+# Skip Playwright Chromium only when browser-backed desktop tests are not needed.
+bun run bootstrap --without-browser
 
 # Build native macOS engine. Desktop dev scripts launch this engine via GG_ENGINE_PATH.
 bun run swift:build
@@ -72,6 +76,7 @@ GG_ENGINE_PATH="$PWD/target/debug/guerillaglass-engine-linux" bun run desktop:de
 ## Verification
 
 ```bash
+bun run repo:check
 bun run js:lint
 bun run gate:typescript
 bun run gate:rust
@@ -121,4 +126,6 @@ bun run i18n:compile
 - Completed migration notes: `docs/MIGRATION.md`
 - Docs coverage thresholds: `docs/doc_coverage_policy.json`
 - Desktop accessibility + hotkey policy: `docs/DESKTOP_ACCESSIBILITY.md`
-- Agent repo conventions: `AGENTS.md`
+- Agent repo conventions: [`AGENTS.md`](AGENTS.md)
+- Change propagation guide: [`docs/CHANGE_MAP.md`](docs/CHANGE_MAP.md)
+- Review rubric: [`REVIEW.md`](REVIEW.md)

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -1,0 +1,69 @@
+# Guerilla Glass review guide
+
+Use this rubric for human and agent review. Report concrete defects with file/line evidence; distinguish blockers from optional improvements. A passing build is necessary but not sufficient when behavior crosses architectural boundaries.
+
+## Universal review
+
+- **Scope:** The change has one coherent purpose and does not silently expand product scope.
+- **Correctness:** Invalid, empty, interrupted, and boundary states are handled, not only the happy path.
+- **Architecture:** Ownership follows `AGENTS.md` and `docs/ARCHITECTURE.md`; no convenience bypass creates a second source of truth.
+- **Automation:** Recurring failure classes are prevented by a type, schema, lint, test, generator, or CI check when practical.
+- **Tests:** Tests assert externally meaningful behavior and would fail before the fix.
+- **Documentation:** Active roadmap state and operational guidance match the implementation.
+- **Security:** File paths, bearer tokens, loopback origins, symlinks, and untrusted payloads retain defensive validation.
+- **Dependencies:** Manifest, lockfile, generated templates, and vendor pins remain aligned.
+
+## Desktop and UI
+
+- Host/renderer bridge handlers remain typed and thin.
+- Long-lived Bun resources are scoped through the existing Effect runtime.
+- User-visible text comes from `messages/*.json`; both `en-US` and `de-DE` are updated.
+- Controls are keyboard reachable, have visible focus, expose names/state, and respect reduced motion.
+- Shortcuts use the shared registry and honor user overrides/conflict validation.
+- Loading, degraded, permission-denied, timeout, and unavailable-engine states remain actionable.
+- Browser tests cover interaction semantics that DOM-only unit tests cannot validate.
+
+## Timeline and editor semantics
+
+- Pure timeline commands remain deterministic and independently tested.
+- Ripple and non-ripple behavior preserve documented clip/gap invariants.
+- Selection and playhead outcomes are explicit after destructive edits.
+- Preview maps program time to source time correctly, including gaps and media-end transitions.
+- Project save/load and migrations preserve the model.
+- Native export matches preview duration, ordering, gaps, trims, and camera transforms.
+
+## Engine contract and native code
+
+- Effect Schema/`HttpApi` changes are the wire-contract source of truth.
+- OpenAPI and Swift/Rust bindings regenerate without unexplained diffs.
+- `engines/protocol-rust/Cargo.toml` dependency changes originate in `openapi-generator-templates/Cargo.mustache`.
+- Swift and Rust handlers use generated request/response types rather than parallel DTOs.
+- New capabilities are advertised only where implemented.
+- Cross-platform parity tests distinguish protocol parity from production media parity.
+- Capture/export changes consider cancellation, cleanup, backpressure, and resource lifetime.
+
+## Project persistence
+
+- New persisted fields have stable defaults and explicit validation constraints.
+- Existing project versions still load or receive a tested migration.
+- Paths cannot escape the project package through traversal or symlinks.
+- Persisted settings flow through contract, renderer, native engine, and export where applicable.
+- Unknown or malformed values fail predictably rather than being partially applied.
+
+## Hosted plane
+
+- Hosted services do not become prerequisites for local capture/edit/export.
+- Authentication and billing apply only to hosted collaboration capabilities.
+- Shared review DTO changes remain versionable and do not leak local media paths.
+- Failure and offline behavior degrades to local-only operation.
+
+## Release and maintenance
+
+- Dependency versions are compatible across workspaces and pinned vendor sources.
+- Package/release metadata carries the intended version and channel semantics.
+- Signing/notarization secrets are not required for documented unsigned dry runs.
+- Build artifacts are reproducible from committed manifests, templates, and lockfiles.
+
+## Required evidence
+
+The author should list commands actually run and identify checks deferred to CI or another platform. For UI changes, include browser-test evidence and screenshots when visual judgment is material. For generated changes, include the generation command and a clean determinism check.

--- a/Scripts/bootstrap.sh
+++ b/Scripts/bootstrap.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun not found; install Bun 1.3+ first" >&2
+  exit 1
+fi
+
+with_browser=1
+if [[ "${1:-}" == "--without-browser" ]]; then
+  with_browser=0
+elif [[ $# -gt 0 ]]; then
+  echo "usage: bun run bootstrap [--without-browser]" >&2
+  exit 2
+fi
+
+echo "==> synchronizing the required Effect vendor submodule"
+git submodule sync -- vendor/effect
+git submodule update --init vendor/effect
+
+echo "==> installing JavaScript dependencies"
+bun install --frozen-lockfile
+
+echo "==> compiling localization output"
+bun run i18n:compile
+
+if [[ "$with_browser" -eq 1 ]]; then
+  echo "==> installing Playwright Chromium"
+  bun run desktop:test:ui:install
+fi
+
+echo "==> checking repository invariants"
+bun run repo:check
+
+echo "==> bootstrap complete"
+if [[ "$with_browser" -eq 0 ]]; then
+  echo "Run 'bun run desktop:test:ui:install' before browser-backed desktop tests."
+fi

--- a/Scripts/check_protocol_determinism.ts
+++ b/Scripts/check_protocol_determinism.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+const generatedPaths = [
+  "packages/engine-contract/generated",
+  "engines/protocol-swift/Sources/EngineProtocol/openapi.json",
+  "engines/protocol-rust/.openapi-generator/FILES",
+  "engines/protocol-rust/.openapi-generator/VERSION",
+  "engines/protocol-rust/Cargo.toml",
+  "engines/protocol-rust/README.md",
+  "engines/protocol-rust/src",
+];
+
+const before = digestGeneratedArtifacts();
+run(["bun", "run", "protocol:generate-bindings"]);
+run(["cargo", "fmt", "--manifest-path", "engines/protocol-rust/Cargo.toml"]);
+checkForStaleGeneratedRustSources();
+const after = digestGeneratedArtifacts();
+
+if (before !== after) {
+  console.error(
+    "Protocol generation changed committed artifacts. Review and keep the generated changes, then rerun this command to prove a second generation is stable.",
+  );
+  process.exit(1);
+}
+
+console.log("Protocol generation is deterministic from the current sources.");
+
+function digestGeneratedArtifacts(): string {
+  const hasher = new Bun.CryptoHasher("sha256");
+  for (const path of generatedPaths.flatMap((path) => collectFiles(resolve(root, path))).sort()) {
+    hasher.update(relative(root, path));
+    hasher.update("\0");
+    hasher.update(readFileSync(path));
+    hasher.update("\0");
+  }
+  return hasher.digest("hex");
+}
+
+function checkForStaleGeneratedRustSources(): void {
+  const protocolRoot = resolve(root, "engines/protocol-rust");
+  const expectedSources = readFileSync(resolve(protocolRoot, ".openapi-generator/FILES"), "utf8")
+    .split("\n")
+    .filter((path) => path.startsWith("src/"))
+    .sort();
+  const actualSources = collectFiles(resolve(protocolRoot, "src"))
+    .map((path) => relative(protocolRoot, path))
+    .sort();
+
+  const staleSources = actualSources.filter((path) => !expectedSources.includes(path));
+  const missingSources = expectedSources.filter((path) => !actualSources.includes(path));
+  if (staleSources.length > 0 || missingSources.length > 0) {
+    console.error(
+      `Generated Rust source inventory differs from .openapi-generator/FILES. Stale: ${staleSources.join(", ") || "none"}; missing: ${missingSources.join(", ") || "none"}`,
+    );
+    process.exit(1);
+  }
+}
+
+function collectFiles(path: string): Array<string> {
+  if (statSync(path).isFile()) {
+    return [path];
+  }
+  const entryNames = readdirSync(path, { withFileTypes: true });
+  return entryNames.flatMap((entry) => {
+    const entryPath = join(path, entry.name);
+    return entry.isDirectory() ? collectFiles(entryPath) : [entryPath];
+  });
+}
+
+function run(command: Array<string>): void {
+  const result = Bun.spawnSync(command, { cwd: root, stdout: "inherit", stderr: "inherit" });
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
+  }
+}

--- a/Scripts/compile_i18n.ts
+++ b/Scripts/compile_i18n.ts
@@ -1,0 +1,19 @@
+#!/usr/bin/env bun
+import { rmSync } from "node:fs";
+import { resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+for (const outputPath of ["apps/desktop-electrobun/src/paraglide", "apps/web/src/paraglide"]) {
+  rmSync(resolve(root, outputPath), { recursive: true, force: true });
+}
+
+for (const script of ["i18n:compile:desktop", "i18n:compile:web"]) {
+  const result = Bun.spawnSync(["bun", "run", script], {
+    cwd: root,
+    stdout: "inherit",
+    stderr: "inherit",
+  });
+  if (result.exitCode !== 0) {
+    process.exit(result.exitCode);
+  }
+}

--- a/Scripts/generate_engine_protocol_v2.sh
+++ b/Scripts/generate_engine_protocol_v2.sh
@@ -2,6 +2,12 @@
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+if ! command -v java >/dev/null 2>&1 || ! java -version >/dev/null 2>&1; then
+  echo "Java is required for OpenAPI generation. Install a JDK and ensure 'java' is on PATH (macOS/Homebrew: brew install openjdk; export PATH=\"/opt/homebrew/opt/openjdk/bin:\$PATH\")." >&2
+  exit 1
+fi
+
 OPENAPI_FILE="$ROOT_DIR/packages/engine-contract/generated/engine.openapi.json"
 RUST_CONFIG_FILE="$ROOT_DIR/engines/protocol-rust/openapi-generator-config.json"
 RUST_TEMPLATE_DIR="$ROOT_DIR/engines/protocol-rust/openapi-generator-templates"

--- a/Scripts/lint_no_state_updates_in_effect.mjs
+++ b/Scripts/lint_no_state_updates_in_effect.mjs
@@ -111,9 +111,7 @@ function isReactHookCall(expression, hookLocalNames, namespaceImports, hookName)
     if (!ts.isIdentifier(expression.expression)) {
       return false;
     }
-    return (
-      namespaceImports.has(expression.expression.text) && expression.name.text === hookName
-    );
+    return namespaceImports.has(expression.expression.text) && expression.name.text === hookName;
   }
   return false;
 }
@@ -133,7 +131,11 @@ function collectStateSetterNames(sourceFile, hookNames) {
         )
       ) {
         const secondElement = node.name.elements[1];
-        if (secondElement && ts.isBindingElement(secondElement) && ts.isIdentifier(secondElement.name)) {
+        if (
+          secondElement &&
+          ts.isBindingElement(secondElement) &&
+          ts.isIdentifier(secondElement.name)
+        ) {
           setterNames.add(secondElement.name.text);
         }
       }
@@ -151,7 +153,13 @@ function getLineAndColumn(sourceFile, node) {
   return `${line + 1}:${character + 1}`;
 }
 
-function findViolationsInEffectCallback(callbackNode, setterNames, sourceFile, filePath, effectName) {
+function findViolationsInEffectCallback(
+  callbackNode,
+  setterNames,
+  sourceFile,
+  filePath,
+  effectName,
+) {
   const violations = [];
 
   function visit(node) {
@@ -178,7 +186,13 @@ function findViolationsInEffectCallback(callbackNode, setterNames, sourceFile, f
 function lintFile(filePath) {
   const sourceText = readFileSync(filePath, "utf8");
   const scriptKind = filePath.endsWith(".tsx") ? ts.ScriptKind.TSX : ts.ScriptKind.TS;
-  const sourceFile = ts.createSourceFile(filePath, sourceText, ts.ScriptTarget.Latest, true, scriptKind);
+  const sourceFile = ts.createSourceFile(
+    filePath,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    true,
+    scriptKind,
+  );
 
   const hookNames = collectReactHookNames(sourceFile);
   const setterNames = collectStateSetterNames(sourceFile, hookNames);

--- a/Scripts/repository_invariants.test.ts
+++ b/Scripts/repository_invariants.test.ts
@@ -68,21 +68,31 @@ describe("repository invariants", () => {
     expect(result.stderr).toContain("missing agent/review guide: REVIEW.md");
   });
 
-  test("reports Effect runtime and vendor version drift", () => {
+  test("reports workspace Effect runtime version drift", () => {
     writeFixture(
       "apps/web/package.json",
       JSON.stringify({ dependencies: { effect: "4.0.0-beta.100" } }),
     );
     const result = runCheck();
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("does not match vendor/effect 4.0.0-beta.101");
+    expect(result.stderr).toContain("workspace Effect runtime versions are not aligned");
   });
 
-  test("reports a missing Effect vendor submodule", () => {
-    rmSync(join(fixtureRoot, "vendor/effect"), { recursive: true, force: true });
+  test("reports vendor drift when the Effect submodule is initialized", () => {
+    writeFixture(
+      "vendor/effect/packages/effect/package.json",
+      JSON.stringify({ version: "4.0.0-beta.100" }),
+    );
     const result = runCheck();
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("git submodule update --init vendor/effect");
+    expect(result.stderr).toContain("does not match vendor/effect 4.0.0-beta.100");
+  });
+
+  test("skips only the vendor comparison when the submodule is absent", () => {
+    rmSync(join(fixtureRoot, "vendor/effect"), { recursive: true, force: true });
+    const result = runCheck();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout).toContain("vendor comparison skipped; submodule not initialized");
   });
 
   test("reports generated Rust dependency drift or missing tables", () => {

--- a/Scripts/repository_invariants.test.ts
+++ b/Scripts/repository_invariants.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+
+const scriptPath = resolve(import.meta.dir, "repository_invariants.ts");
+const guidePaths = [
+  "AGENTS.md",
+  "REVIEW.md",
+  "docs/CHANGE_MAP.md",
+  "apps/desktop-electrobun/AGENTS.md",
+  "apps/web/AGENTS.md",
+  "packages/engine-contract/AGENTS.md",
+  "engines/AGENTS.md",
+];
+
+let fixtureRoot = "";
+
+beforeEach(() => {
+  fixtureRoot = mkdtempSync(join(tmpdir(), "gg-repository-invariants-"));
+  for (const guidePath of guidePaths) {
+    writeFixture(guidePath, "# Guide\n");
+  }
+  writeFixture("package.json", JSON.stringify({ dependencies: { effect: "4.0.0-beta.101" } }));
+  writeFixture(
+    "vendor/effect/packages/effect/package.json",
+    JSON.stringify({ version: "4.0.0-beta.101" }),
+  );
+  writeFixture(
+    "engines/protocol-rust/Cargo.toml",
+    '[package]\nname = "protocol-rust"\n\n[dependencies]\nbase64 = "0.23"\nserde = "1"\n\n[dev-dependencies]\ntower = "0.5"\n',
+  );
+  writeFixture(
+    "engines/protocol-rust/openapi-generator-templates/Cargo.mustache",
+    '[package]\nname = "{{packageName}}"\n\n[dependencies]\nbase64 = "0.23"\nserde = "1"\n\n[dev-dependencies]\ntower = "0.5"\n',
+  );
+  writeFixture(
+    "project.inlang/settings.json",
+    JSON.stringify({
+      baseLocale: "en-US",
+      locales: ["en-US", "de-DE"],
+      "plugin.inlang.messageFormat": { pathPattern: "./messages/{locale}.json" },
+    }),
+  );
+  writeFixture(
+    "messages/en-US.json",
+    JSON.stringify({ greeting: "Hello {name}", status: "Ready" }),
+  );
+  writeFixture(
+    "messages/de-DE.json",
+    JSON.stringify({ greeting: "Hallo {name}", status: "Bereit" }),
+  );
+});
+
+afterEach(() => {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+});
+
+describe("repository invariants", () => {
+  test("accepts an aligned repository fixture", () => {
+    expect(runCheck()).toMatchObject({ exitCode: 0 });
+  });
+
+  test("reports missing operational guidance", () => {
+    unlinkSync(join(fixtureRoot, "REVIEW.md"));
+    const result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("missing agent/review guide: REVIEW.md");
+  });
+
+  test("reports Effect runtime and vendor version drift", () => {
+    writeFixture(
+      "apps/web/package.json",
+      JSON.stringify({ dependencies: { effect: "4.0.0-beta.100" } }),
+    );
+    const result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("does not match vendor/effect 4.0.0-beta.101");
+  });
+
+  test("reports a missing Effect vendor submodule", () => {
+    rmSync(join(fixtureRoot, "vendor/effect"), { recursive: true, force: true });
+    const result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("git submodule update --init vendor/effect");
+  });
+
+  test("reports generated Rust dependency drift or missing tables", () => {
+    writeFixture(
+      "engines/protocol-rust/Cargo.toml",
+      '[dependencies]\nbase64 = "0.22"\nserde = "1"\n',
+    );
+    let result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("[dependencies] does not match");
+
+    writeFixture("engines/protocol-rust/Cargo.toml", '[package]\nname = "empty"\n');
+    writeFixture(
+      "engines/protocol-rust/openapi-generator-templates/Cargo.mustache",
+      '[package]\nname = "empty"\n',
+    );
+    result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("[dependencies] does not match");
+  });
+
+  test("reports localization key and placeholder drift", () => {
+    writeFixture(
+      "messages/de-DE.json",
+      JSON.stringify({ greeting: "Hallo {person}", invalid: 42 }),
+    );
+    const result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("localization key mismatch");
+    expect(result.stderr).toContain("localization placeholder mismatch for greeting");
+    expect(result.stderr).toContain("localization messages must be strings");
+  });
+
+  test("reports broken inline local Markdown file links", () => {
+    writeFixture("AGENTS.md", "# Guide\n\n[Missing](docs/DOES_NOT_EXIST.md)\n");
+    const result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("broken local Markdown link in AGENTS.md");
+  });
+});
+
+function writeFixture(path: string, content: string): void {
+  const absolutePath = join(fixtureRoot, path);
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content);
+}
+
+function runCheck(): { exitCode: number; stdout: string; stderr: string } {
+  const result = Bun.spawnSync(["bun", scriptPath], {
+    env: { ...process.env, GG_REPOSITORY_ROOT: fixtureRoot },
+  });
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}

--- a/Scripts/repository_invariants.ts
+++ b/Scripts/repository_invariants.ts
@@ -1,0 +1,297 @@
+#!/usr/bin/env bun
+import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+type PackageManifest = {
+  version?: unknown;
+  dependencies?: Record<string, unknown>;
+  devDependencies?: Record<string, unknown>;
+  peerDependencies?: Record<string, unknown>;
+  optionalDependencies?: Record<string, unknown>;
+};
+
+const root = resolve(process.env.GG_REPOSITORY_ROOT ?? resolve(import.meta.dir, ".."));
+const failures: Array<string> = [];
+
+const requiredGuides = [
+  "AGENTS.md",
+  "REVIEW.md",
+  "docs/CHANGE_MAP.md",
+  "apps/desktop-electrobun/AGENTS.md",
+  "apps/web/AGENTS.md",
+  "packages/engine-contract/AGENTS.md",
+  "engines/AGENTS.md",
+];
+
+for (const guide of requiredGuides) {
+  if (!existsSync(join(root, guide))) {
+    failures.push(`missing agent/review guide: ${guide}`);
+  }
+}
+
+checkEffectVersionAlignment();
+checkGeneratedRustDependencyOwnership();
+checkLocalizationParity();
+checkMarkdownLinks();
+
+if (failures.length > 0) {
+  console.error("Repository invariant check failed:");
+  for (const failure of failures) {
+    console.error(`- ${failure}`);
+  }
+  process.exit(1);
+}
+
+console.log("Repository invariant check passed:");
+console.log(`- ${requiredGuides.length} required agent/review guides present`);
+console.log("- Effect runtime package allowlist matches the vendor version");
+console.log("- generated Rust dependency table matches the generator template");
+console.log("- localization keys and placeholders match across supported locales");
+console.log("- inline local Markdown file links resolve");
+
+function checkEffectVersionAlignment(): void {
+  const manifestPaths = [
+    "package.json",
+    ...workspaceManifestPaths("apps"),
+    ...workspaceManifestPaths("packages"),
+  ];
+  const runtimePackageNames = new Set(["effect", "@effect/platform-bun", "@effect/vitest"]);
+  const versions = new Map<string, Array<string>>();
+
+  for (const manifestPath of manifestPaths) {
+    const manifest = readJson(join(root, manifestPath));
+    for (const dependencyGroup of [
+      manifest.dependencies,
+      manifest.devDependencies,
+      manifest.peerDependencies,
+      manifest.optionalDependencies,
+    ]) {
+      if (!dependencyGroup || typeof dependencyGroup !== "object") {
+        continue;
+      }
+      for (const [name, version] of Object.entries(dependencyGroup)) {
+        if (!runtimePackageNames.has(name) || typeof version !== "string") {
+          continue;
+        }
+        const locations = versions.get(version) ?? [];
+        locations.push(`${manifestPath}:${name}`);
+        versions.set(version, locations);
+      }
+    }
+  }
+
+  const vendorManifestPath = "vendor/effect/packages/effect/package.json";
+  if (!existsSync(join(root, vendorManifestPath))) {
+    failures.push(
+      `Effect vendor submodule is unavailable; run git submodule update --init vendor/effect`,
+    );
+    return;
+  }
+
+  const vendorVersion = readJson(join(root, vendorManifestPath)).version;
+  if (typeof vendorVersion !== "string") {
+    failures.push(`${vendorManifestPath} has no string version`);
+    return;
+  }
+
+  if (versions.size === 0) {
+    failures.push("no Effect runtime dependencies found in workspace manifests");
+    return;
+  }
+
+  for (const [version, locations] of versions) {
+    if (version !== vendorVersion) {
+      failures.push(
+        `Effect version ${version} at ${locations.join(", ")} does not match vendor/effect ${vendorVersion}`,
+      );
+    }
+  }
+}
+
+function checkGeneratedRustDependencyOwnership(): void {
+  const generatedPath = "engines/protocol-rust/Cargo.toml";
+  const templatePath = "engines/protocol-rust/openapi-generator-templates/Cargo.mustache";
+  const generated = readFileSync(join(root, generatedPath), "utf8");
+  const template = readFileSync(join(root, templatePath), "utf8");
+  const generatedDependencies = tomlSection(generated, "dependencies");
+  const templateDependencies = tomlSection(template, "dependencies");
+
+  if (
+    generatedDependencies.length === 0 ||
+    templateDependencies.length === 0 ||
+    generatedDependencies.join("\n") !== templateDependencies.join("\n")
+  ) {
+    failures.push(
+      `${generatedPath} [dependencies] does not match ${templatePath}; edit the template and regenerate bindings`,
+    );
+  }
+}
+
+function checkLocalizationParity(): void {
+  const settingsPath = join(root, "project.inlang/settings.json");
+  const settings = readUnknownRecord(settingsPath);
+  const locales = Array.isArray(settings.locales)
+    ? settings.locales.filter((locale): locale is string => typeof locale === "string")
+    : [];
+  const baseLocale = typeof settings.baseLocale === "string" ? settings.baseLocale : undefined;
+  const pathPattern =
+    typeof settings["plugin.inlang.messageFormat"] === "object" &&
+    settings["plugin.inlang.messageFormat"] !== null &&
+    "pathPattern" in settings["plugin.inlang.messageFormat"] &&
+    typeof settings["plugin.inlang.messageFormat"].pathPattern === "string"
+      ? settings["plugin.inlang.messageFormat"].pathPattern
+      : undefined;
+
+  if (!baseLocale || locales.length === 0 || !pathPattern?.includes("{locale}")) {
+    failures.push(
+      "project.inlang/settings.json must define baseLocale, locales, and a {locale} message path",
+    );
+    return;
+  }
+
+  const orderedLocales = [baseLocale, ...locales.filter((locale) => locale !== baseLocale)];
+  const localePaths = orderedLocales.map((locale) =>
+    pathPattern.replace("{locale}", locale).replace(/^\.\//, ""),
+  );
+  const localeMessages = localePaths.map(
+    (path) => [path, readStringRecord(join(root, path))] as const,
+  );
+  const [basePath, baseMessages] = localeMessages[0] ?? ["", {}];
+  const baseKeys = Object.keys(baseMessages).sort();
+
+  for (const [localePath, messages] of localeMessages.slice(1)) {
+    const keys = Object.keys(messages).sort();
+    const missing = baseKeys.filter((key) => !(key in messages));
+    const extra = keys.filter((key) => !(key in baseMessages));
+    if (missing.length > 0 || extra.length > 0) {
+      failures.push(
+        `localization key mismatch ${basePath} ↔ ${localePath}; missing: ${missing.join(", ") || "none"}; extra: ${extra.join(", ") || "none"}`,
+      );
+    }
+
+    for (const key of baseKeys.filter((candidate) => candidate in messages)) {
+      const basePlaceholders = placeholders(baseMessages[key] ?? "");
+      const localePlaceholders = placeholders(messages[key] ?? "");
+      if (basePlaceholders.join("|") !== localePlaceholders.join("|")) {
+        failures.push(
+          `localization placeholder mismatch for ${key}: ${basePath} has {${basePlaceholders.join(", ")}}, ${localePath} has {${localePlaceholders.join(", ")}}`,
+        );
+      }
+    }
+  }
+}
+
+function checkMarkdownLinks(): void {
+  const markdownFiles = collectMarkdownFiles(root);
+  const linkPattern = /\[[^\]]*\]\(([^)]+)\)/g;
+
+  for (const absolutePath of markdownFiles) {
+    const text = readFileSync(absolutePath, "utf8");
+    for (const match of text.matchAll(linkPattern)) {
+      const rawTarget = match[1]?.trim();
+      if (!rawTarget || rawTarget.startsWith("#") || /^(?:https?:|mailto:)/.test(rawTarget)) {
+        continue;
+      }
+      const withoutTitle = rawTarget.split(/\s+["']/)[0] ?? rawTarget;
+      const fileTarget = decodeURIComponent(withoutTitle.split("#")[0] ?? "");
+      if (!fileTarget) {
+        continue;
+      }
+      const resolvedTarget = resolve(dirname(absolutePath), fileTarget);
+      if (!existsSync(resolvedTarget)) {
+        failures.push(
+          `broken local Markdown link in ${relative(root, absolutePath)}: ${rawTarget}`,
+        );
+      }
+    }
+  }
+}
+
+function workspaceManifestPaths(directory: string): Array<string> {
+  const absoluteDirectory = join(root, directory);
+  return readdirSync(absoluteDirectory, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => join(directory, entry.name, "package.json"))
+    .filter((manifestPath) => existsSync(join(root, manifestPath)));
+}
+
+function tomlSection(content: string, section: string): Array<string> {
+  const lines = content.split("\n");
+  const start = lines.findIndex((line) => line.trim() === `[${section}]`);
+  if (start < 0) {
+    return [];
+  }
+  const end = lines.findIndex((line, index) => index > start && /^\s*\[/.test(line));
+  return lines
+    .slice(start + 1, end < 0 ? undefined : end)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !line.startsWith("#"));
+}
+
+function placeholders(message: string): Array<string> {
+  return [...message.matchAll(/\{([^}]+)\}/g)]
+    .map((match) => match[1] ?? "")
+    .filter(Boolean)
+    .sort();
+}
+
+function collectMarkdownFiles(directory: string): Array<string> {
+  const ignoredDirectories = new Set([
+    ".build",
+    ".git",
+    ".tmp",
+    "node_modules",
+    "target",
+    "vendor",
+  ]);
+  const files: Array<string> = [];
+
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.isDirectory() && ignoredDirectories.has(entry.name)) {
+      continue;
+    }
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectMarkdownFiles(entryPath));
+    } else if (entry.isFile() && entry.name.endsWith(".md") && statSync(entryPath).isFile()) {
+      files.push(entryPath);
+    }
+  }
+
+  return files;
+}
+
+function readJson(path: string): PackageManifest {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as PackageManifest;
+  } catch (error) {
+    failures.push(`invalid JSON in ${relative(root, path)}: ${String(error)}`);
+    return {};
+  }
+}
+
+function readStringRecord(path: string): Record<string, string> {
+  const parsed = readUnknownRecord(path);
+  const nonStringKeys = Object.entries(parsed)
+    .filter(([, value]) => typeof value !== "string")
+    .map(([key]) => key);
+  if (nonStringKeys.length > 0) {
+    failures.push(
+      `localization messages must be strings in ${relative(root, path)}: ${nonStringKeys.join(", ")}`,
+    );
+  }
+  return Object.fromEntries(
+    Object.entries(parsed).filter(
+      (entry): entry is [string, string] => typeof entry[1] === "string",
+    ),
+  );
+}
+
+function readUnknownRecord(path: string): Record<string, unknown> {
+  try {
+    return JSON.parse(readFileSync(path, "utf8")) as Record<string, unknown>;
+  } catch (error) {
+    failures.push(`invalid JSON in ${relative(root, path)}: ${String(error)}`);
+    return {};
+  }
+}

--- a/Scripts/repository_invariants.ts
+++ b/Scripts/repository_invariants.ts
@@ -12,6 +12,7 @@ type PackageManifest = {
 
 const root = resolve(process.env.GG_REPOSITORY_ROOT ?? resolve(import.meta.dir, ".."));
 const failures: Array<string> = [];
+let effectVendorVersionChecked = false;
 
 const requiredGuides = [
   "AGENTS.md",
@@ -44,7 +45,11 @@ if (failures.length > 0) {
 
 console.log("Repository invariant check passed:");
 console.log(`- ${requiredGuides.length} required agent/review guides present`);
-console.log("- Effect runtime package allowlist matches the vendor version");
+console.log(
+  effectVendorVersionChecked
+    ? "- Effect runtime packages are aligned and match the initialized vendor submodule"
+    : "- Effect runtime packages are aligned (vendor comparison skipped; submodule not initialized)",
+);
 console.log("- generated Rust dependency table matches the generator template");
 console.log("- localization keys and placeholders match across supported locales");
 console.log("- inline local Markdown file links resolve");
@@ -80,11 +85,23 @@ function checkEffectVersionAlignment(): void {
     }
   }
 
+  if (versions.size === 0) {
+    failures.push("no Effect runtime dependencies found in workspace manifests");
+    return;
+  }
+
+  if (versions.size > 1) {
+    failures.push(
+      `workspace Effect runtime versions are not aligned: ${[...versions.entries()]
+        .map(([version, locations]) => `${version} at ${locations.join(", ")}`)
+        .join("; ")}`,
+    );
+    return;
+  }
+
+  const workspaceVersion = versions.keys().next().value;
   const vendorManifestPath = "vendor/effect/packages/effect/package.json";
   if (!existsSync(join(root, vendorManifestPath))) {
-    failures.push(
-      `Effect vendor submodule is unavailable; run git submodule update --init vendor/effect`,
-    );
     return;
   }
 
@@ -94,17 +111,11 @@ function checkEffectVersionAlignment(): void {
     return;
   }
 
-  if (versions.size === 0) {
-    failures.push("no Effect runtime dependencies found in workspace manifests");
-    return;
-  }
-
-  for (const [version, locations] of versions) {
-    if (version !== vendorVersion) {
-      failures.push(
-        `Effect version ${version} at ${locations.join(", ")} does not match vendor/effect ${vendorVersion}`,
-      );
-    }
+  effectVendorVersionChecked = true;
+  if (workspaceVersion !== vendorVersion) {
+    failures.push(
+      `workspace Effect runtime version ${workspaceVersion} does not match vendor/effect ${vendorVersion}`,
+    );
   }
 }
 

--- a/Scripts/typescript_gate.sh
+++ b/Scripts/typescript_gate.sh
@@ -12,21 +12,22 @@ process_start_identity() {
 
 while ! mkdir "$lock_dir" 2>/dev/null; do
   if [[ ! -f "$lock_dir/owner" ]]; then
-    # The owner writes this immediately after mkdir. Give it one second, then recover a lock
-    # left by a process that exited between those operations.
+    # The owner writes this immediately after mkdir. Give it one second to publish ownership.
     sleep 1
     lock_waited_seconds=$((lock_waited_seconds + 1))
     if [[ ! -f "$lock_dir/owner" ]]; then
-      rm -rf "$lock_dir"
-      continue
+      echo "Stale TypeScript gate lock has no owner metadata: $lock_dir" >&2
+      echo "After confirming no gate is running, remove it with: rm -rf '$lock_dir'" >&2
+      exit 1
     fi
   fi
 
   IFS='|' read -r lock_pid lock_process_start < "$lock_dir/owner" || true
   current_process_start="$(process_start_identity "${lock_pid:-0}")"
   if [[ -z "$current_process_start" || "$current_process_start" != "$lock_process_start" ]]; then
-    rm -rf "$lock_dir"
-    continue
+    echo "Stale TypeScript gate lock is owned by an exited or recycled process: $lock_dir" >&2
+    echo "After confirming no gate is running, remove it with: rm -rf '$lock_dir'" >&2
+    exit 1
   fi
 
   if ((lock_waited_seconds >= lock_timeout_seconds)); then

--- a/Scripts/typescript_gate.sh
+++ b/Scripts/typescript_gate.sh
@@ -2,17 +2,53 @@
 set -euo pipefail
 
 lock_dir=".tmp/typescript-gate.lock"
+lock_timeout_seconds="${GG_TYPESCRIPT_GATE_LOCK_TIMEOUT_SECONDS:-1800}"
+lock_waited_seconds=0
 mkdir -p .tmp
+
+process_start_identity() {
+  ps -o lstart= -p "$1" 2>/dev/null | awk '{$1=$1; print}'
+}
+
 while ! mkdir "$lock_dir" 2>/dev/null; do
-  if [[ -f "$lock_dir/pid" ]] && ! kill -0 "$(cat "$lock_dir/pid")" 2>/dev/null; then
+  if [[ ! -f "$lock_dir/owner" ]]; then
+    # The owner writes this immediately after mkdir. Give it one second, then recover a lock
+    # left by a process that exited between those operations.
+    sleep 1
+    lock_waited_seconds=$((lock_waited_seconds + 1))
+    if [[ ! -f "$lock_dir/owner" ]]; then
+      rm -rf "$lock_dir"
+      continue
+    fi
+  fi
+
+  IFS='|' read -r lock_pid lock_process_start < "$lock_dir/owner" || true
+  current_process_start="$(process_start_identity "${lock_pid:-0}")"
+  if [[ -z "$current_process_start" || "$current_process_start" != "$lock_process_start" ]]; then
     rm -rf "$lock_dir"
     continue
   fi
-  echo "==> waiting for another TypeScript gate in this worktree"
+
+  if ((lock_waited_seconds >= lock_timeout_seconds)); then
+    echo "Timed out waiting ${lock_timeout_seconds}s for TypeScript gate owned by PID ${lock_pid}." >&2
+    exit 1
+  fi
+
+  echo "==> waiting for another TypeScript gate in this worktree (PID ${lock_pid})"
   sleep 1
+  lock_waited_seconds=$((lock_waited_seconds + 1))
 done
-printf '%s\n' "$$" > "$lock_dir/pid"
-trap 'rm -rf "$lock_dir"' EXIT INT TERM
+
+own_lock_identity="$$|$(process_start_identity "$$")"
+printf '%s\n' "$own_lock_identity" > "$lock_dir/owner"
+cleanup_gate_lock() {
+  if [[ -f "$lock_dir/owner" ]] && [[ "$(cat "$lock_dir/owner")" == "$own_lock_identity" ]]; then
+    rm -rf "$lock_dir"
+  fi
+}
+trap cleanup_gate_lock EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
 
 if ! command -v bun >/dev/null 2>&1; then
   echo "bun not found; install Bun first" >&2

--- a/Scripts/typescript_gate.sh
+++ b/Scripts/typescript_gate.sh
@@ -1,10 +1,30 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+lock_dir=".tmp/typescript-gate.lock"
+mkdir -p .tmp
+while ! mkdir "$lock_dir" 2>/dev/null; do
+  if [[ -f "$lock_dir/pid" ]] && ! kill -0 "$(cat "$lock_dir/pid")" 2>/dev/null; then
+    rm -rf "$lock_dir"
+    continue
+  fi
+  echo "==> waiting for another TypeScript gate in this worktree"
+  sleep 1
+done
+printf '%s\n' "$$" > "$lock_dir/pid"
+trap 'rm -rf "$lock_dir"' EXIT INT TERM
+
 if ! command -v bun >/dev/null 2>&1; then
   echo "bun not found; install Bun first" >&2
   exit 1
 fi
+
+echo "==> repository invariants"
+bun run repo:check
+bun run repo:test
+
+echo "==> documentation coverage ratchet"
+bun run docs:check
 
 echo "==> js format check (oxfmt)"
 bun run js:format:check

--- a/apps/desktop-electrobun/AGENTS.md
+++ b/apps/desktop-electrobun/AGENTS.md
@@ -1,0 +1,40 @@
+# Desktop agent guide
+
+Read the root `AGENTS.md` first.
+
+## Boundaries
+
+- `src/bun`: Electrobun host, one scoped Effect runtime, native engine/media services, menus/tray/windows.
+- `src/mainview`: React Creator Studio renderer.
+- `src/shared`: bridge contracts, command and shortcut registries, localization-facing shared models.
+- `tests`: unit, integration, parity, and Vitest Browser interaction coverage.
+
+The renderer talks through typed bridge/query boundaries. Do not import Bun or native filesystem/process APIs into renderer code. Keep `requestHandlers` thin; business flows belong in services composed by `AppRuntime`/`AppLayer`.
+
+## UI conventions
+
+- Preserve the editor-first `Capture -> Edit -> Deliver` shell and persistent timeline.
+- Use shared UI primitives and semantic tone tokens instead of one-off styling.
+- Route strings through `messages/en-US.json` and `messages/de-DE.json` and the existing localization model.
+- Use the shared shortcut registry; honor overrides, conflict validation, editable-target scoping, and single-key-shortcut policy.
+- Interactive timeline and separator controls require keyboard semantics, pointer capture where appropriate, visible focus, and reduced-motion behavior.
+- Keep degraded engine/permission/host-dialog states visible and actionable.
+
+## State and media
+
+- Pure edit semantics belong in domain command modules, not React components.
+- Keep display-clock rendering separate from frame-quantized edit decisions.
+- Never send raw local media paths to the renderer; use tokenized loopback media URLs.
+- Preview semantics must match persisted project state and native export.
+
+## Testing
+
+Use unit tests for pure commands and model parsing, component tests for view dispatch/state, Vitest Browser for pointer/keyboard/media interactions, and parity tests for real engine-client behavior.
+
+```bash
+bun run i18n:compile
+bun run desktop:typecheck
+bun run desktop:test
+bun run desktop:test:ui
+bun run desktop:test:e2e
+```

--- a/apps/web/AGENTS.md
+++ b/apps/web/AGENTS.md
@@ -1,0 +1,23 @@
+# Web agent guide
+
+Read the root `AGENTS.md` first.
+
+The web app is the hosted review/auth shell, not the local media plane. TanStack Start routes/components live under `src`; Convex functions and hosted data live under `convex`; shared hosted DTOs belong in `packages/review-protocol`.
+
+## Rules
+
+- Do not make web availability, authentication, billing, or Convex connectivity a prerequisite for desktop capture/edit/export.
+- Do not place raw local media paths or local engine credentials in hosted contracts.
+- Keep auth-provider casts and compatibility workarounds narrow, documented, and removable when upstream types align.
+- Route user-visible strings through shared localization sources and do not commit generated Paraglide output.
+- Prefer versionable review-protocol DTOs over ad hoc route payloads.
+- Add tests when the package has behavior to test; a package with no tests should still typecheck and build cleanly.
+
+## Checks
+
+```bash
+bun run i18n:compile:web
+bun run web:typecheck
+bun run web:build
+cd apps/web && bun run test:ci -- --passWithNoTests
+```

--- a/docs/BACKGROUND_FRAMING_DESIGN.md
+++ b/docs/BACKGROUND_FRAMING_DESIGN.md
@@ -1,0 +1,103 @@
+# Background framing contract design
+
+Status: approved contract for the Phase 2 `background-framing-contract` and `background-framing-renderer` slices.
+
+## Goal
+
+Place captured screen content on a deterministic background stage with padding, rounded corners, and a shadow. The model must persist in project packages, travel explicitly with export requests, remain resolution-independent, and preserve existing output for old projects.
+
+## Version 1 model
+
+Use one shared `BackgroundFramingSettings` object:
+
+```ts
+type BackgroundFramingSettings = {
+  version: 1;
+  enabled: boolean;
+  backgroundColor: string;
+  paddingFraction: number;
+  cornerRadiusFraction: number;
+  shadowStrength: number;
+};
+```
+
+Contract constraints and defaults:
+
+| Field                  | Constraint                                                              | Default   | Meaning                                                                            |
+| ---------------------- | ----------------------------------------------------------------------- | --------- | ---------------------------------------------------------------------------------- |
+| `version`              | literal `1`                                                             | `1`       | Style-algorithm version for deterministic future evolution.                        |
+| `enabled`              | boolean                                                                 | `false`   | Disabled preserves the pre-framing full-frame render.                              |
+| `backgroundColor`      | uppercase or lowercase `#RRGGBB`; normalize to uppercase when persisted | `#18181B` | Opaque sRGB stage color. Alpha, gradients, and images are not part of v1.          |
+| `paddingFraction`      | finite number, `0...0.25`                                               | `0.06`    | Inset on every side as a fraction of the shorter output dimension.                 |
+| `cornerRadiusFraction` | finite number, `0...0.10`                                               | `0.025`   | Card corner radius as a fraction of the shorter fitted-card dimension.             |
+| `shadowStrength`       | finite number, `0...1`                                                  | `0.35`    | Unitless input to the versioned renderer shadow formula. Zero disables the shadow. |
+
+Do not store pixels: the same project must render consistently at different export resolutions and aspect ratios. Do not add per-clip framing in v1; these settings are project-global with an optional export override.
+
+## Contract placement
+
+Define the schema and runtime type in `packages/engine-contract/src/shared/valueObjects.ts`, then add:
+
+- required `backgroundFraming` to `projectStateSchema`;
+- optional `backgroundFraming` to `projectSavePayloadSchema`;
+- optional `backgroundFraming` to `exportRunPayloadSchema`.
+
+The required project-state field represents the resolved default. Save/export payload fields remain optional for wire compatibility with older clients.
+
+## Persistence and migration
+
+- Persist the object at the project root as `backgroundFraming`.
+- Existing project versions and missing fields decode to the defaults above.
+- Follow the existing project migration/versioning mechanism; add explicit fixtures for the previous current version and the new version.
+- Reject non-finite/out-of-range values at the contract boundary. Native decoding of legacy project files may default a wholly absent object, but must not partially accept malformed present values.
+- Saving should emit the complete normalized v1 object.
+
+## Export precedence
+
+Resolve settings in this order:
+
+1. explicit `export.run` payload override;
+2. active persisted project settings;
+3. v1 defaults.
+
+Desktop export should send the renderer/controller's complete resolved settings so unsaved inspector changes are deterministic. Older clients may omit the field and receive persisted/default behavior.
+
+During the contract-only slice, native export may accept and retain the setting while `enabled: false` preserves old output. Enabling UI and rendering non-default settings belongs to the immediately following renderer slice; do not expose a control that claims to affect preview/export before that wiring lands.
+
+## Version 1 renderer semantics
+
+The renderer slice must implement the same geometry for preview and native export:
+
+1. Fill the output with `backgroundColor`.
+2. Compute `paddingPixels = paddingFraction * min(outputWidth, outputHeight)`.
+3. Aspect-fit the source inside the output rectangle inset by `paddingPixels`; never crop in this slice.
+4. Compute `cornerRadiusPixels = cornerRadiusFraction * min(cardWidth, cardHeight)` and clip the source card.
+5. Derive the shadow from `shadowStrength` and style `version`:
+   - opacity: `0.30 * shadowStrength`;
+   - blur radius: `0.035 * min(outputWidth, outputHeight) * shadowStrength`;
+   - x offset: `0`;
+   - y offset: `0.012 * min(outputWidth, outputHeight) * shadowStrength`.
+6. Apply timeline/camera transforms within the source card's content coordinate space, not to the background stage.
+
+Exact rounding should use floating-point geometry until the final render API; tests may allow a one-pixel raster tolerance while asserting deterministic transform values.
+
+## Explicit non-goals
+
+- Gradient, image, blur, or transparent backgrounds.
+- User-defined shadow offsets/colors.
+- Per-clip or keyframed framing.
+- Crop/reframe behavior.
+- Vertical camera replanning.
+- Motion blur.
+
+Those require new versioned fields or later roadmap slices rather than overloading v1 values.
+
+## Required contract-slice coverage
+
+- Effect Schema valid/default-shaped encode/decode tests and every numeric boundary.
+- Invalid color, NaN/infinity, negative, and over-maximum rejection.
+- Generated OpenAPI and Swift/Rust binding determinism.
+- Swift project migration and save/open round trip.
+- Rust foundation project save/open parity.
+- Export precedence tests, even before visual rendering is enabled.
+- Desktop payload propagation tests without exposing incomplete controls.

--- a/docs/CHANGE_MAP.md
+++ b/docs/CHANGE_MAP.md
@@ -1,0 +1,137 @@
+# Change map
+
+This guide maps common changes to their sources of truth, propagation path, and minimum validation. Read the nearest subsystem `AGENTS.md` as well.
+
+## Engine endpoint or wire-schema change
+
+```text
+packages/engine-contract/src/domains/*
+  -> packages/engine-contract/src/httpApi.ts
+  -> generated OpenAPI
+  -> generated Swift/Rust bindings
+  -> packages/engine-client
+  -> native handlers
+  -> Bun host bridge
+  -> renderer
+```
+
+Procedure:
+
+1. Change the Effect schema/domain and `HttpApi` definition.
+2. Add contract tests for encoding, decoding, and failure shapes.
+3. Run `bun run protocol:generate-bindings`.
+4. Format generated Rust with `cargo fmt --all`.
+5. Implement client and native handlers using generated types.
+6. Add native and parity tests.
+7. Run `bun run protocol:check-determinism`; it hashes generated artifacts, regenerates them, and fails if the second generation changes those artifacts.
+
+Minimum checks:
+
+```bash
+bun run repo:check
+bun run protocol:typecheck
+bun run protocol:generate-bindings
+cargo fmt --all
+bun run protocol:check-determinism
+cargo test --workspace --all-targets
+swift test
+```
+
+## Persisted project setting
+
+```text
+Effect project schema/default
+  -> generated protocol
+  -> Swift/Rust project model or handler
+  -> project migration/store
+  -> renderer controller
+  -> inspector/preview
+  -> export payload and renderer
+```
+
+Define constraints and defaults before UI. Existing projects must load. Add migration/round-trip tests and verify malformed values are sanitized or rejected consistently. If a visual setting affects final media, preview and export must share the same semantics.
+
+## Timeline operation
+
+```text
+pure timeline command
+  -> controller action
+  -> timeline/inspector interaction
+  -> selection and playhead result
+  -> project persistence
+  -> preview mapping
+  -> export mapping
+```
+
+Start with deterministic command tests. Cover ripple and non-ripple behavior, edge gaps, source/program time mapping, undoable state boundaries where present, and browser interaction. Consult `docs/TIMELINE_EDITING_DESIGN.md`.
+
+Minimum checks:
+
+```bash
+bun run desktop:typecheck
+bun run desktop:test
+bun run desktop:test:ui
+swift test
+bun run desktop:test:e2e
+```
+
+## Localized desktop UI
+
+1. Add message keys to both `messages/en-US.json` and `messages/de-DE.json`.
+2. Expose messages through the existing localization model rather than importing generated messages throughout components.
+3. Compile with `bun run i18n:compile`.
+4. Do not commit `src/paraglide` output.
+5. Test keyboard operation, accessible names/state, focus visibility, and reduced motion.
+
+## Electrobun host capability
+
+```text
+shared bridge contract
+  -> scoped Bun service/AppLayer
+  -> thin request handler or host command router
+  -> renderer query/controller
+  -> UI
+```
+
+Do not add application logic directly to bridge handlers. Acquire windows, menus, trays, servers, processes, and subscriptions through scoped services. Test lifecycle cleanup and recoverable host-dialog timeouts.
+
+## Native capture or export behavior
+
+- macOS production behavior belongs under `engines/macos-swift`.
+- Shared HTTP/security/foundation behavior belongs under `engines/native-foundation` when genuinely portable.
+- Windows/Linux shells must report only implemented capabilities.
+- Add unit coverage at the native layer and parity coverage through the engine client.
+- Capture work must consider permission denial, cancellation, static scenes, dropped frames, backpressure, and cleanup.
+- Export work must consider invalid paths, symlinks, timeline gaps, trim time domains, and deterministic output settings.
+
+## Hosted review/auth change
+
+```text
+packages/review-protocol
+  -> apps/web/convex
+  -> apps/web routes/components
+```
+
+Keep hosted identity and billing out of local engine contracts. Verify local desktop workflows remain independent of network/auth availability.
+
+## Dependency upgrade
+
+1. Upgrade direct manifests and regenerate lockfiles.
+2. Keep all Effect package versions aligned with `vendor/effect/packages/effect/package.json`.
+3. For generated Rust dependencies, edit `engines/protocol-rust/openapi-generator-templates/Cargo.mustache`, regenerate, and verify the generated manifest.
+4. Check Swift direct pins and resolved transitive changes.
+5. Run `bun outdated --recursive`, `cargo update --dry-run`, and `swift package show-dependencies`; use release metadata to check whether direct Cargo/Swift manifest pins are current and document intentional compatibility holds.
+6. Run `bun install --frozen-lockfile`, `bun run repo:check`, and the full gate.
+
+## Documentation or roadmap change
+
+- Requirements belong in `docs/SPEC.md`.
+- Execution status and ordering belong in `docs/ROADMAP.md`.
+- Architecture boundaries belong in `docs/ARCHITECTURE.md`.
+- Agent operations belong in `AGENTS.md` or the nearest nested agent guide.
+- Review policy belongs in `REVIEW.md`.
+- Historical migration documents should not become an alternate active backlog.
+
+When a tracked feature merges, update its checkbox and implementation notes in the same PR.
+
+`docs/doc_coverage_policy.json` records ratchet floors from the current documented public surface. Do not lower a floor to make a change pass; add API documentation and raise floors as coverage improves. Generated protocol surfaces currently remain measured so generator/template improvements can raise their baseline over time.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,7 +30,10 @@ Creator Studio tracking checklist (current repo):
 - [x] Route `Current Window` recording through engine-side frontmost window resolution (`capture.startCurrentWindow`) instead of renderer-side source-order inference
 - [x] Handle host-dialog RPC timeouts as recoverable workflow interruptions with guidance copy
 - [x] Keep core keyboard shortcuts (`record`, `play/pause`, `trim in/out`, `save`, `export`)
-- [ ] Add user-configurable shortcut overrides with validation and conflict handling
+- [x] Add user-configurable shortcut overrides with validation and conflict handling
+  - Implementation notes:
+    - Shortcut overrides are edited in the inspector, validated against active bindings, persisted as desktop preferences, and reflected in renderer hotkeys plus native menu/tray hints.
+    - Shared shortcut registry tests cover sanitization, conflicts, host menu synchronization, and customized hotkey dispatch.
 - [x] Keep degraded-mode messaging visible near preview/recording context
 - [x] Add host command bus between Bun shell menu/tray and renderer actions
 - [x] Add cross-platform native shell actions (application menu on macOS/Windows, tray fallback on Linux)
@@ -185,7 +188,7 @@ Groundwork already present:
 
 - [x] Editor-first shell baseline exists (`Capture` / `Edit` / `Deliver`).
 - [x] Timeline toolbar and lane surface exist.
-- [x] Auto-zoom and background-framing settings exist in the inspector.
+- [x] Auto-zoom settings exist in the inspector; background-framing localization/scaffold labels exist for the pending contract and renderer slices.
 - [x] Deliver/export route exists as a local surface.
 - [x] Imported-transcript protocol groundwork exists for later caption/transcript editing.
 
@@ -302,7 +305,7 @@ Suggested Phase 2 PR slices:
 
 1. `phase2/timeline-v2-export-macos` — make macOS export honor timeline v2 edits, gaps, and program-time Deliver trims.
 2. `phase2/timeline-drag-move-gaps` — add drag-to-move, finish gap interaction/readability, and verify preview behavior across gaps.
-3. `phase2/background-framing-contract` — define persisted background framing/effects settings in the project/export contract.
+3. `phase2/background-framing-contract` — define persisted background framing/effects settings in the project/export contract per `docs/BACKGROUND_FRAMING_DESIGN.md`.
 4. `phase2/background-framing-renderer` — implement native export rendering for background stage, padding, rounded screen card, and shadow.
 5. `phase2/vertical-camera-replan` — make camera planning/export aspect-ratio-aware for 9:16 vertical output.
 6. `phase2/segment-camera-overrides` — add clip-level camera/keyframe override model and inspector controls.
@@ -318,7 +321,7 @@ Suggested Phase 2 PR slices:
 **Phase 3 — Packaging, hosted delivery, polish, and parity**
 
 - Motion blur controls
-- Per-segment overrides
+- Advanced per-segment visual/effect overrides beyond Phase 2 camera/keyframe controls
 - Simulator auto-crop
 - Optional ProRes mezzanine
 - Delivery packaging improvements (chapters/titles/end-card style metadata where they fit)
@@ -331,7 +334,7 @@ Suggested Phase 2 PR slices:
 Progress (current repo)
 
 - [ ] Motion blur controls
-- [ ] Per-segment overrides
+- [ ] Advanced per-segment visual/effect overrides beyond Phase 2 camera/keyframe controls
 - [ ] Simulator auto-crop
 - [ ] Optional ProRes mezzanine
 - [ ] Delivery packaging improvements

--- a/docs/doc_coverage_policy.json
+++ b/docs/doc_coverage_policy.json
@@ -4,7 +4,7 @@
       "name": "desktop-bridge-public-api",
       "roots": ["apps/desktop-electrobun/src/bun"],
       "extensions": [".ts"],
-      "minimumCoverage": 1
+      "minimumCoverage": 0.4479166666666667
     }
   ],
   "swift": [
@@ -18,7 +18,7 @@
       "name": "macos-engine-public-surface",
       "roots": ["engines/macos-swift"],
       "extensions": [".swift"],
-      "minimumCoverage": 1
+      "minimumCoverage": 0.9066666666666666
     }
   ],
   "rust": [
@@ -26,13 +26,13 @@
       "name": "protocol-rust-public-api",
       "roots": ["engines/protocol-rust/src"],
       "extensions": [".rs"],
-      "minimumCoverage": 1
+      "minimumCoverage": 0.16666666666666666
     },
     {
       "name": "native-foundation-public-api",
       "roots": ["engines/native-foundation/src"],
       "extensions": [".rs"],
-      "minimumCoverage": 1
+      "minimumCoverage": 0.6
     }
   ]
 }

--- a/engines/AGENTS.md
+++ b/engines/AGENTS.md
@@ -1,0 +1,32 @@
+# Native engines agent guide
+
+Read the root `AGENTS.md` and `docs/CHANGE_MAP.md` first.
+
+## Ownership
+
+- `macos-swift`: production macOS capture, recording, project, and export behavior.
+- `native-foundation`: portable Rust HTTP/security/state behavior.
+- `linux-native`, `windows-native`: protocol/parity shells until production media milestones are implemented.
+- `protocol-swift`, `protocol-rust`: generated OpenAPI bindings plus clearly separated project-owned middleware/helpers/templates.
+
+## Rules
+
+- Implement generated `APIProtocol`/Axum shapes; do not create a parallel wire protocol.
+- Advertise capabilities only when the target implements them.
+- Keep bearer authentication, loopback restrictions, request limits, path traversal, and symlink defenses intact.
+- Capture resources must clean up on cancellation, failure, and restart.
+- Export must match renderer program-time semantics, including clip order, gaps, trims, and camera transforms.
+- A dependency change in generated `protocol-rust/Cargo.toml` must originate in `protocol-rust/openapi-generator-templates/Cargo.mustache`.
+- Do not edit generated model/server files directly; regenerate from the TypeScript contract.
+
+## Checks
+
+```bash
+cargo fmt --all --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo test --workspace --all-targets
+swiftformat --lint .
+swiftlint --quiet
+swift test
+bun run protocol:generate-bindings
+```

--- a/package.json
+++ b/package.json
@@ -7,15 +7,18 @@
     "packages/*"
   ],
   "scripts": {
+    "bootstrap": "bash ./Scripts/bootstrap.sh",
     "gate": "bash ./Scripts/full_gate.sh",
     "gate:rust": "bash ./Scripts/rust_gate.sh",
     "gate:typescript": "bash ./Scripts/typescript_gate.sh",
-    "js:format": "bunx oxfmt --write apps packages '!apps/*/src/paraglide/**' '!apps/*/build/**' '!apps/*/dist/**' '!packages/engine-contract/generated/**'",
-    "js:format:check": "bunx oxfmt --check apps packages '!apps/*/src/paraglide/**' '!apps/*/build/**' '!apps/*/dist/**' '!packages/engine-contract/generated/**'",
+    "repo:check": "bun ./Scripts/repository_invariants.ts",
+    "repo:test": "bun test Scripts/repository_invariants.test.ts",
+    "js:format": "bunx oxfmt --write apps packages Scripts '!apps/*/src/paraglide/**' '!apps/*/build/**' '!apps/*/dist/**' '!packages/engine-contract/generated/**'",
+    "js:format:check": "bunx oxfmt --check apps packages Scripts '!apps/*/src/paraglide/**' '!apps/*/build/**' '!apps/*/dist/**' '!packages/engine-contract/generated/**'",
     "js:lint": "bun run i18n:compile && bun run js:lint:ci",
     "js:lint:ci": "bunx oxlint --type-aware --type-check --deny-warnings apps packages Scripts",
     "js:lint:react-effects": "bun ./Scripts/lint_no_state_updates_in_effect.mjs",
-    "i18n:compile": "bun run i18n:compile:desktop && bun run i18n:compile:web",
+    "i18n:compile": "bun ./Scripts/compile_i18n.ts",
     "i18n:compile:desktop": "paraglide-js compile --project ./project.inlang --outdir ./apps/desktop-electrobun/src/paraglide --strategy localStorage baseLocale --emit-ts-declarations --no-emit-git-ignore",
     "i18n:compile:web": "paraglide-js compile --project ./project.inlang --outdir ./apps/web/src/paraglide --strategy localStorage baseLocale --emit-ts-declarations --no-emit-git-ignore",
     "desktop:dev": "cd apps/desktop-electrobun && bun run dev",
@@ -32,6 +35,7 @@
     "web:build": "cd apps/web && bun run build",
     "web:typecheck": "cd apps/web && bun run typecheck",
     "protocol:generate-bindings": "bash Scripts/generate_engine_protocol_v2.sh",
+    "protocol:check-determinism": "bun ./Scripts/check_protocol_determinism.ts",
     "protocol:typecheck": "(cd packages/engine-contract && bun run check:contract:full) && (cd packages/engine-client && bun run typecheck) && (cd packages/review-protocol && bun run typecheck)",
     "protocol:rust:test": "cargo test --manifest-path engines/protocol-rust/Cargo.toml",
     "swift:build": "swift build",
@@ -47,6 +51,12 @@
     "coverage:check": "bash ./Scripts/coverage_check.sh",
     "prepare": "effect-language-service patch"
   },
+  "dependencies": {
+    "@better-auth/expo": "~1.6.15",
+    "@convex-dev/better-auth": "^0.12.5",
+    "better-auth": "~1.6.15",
+    "convex": "^1.42.3"
+  },
   "devDependencies": {
     "@effect/language-service": "^0.87.1",
     "@inlang/paraglide-js": "^2.22.0",
@@ -60,11 +70,5 @@
     "oxlint-tsgolint": "^7.0.2001",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.65.0"
-  },
-  "dependencies": {
-    "@better-auth/expo": "~1.6.15",
-    "@convex-dev/better-auth": "^0.12.5",
-    "better-auth": "~1.6.15",
-    "convex": "^1.42.3"
   }
 }

--- a/packages/engine-contract/AGENTS.md
+++ b/packages/engine-contract/AGENTS.md
@@ -1,0 +1,24 @@
+# Engine contract agent guide
+
+Read the root `AGENTS.md` and `docs/CHANGE_MAP.md` first.
+
+This package is the source of truth for the native engine wire protocol. Domain models use Effect Schema and operations are assembled in `src/httpApi.ts`. Generated OpenAPI and native bindings are derivatives.
+
+## Rules
+
+- Define reusable constrained values in domain/shared schema modules rather than duplicating validation.
+- Keep transport errors explicit and serializable.
+- Add encoding/decoding and operation-shape tests for contract changes.
+- Do not hand-edit `generated/engine.openapi.json`.
+- After a contract change, run root `bun run protocol:generate-bindings`; this also updates native OpenAPI inputs and Rust bindings.
+- Native handlers and `packages/engine-client` should consume generated/contract types rather than parallel DTOs.
+- Persisted project changes require defaults, compatibility/migration consideration, and preview/export parity.
+
+## Checks
+
+```bash
+(cd packages/engine-contract && bun run check:contract:full)
+bun run protocol:generate-bindings
+cargo fmt --all
+bun run protocol:check-determinism
+```


### PR DESCRIPTION
## Summary
- add root and subsystem `AGENTS.md` guides, a repository review rubric, and a cross-layer change map
- specify the complete background-framing v1 contract so the next Phase 2 slice can start without prompt-only domain knowledge
- add a one-command bootstrap path with required submodule, frozen dependency, localization, browser, and invariant setup
- enforce workspace Effect version alignment (plus vendor matching when the submodule is already initialized), generated Rust manifest ownership, locale key/placeholder parity, required guides, and local Markdown links
- add tested protocol determinism/stale-source inventory checks and wire them into CI
- restore documentation coverage as an exact current-baseline ratchet and run it in the canonical TypeScript gate
- serialize concurrent TypeScript gates in one worktree to prevent generated localization races between agents
- reconcile stale/ambiguous roadmap entries and make the PR template review-aware

## Validation
- `bun run bootstrap`
- `bun run repo:check`
- `bun run repo:test` (7 tests)
- `bun run docs:check`
- `bun run protocol:typecheck`
- `bun run protocol:check-determinism` (with Homebrew OpenJDK on `PATH`)
- two concurrent `SKIP_DESKTOP_TESTS=1 bun run gate:typescript` invocations (both passed; second waited on worktree lock)
- `bun run gate`
- `git diff --check`

## Independent Herdr validation
Two zero-context pi agents in the neighboring Herdr panes independently exercised contributor navigation and reviewed correctness/enforceability. Their first reviews found command, CI, bootstrap, roadmap, ratchet, stale-generation, and concurrency gaps; those findings were fixed and revalidated.

Final verdicts:
- first-day navigation agent: **10/10 discoverability**, no blockers, can begin `phase2/background-framing-contract` without prompter context
- DevEx reviewer: **9/10 discoverability / correctness / enforceability**, no blocker/high findings, **Ship**

