### PR TITLE
refactor(types): enforce Effect branded domain identities

### DIFF
--- a/REVIEW.md
+++ b/REVIEW.md
@@ -35,6 +35,7 @@ Use this rubric for human and agent review. Report concrete defects with file/li
 ## Engine contract and native code
 
 - Effect Schema/`HttpApi` changes are the wire-contract source of truth.
+- Domain IDs, tokens, paths, and URL/path handles retain `Schema.brand` types through engine-client and bridge internals; raw primitives are converted at boundaries.
 - OpenAPI and Swift/Rust bindings regenerate without unexplained diffs.
 - `engines/protocol-rust/Cargo.toml` dependency changes originate in `openapi-generator-templates/Cargo.mustache`.
 - Swift and Rust handlers use generated request/response types rather than parallel DTOs.

--- a/Scripts/capture_benchmark.ts
+++ b/Scripts/capture_benchmark.ts
@@ -108,7 +108,7 @@ function createBenchmarkEngineClient(enginePath: string) {
     startDisplayCapture: (
       enableMic: boolean,
       captureFps: CaptureFrameRate,
-      displayId?: number,
+      displayId?: DisplaySource["id"],
       enablePreview?: boolean,
     ) =>
       runCaptureStatus(
@@ -117,7 +117,7 @@ function createBenchmarkEngineClient(enginePath: string) {
         ),
       ),
     startWindowCapture: (
-      windowId: number,
+      windowId: WindowSource["id"],
       enableMic: boolean,
       captureFps: CaptureFrameRate,
       enablePreview?: boolean,

--- a/apps/desktop-electrobun/src/bun/bridge/HostBridgeService.ts
+++ b/apps/desktop-electrobun/src/bun/bridge/HostBridgeService.ts
@@ -1,5 +1,8 @@
 import { Context, Effect, Layer, Option, Schema } from "effect";
-import { isoDateTimeSchema } from "@guerillaglass/engine-contract/schema-primitives";
+import {
+  isoDateTimeSchema,
+  type AgentJobId,
+} from "@guerillaglass/engine-contract/schema-primitives";
 import type { ReviewBridgeEvent } from "@guerillaglass/review-protocol";
 import {
   capturePreviewFrameResultSchema,
@@ -135,11 +138,11 @@ export const layerHostBridgeService = Layer.succeed(
           }
           case "ggEngineAgentStatus": {
             const agent = yield* AgentService;
-            return yield* agent.status((params as { jobId: string }).jobId);
+            return yield* agent.status((params as { jobId: AgentJobId }).jobId);
           }
           case "ggEngineAgentApply": {
             const agent = yield* AgentService;
-            return yield* agent.apply((params as { jobId: string }).jobId, params as never);
+            return yield* agent.apply((params as { jobId: AgentJobId }).jobId, params as never);
           }
           case "ggEngineRequestScreenRecordingPermission": {
             const permissions = yield* PermissionsService;
@@ -306,7 +309,7 @@ export const layerHostBridgeService = Layer.succeed(
             const capabilities = yield* CapabilityGrantService;
             const reviewId = (params as { reviewId: string }).reviewId;
             yield* capabilities.consume({
-              token: (params as { capabilityToken: string }).capabilityToken,
+              token: (params as BridgeRequests["ggReviewCreateComment"]["params"]).capabilityToken,
               scope: "review:mutate",
               subject: reviewMutationSubject(reviewId),
             });
@@ -320,7 +323,8 @@ export const layerHostBridgeService = Layer.succeed(
             const capabilities = yield* CapabilityGrantService;
             const reviewId = (params as { reviewId: string }).reviewId;
             yield* capabilities.consume({
-              token: (params as { capabilityToken: string }).capabilityToken,
+              token: (params as BridgeRequests["ggReviewSetWorkflowStatus"]["params"])
+                .capabilityToken,
               scope: "review:mutate",
               subject: reviewMutationSubject(reviewId),
             });
@@ -372,7 +376,8 @@ export const layerHostBridgeService = Layer.succeed(
               ),
             );
             yield* capabilities.consume({
-              token: (params as { capabilityToken: string }).capabilityToken,
+              token: (params as BridgeRequests["ggResolveMediaSourceURL"]["params"])
+                .capabilityToken,
               scope: "media:resolve-source",
               subject: mediaSourceSubject(allowedMediaPath),
             });
@@ -426,7 +431,8 @@ export const layerHostBridgeService = Layer.succeed(
               Effect.annotateLogs({ component: "host-bridge-capture", captureSessionId }),
             );
             yield* capabilities.consume({
-              token: (params as { capabilityToken: string }).capabilityToken,
+              token: (params as BridgeRequests["ggResolveCapturePreviewURL"]["params"])
+                .capabilityToken,
               scope: "capture:resolve-preview-url",
               subject: capturePreviewSubject(captureSessionId),
             });

--- a/apps/desktop-electrobun/src/bun/review/service.ts
+++ b/apps/desktop-electrobun/src/bun/review/service.ts
@@ -3,33 +3,36 @@ import { makeFunctionReference } from "convex/server";
 import { Context, Effect, Layer, Redacted } from "effect";
 import type {
   ReviewComment,
+  ReviewCommentId,
+  ReviewId,
   ReviewSessionSnapshot,
   ReviewSetWorkflowStatusResponse,
   ReviewWorkflowStatus,
 } from "@guerillaglass/review-protocol";
+import type { ReviewAuthToken } from "@guerillaglass/engine-contract/schema-primitives";
 import { messageFromUnknownError } from "@guerillaglass/engine-client/errors";
 import { AppConfig } from "../app/AppConfig";
 import { ReviewBridgeError } from "../../shared/errors/desktopErrors";
 
 const reviewSessionSnapshotQuery = makeFunctionReference<
   "query",
-  { reviewId: string },
+  { reviewId: ReviewId },
   ReviewSessionSnapshot
 >("review:sessionSnapshot");
 const reviewCreateCommentMutation = makeFunctionReference<
   "mutation",
   {
-    reviewId: string;
+    reviewId: ReviewId;
     body: string;
     frameNumber?: number;
     timestampSeconds?: number;
-    parentCommentId?: string;
+    parentCommentId?: ReviewCommentId;
   },
   ReviewComment
 >("review:createComment");
 const reviewSetWorkflowStatusMutation = makeFunctionReference<
   "mutation",
-  { reviewId: string; status: ReviewWorkflowStatus },
+  { reviewId: ReviewId; status: ReviewWorkflowStatus },
   ReviewSetWorkflowStatusResponse
 >("review:setWorkflowStatus");
 
@@ -37,20 +40,20 @@ type ReviewClientLike = Pick<ConvexHttpClient, "query" | "mutation">;
 
 type ReviewGatewayService = {
   sessionSnapshot: (params: {
-    authToken: string;
-    reviewId: string;
+    authToken: ReviewAuthToken;
+    reviewId: ReviewId;
   }) => Effect.Effect<ReviewSessionSnapshot, ReviewBridgeError>;
   createComment: (params: {
-    authToken: string;
-    reviewId: string;
+    authToken: ReviewAuthToken;
+    reviewId: ReviewId;
     body: string;
     frameNumber?: number;
     timestampSeconds?: number;
-    parentCommentId?: string;
+    parentCommentId?: ReviewCommentId;
   }) => Effect.Effect<ReviewComment, ReviewBridgeError>;
   setWorkflowStatus: (params: {
-    authToken: string;
-    reviewId: string;
+    authToken: ReviewAuthToken;
+    reviewId: ReviewId;
     status: ReviewWorkflowStatus;
   }) => Effect.Effect<ReviewSetWorkflowStatusResponse, ReviewBridgeError>;
 };

--- a/apps/desktop-electrobun/src/bun/security/DesktopCapabilities.ts
+++ b/apps/desktop-electrobun/src/bun/security/DesktopCapabilities.ts
@@ -1,5 +1,9 @@
 import { randomBytes } from "node:crypto";
 import { Context, Effect, Layer, Redacted } from "effect";
+import {
+  desktopCapabilityTokenSchema,
+  type DesktopCapabilityToken,
+} from "../../shared/bridge/desktopBridgeContract";
 import { CapabilityTokenError } from "../../shared/errors/desktopErrors";
 
 export const desktopCapabilityScopes = [
@@ -11,7 +15,7 @@ export const desktopCapabilityScopes = [
 export type DesktopCapabilityScope = (typeof desktopCapabilityScopes)[number];
 
 type CapabilityRecord = {
-  readonly token: Redacted.Redacted<string>;
+  readonly token: Redacted.Redacted<DesktopCapabilityToken>;
   readonly scope: DesktopCapabilityScope;
   readonly subject: string;
   readonly expiresAt: number;
@@ -29,15 +33,17 @@ export type MintCapabilityParams = {
 };
 
 export type ConsumeCapabilityParams = {
-  readonly token: string;
+  readonly token: DesktopCapabilityToken;
   readonly scope: DesktopCapabilityScope;
   readonly subject: string;
 };
 
 export type CapabilityGrantServiceShape = {
-  readonly mint: (params: MintCapabilityParams) => Effect.Effect<string, CapabilityTokenError>;
+  readonly mint: (
+    params: MintCapabilityParams,
+  ) => Effect.Effect<DesktopCapabilityToken, CapabilityTokenError>;
   readonly consume: (params: ConsumeCapabilityParams) => Effect.Effect<void, CapabilityTokenError>;
-  readonly revoke: (token: string) => Effect.Effect<void>;
+  readonly revoke: (token: DesktopCapabilityToken) => Effect.Effect<void>;
 };
 
 export class CapabilityGrantService extends Context.Service<
@@ -57,8 +63,8 @@ const defaultIdleTtlMsByScope: Record<DesktopCapabilityScope, number> = {
   "capture:resolve-preview-url": 15 * 1000,
 };
 
-function makeOpaqueToken(): string {
-  return randomBytes(32).toString("base64url");
+function makeOpaqueToken(): DesktopCapabilityToken {
+  return desktopCapabilityTokenSchema.make(randomBytes(32).toString("base64url"));
 }
 
 function tokenError(description: string): CapabilityTokenError {

--- a/apps/desktop-electrobun/src/mainview/app/studio/domain/timelineCommands.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/domain/timelineCommands.ts
@@ -4,6 +4,7 @@ import type {
   TimelineGapItem,
   TimelineItem,
 } from "@guerillaglass/engine-contract/shared/valueObjects";
+import { timelineSegmentIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import { compileTimelineItems } from "./timelineDomainModel";
 
 type TimelineIdFactory = () => string;
@@ -23,6 +24,10 @@ type MoveTimelineItemsOptions =
       destinationGapId: string;
       destinationOffsetSeconds?: number;
     };
+
+function makeTimelineSegmentId(idFactory: TimelineIdFactory) {
+  return timelineSegmentIdSchema.make(idFactory());
+}
 
 function defaultTimelineIdFactory(): string {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -112,7 +117,7 @@ function selectedIndexRuns(
 function buildGapItem(durationSeconds: number, idFactory: TimelineIdFactory): TimelineGapItem {
   return {
     kind: "gap",
-    id: idFactory(),
+    id: makeTimelineSegmentId(idFactory),
     durationSeconds,
   };
 }
@@ -156,7 +161,7 @@ export function splitTimelineClipAtProgramTime(
   };
   const rightClip: TimelineClipItem = {
     kind: "clip",
-    id: idFactory(),
+    id: makeTimelineSegmentId(idFactory),
     sourceAssetId: target.sourceAssetId,
     sourceStartSeconds: splitSeconds,
     sourceEndSeconds: target.sourceEndSeconds,
@@ -324,7 +329,7 @@ export function moveTimelineItems(
     if (selectedSet.has(item.id)) {
       nextItems.push({
         kind: "gap",
-        id: idFactory(),
+        id: makeTimelineSegmentId(idFactory),
         durationSeconds: timelineItemDurationSeconds(item),
       });
       continue;
@@ -345,7 +350,10 @@ export function moveTimelineItems(
     if (trailingGapSeconds > Number.EPSILON) {
       nextItems.push({
         kind: "gap",
-        id: destinationOffsetSeconds > Number.EPSILON ? idFactory() : destinationGap.id,
+        id:
+          destinationOffsetSeconds > Number.EPSILON
+            ? makeTimelineSegmentId(idFactory)
+            : destinationGap.id,
         durationSeconds: trailingGapSeconds,
       });
     }

--- a/apps/desktop-electrobun/src/mainview/app/studio/domain/timelineDomainModel.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/domain/timelineDomainModel.ts
@@ -1,3 +1,4 @@
+import { timelineSegmentIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import type {
   InputEvent,
   TimelineClipItem,
@@ -94,7 +95,7 @@ export function createSingleSegmentTimelineDocument(
     items: [
       {
         kind: "clip",
-        id: "segment-0",
+        id: timelineSegmentIdSchema.make("segment-0"),
         sourceAssetId: "recording",
         sourceStartSeconds: 0,
         sourceEndSeconds: duration,

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioMutations.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioMutations.ts
@@ -579,7 +579,7 @@ export function useStudioMutations({
 
   const saveProjectMutation = useMutation({
     mutationFn: async (saveAs: boolean) => {
-      let projectPath = projectQuery.data?.projectPath ?? undefined;
+      let projectPath: string | undefined = projectQuery.data?.projectPath ?? undefined;
       if (saveAs || !projectPath) {
         const pickedPath = await pickPathSafely({
           mode: "saveProjectAs",

--- a/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
+++ b/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
@@ -50,13 +50,18 @@ import {
   reviewWorkflowStatusSchema,
   type ReviewBridgeEvent,
   type ReviewComment,
+  type ReviewCommentId,
   type ReviewCreateCommentRequest,
+  type ReviewId,
   type ReviewSessionSnapshot,
   type ReviewSessionSnapshotRequest,
   type ReviewSetWorkflowStatusRequest,
   type ReviewSetWorkflowStatusResponse,
 } from "@guerillaglass/review-protocol";
 import {
+  agentJobIdSchema,
+  agentPreflightTokenSchema,
+  displayIdSchema,
   exportPresetIdSchema,
   filePathSchema,
   isoDateTimeSchema,
@@ -66,6 +71,7 @@ import {
   reviewCommentIdSchema,
   captureSessionIdSchema,
   reviewIdSchema,
+  windowIdSchema,
 } from "@guerillaglass/engine-contract/schema-primitives";
 import { Schema } from "effect";
 import {
@@ -173,7 +179,12 @@ export const readTextFileRequestSchema = Schema.Struct({
   filePath: filePathSchema,
 });
 export const readTextFileResponseSchema = Schema.String;
-export const desktopCapabilityTokenSchema = Schema.NonEmptyString.check(Schema.isMaxLength(512));
+export const desktopCapabilityTokenSchema = Schema.NonEmptyString.check(
+  Schema.isMaxLength(512),
+).pipe(Schema.brand("DesktopCapabilityToken"));
+
+/** Nominal token authorizing one desktop capability operation. */
+export type DesktopCapabilityToken = typeof desktopCapabilityTokenSchema.Type;
 export const resolveMediaSourceURLRequestSchema = Schema.Struct({
   filePath: filePathSchema,
   capabilityToken: desktopCapabilityTokenSchema,
@@ -214,9 +225,9 @@ export const studioDiagnosticsEntrySchema = Schema.Struct({
 const undefinedBridgeParamsSchema = Schema.Void;
 const engineAgentPreflightBridgeParamsSchema = agentPreflightPayloadSchema;
 const engineAgentRunBridgeParamsSchema = agentRunPayloadSchema;
-const engineAgentStatusBridgeParamsSchema = Schema.Struct({ jobId: Schema.NonEmptyString });
+const engineAgentStatusBridgeParamsSchema = Schema.Struct({ jobId: agentJobIdSchema });
 const engineAgentApplyBridgeParamsSchema = Schema.Struct({
-  jobId: Schema.NonEmptyString,
+  jobId: agentJobIdSchema,
   destructiveIntent: Schema.optionalKey(Schema.Boolean),
 });
 const engineCaptureStartBridgeParamsSchema = captureStartCurrentWindowPayloadSchema;
@@ -292,9 +303,56 @@ const reviewSetWorkflowStatusBridgeParamsSchema = Schema.Struct({
   status: reviewWorkflowStatusSchema,
 });
 
-type ProjectPath = Schema.Schema.Type<typeof projectPathSchema>;
-type OutputUrl = Schema.Schema.Type<typeof outputUrlSchema>;
-type ExportPresetId = Schema.Schema.Type<typeof exportPresetIdSchema>;
+type CaptureSessionId = typeof captureSessionIdSchema.Type;
+type FilePath = typeof filePathSchema.Type;
+type ReviewAuthToken = typeof reviewAuthTokenSchema.Type;
+type AgentJobId = typeof agentJobIdSchema.Type;
+type AgentPreflightToken = typeof agentPreflightTokenSchema.Type;
+type DisplayId = typeof displayIdSchema.Type;
+type ProjectPath = typeof projectPathSchema.Type;
+type OutputUrl = typeof outputUrlSchema.Type;
+type ExportPresetId = typeof exportPresetIdSchema.Type;
+type WindowId = typeof windowIdSchema.Type;
+
+function makeCaptureSessionId(value: string): CaptureSessionId {
+  return captureSessionIdSchema.make(value);
+}
+
+function makeDesktopCapabilityToken(value: string): DesktopCapabilityToken {
+  return desktopCapabilityTokenSchema.make(value);
+}
+
+function makeFilePath(value: string): FilePath {
+  return filePathSchema.make(value);
+}
+
+function makeReviewAuthToken(value: string): ReviewAuthToken {
+  return reviewAuthTokenSchema.make(value);
+}
+
+function makeReviewCommentId(value: string): ReviewCommentId {
+  return reviewCommentIdSchema.make(value);
+}
+
+function makeOptionalReviewCommentId(value: string | undefined): ReviewCommentId | undefined {
+  return value === undefined ? undefined : makeReviewCommentId(value);
+}
+
+function makeReviewId(value: string): ReviewId {
+  return reviewIdSchema.make(value);
+}
+
+function makeAgentJobId(value: string): AgentJobId {
+  return agentJobIdSchema.make(value);
+}
+
+function makeAgentPreflightToken(value: string): AgentPreflightToken {
+  return agentPreflightTokenSchema.make(value);
+}
+
+function makeOptionalDisplayId(value: number | undefined): DisplayId | undefined {
+  return value === undefined ? undefined : displayIdSchema.make(value);
+}
 
 function makeOptionalProjectPath(value: string | undefined): ProjectPath | undefined {
   return value === undefined ? undefined : projectPathSchema.make(value);
@@ -308,6 +366,10 @@ function makeExportPresetId(value: string): ExportPresetId {
   return exportPresetIdSchema.make(value);
 }
 
+function makeWindowId(value: number): WindowId {
+  return windowIdSchema.make(value);
+}
+
 type BridgeRequestDefinition<Params, Response, Args extends readonly unknown[]> = {
   toParams: (...args: Args) => Params;
   responseType: Response;
@@ -316,11 +378,11 @@ type BridgeRequestDefinition<Params, Response, Args extends readonly unknown[]> 
 };
 
 type ReviewBridgeRequestWithAuth<TRequest> = TRequest & {
-  authToken: string;
+  authToken: ReviewAuthToken;
 };
 
 type ReviewBridgeMutationRequestWithAuth<TRequest> = ReviewBridgeRequestWithAuth<TRequest> & {
-  capabilityToken: string;
+  capabilityToken: DesktopCapabilityToken;
 };
 
 function defineBridgeRequest<Params, Response, Args extends readonly unknown[]>(
@@ -390,7 +452,7 @@ export const bridgeRequestDefinitions = {
   ),
   ggEngineAgentRun: defineValidatedBridgeRequest<
     {
-      preflightToken: string;
+      preflightToken: AgentPreflightToken;
       runtimeBudgetMinutes?: number;
       transcriptionProvider?: "none" | "imported_transcript";
       importedTranscriptPath?: ProjectPath;
@@ -409,25 +471,30 @@ export const bridgeRequestDefinitions = {
   >(
     (params) => ({
       ...params,
+      preflightToken: makeAgentPreflightToken(params.preflightToken),
       importedTranscriptPath: makeOptionalProjectPath(params.importedTranscriptPath),
     }),
     engineAgentRunBridgeParamsSchema,
     engineSuccessSchema("agent.run"),
   ),
   ggEngineAgentStatus: defineValidatedBridgeRequest<
-    { jobId: string },
+    { jobId: AgentJobId },
     AgentStatusResult,
     [jobId: string]
   >(
-    (jobId) => ({ jobId }),
+    (jobId) => ({ jobId: makeAgentJobId(jobId) }),
     engineAgentStatusBridgeParamsSchema,
     engineSuccessSchema("agent.status"),
   ),
   ggEngineAgentApply: defineValidatedBridgeRequest<
-    { jobId: string; destructiveIntent?: boolean },
+    { jobId: AgentJobId; destructiveIntent?: boolean },
     ActionResult,
     [params: { jobId: string; destructiveIntent?: boolean }]
-  >((params) => params, engineAgentApplyBridgeParamsSchema, engineSuccessSchema("agent.apply")),
+  >(
+    (params) => ({ ...params, jobId: makeAgentJobId(params.jobId) }),
+    engineAgentApplyBridgeParamsSchema,
+    engineSuccessSchema("agent.apply"),
+  ),
   ggEngineRequestScreenRecordingPermission: defineValidatedBridgeRequest<
     undefined,
     ActionResult,
@@ -463,7 +530,7 @@ export const bridgeRequestDefinitions = {
   ),
   ggEngineStartDisplayCapture: defineValidatedBridgeRequest<
     {
-      displayId?: number;
+      displayId?: DisplayId;
       enableMic: boolean;
       enablePreview?: boolean;
       captureFps: CaptureFrameRate;
@@ -472,7 +539,7 @@ export const bridgeRequestDefinitions = {
     [enableMic: boolean, captureFps: CaptureFrameRate, displayId?: number, enablePreview?: boolean]
   >(
     (enableMic, captureFps, displayId, enablePreview) => ({
-      displayId,
+      displayId: makeOptionalDisplayId(displayId),
       enableMic,
       enablePreview,
       captureFps,
@@ -490,12 +557,17 @@ export const bridgeRequestDefinitions = {
     engineSuccessSchema("capture.startCurrentWindow"),
   ),
   ggEngineStartWindowCapture: defineValidatedBridgeRequest<
-    { windowId: number; enableMic: boolean; enablePreview?: boolean; captureFps: CaptureFrameRate },
+    {
+      windowId: WindowId;
+      enableMic: boolean;
+      enablePreview?: boolean;
+      captureFps: CaptureFrameRate;
+    },
     CaptureStatusResult,
     [windowId: number, enableMic: boolean, captureFps: CaptureFrameRate, enablePreview?: boolean]
   >(
     (windowId, enableMic, captureFps, enablePreview) => ({
-      windowId,
+      windowId: makeWindowId(windowId),
       enableMic,
       enablePreview,
       captureFps,
@@ -568,7 +640,7 @@ export const bridgeRequestDefinitions = {
     {
       outputURL: OutputUrl;
       presetId: ExportPresetId;
-      jobId: string;
+      jobId: AgentJobId;
     },
     ExportRunCutPlanResult,
     [params: { outputURL: string; presetId: string; jobId: string }]
@@ -577,6 +649,7 @@ export const bridgeRequestDefinitions = {
       ...params,
       outputURL: makeOutputUrl(params.outputURL),
       presetId: makeExportPresetId(params.presetId),
+      jobId: makeAgentJobId(params.jobId),
     }),
     engineRunCutPlanExportBridgeParamsSchema,
     engineSuccessSchema("export.runCutPlan"),
@@ -619,24 +692,70 @@ export const bridgeRequestDefinitions = {
   ggReviewSessionSnapshot: defineValidatedBridgeRequest<
     ReviewBridgeRequestWithAuth<ReviewSessionSnapshotRequest>,
     ReviewSessionSnapshot,
-    [params: ReviewBridgeRequestWithAuth<ReviewSessionSnapshotRequest>]
-  >((params) => params, reviewSessionSnapshotBridgeParamsSchema, reviewSessionSnapshotSchema),
-  ggGrantReviewMutationCapability: defineValidatedBridgeRequest<
-    { authToken: string; reviewId: string },
-    string,
     [params: { authToken: string; reviewId: string }]
-  >((params) => params, reviewMutationCapabilityBridgeParamsSchema, desktopCapabilityTokenSchema),
+  >(
+    (params) => ({
+      authToken: makeReviewAuthToken(params.authToken),
+      reviewId: makeReviewId(params.reviewId),
+    }),
+    reviewSessionSnapshotBridgeParamsSchema,
+    reviewSessionSnapshotSchema,
+  ),
+  ggGrantReviewMutationCapability: defineValidatedBridgeRequest<
+    { authToken: ReviewAuthToken; reviewId: ReviewId },
+    DesktopCapabilityToken,
+    [params: { authToken: string; reviewId: string }]
+  >(
+    (params) => ({
+      authToken: makeReviewAuthToken(params.authToken),
+      reviewId: makeReviewId(params.reviewId),
+    }),
+    reviewMutationCapabilityBridgeParamsSchema,
+    desktopCapabilityTokenSchema,
+  ),
   ggReviewCreateComment: defineValidatedBridgeRequest<
     ReviewBridgeMutationRequestWithAuth<ReviewCreateCommentRequest>,
     ReviewComment,
-    [params: ReviewBridgeMutationRequestWithAuth<ReviewCreateCommentRequest>]
-  >((params) => params, reviewCreateCommentBridgeParamsSchema, reviewCommentSchema),
+    [
+      params: {
+        authToken: string;
+        reviewId: string;
+        capabilityToken: string;
+        body: string;
+        frameNumber?: number;
+        timestampSeconds?: number;
+        parentCommentId?: string;
+      },
+    ]
+  >(
+    (params) => ({
+      ...params,
+      authToken: makeReviewAuthToken(params.authToken),
+      reviewId: makeReviewId(params.reviewId),
+      capabilityToken: makeDesktopCapabilityToken(params.capabilityToken),
+      parentCommentId: makeOptionalReviewCommentId(params.parentCommentId),
+    }),
+    reviewCreateCommentBridgeParamsSchema,
+    reviewCommentSchema,
+  ),
   ggReviewSetWorkflowStatus: defineValidatedBridgeRequest<
     ReviewBridgeMutationRequestWithAuth<ReviewSetWorkflowStatusRequest>,
     ReviewSetWorkflowStatusResponse,
-    [params: ReviewBridgeMutationRequestWithAuth<ReviewSetWorkflowStatusRequest>]
+    [
+      params: {
+        authToken: string;
+        reviewId: string;
+        capabilityToken: string;
+        status: ReviewSetWorkflowStatusRequest["status"];
+      },
+    ]
   >(
-    (params) => params,
+    (params) => ({
+      ...params,
+      authToken: makeReviewAuthToken(params.authToken),
+      reviewId: makeReviewId(params.reviewId),
+      capabilityToken: makeDesktopCapabilityToken(params.capabilityToken),
+    }),
     reviewSetWorkflowStatusBridgeParamsSchema,
     reviewSetWorkflowStatusResponseSchema,
   ),
@@ -645,49 +764,52 @@ export const bridgeRequestDefinitions = {
     string | null,
     [params: { mode: HostPathPickerMode; startingFolder?: string }]
   >((params) => params, pickPathRequestSchema, pickPathResponseSchema),
-  ggReadTextFile: defineValidatedBridgeRequest<{ filePath: string }, string, [filePath: string]>(
+  ggReadTextFile: defineValidatedBridgeRequest<{ filePath: FilePath }, string, [filePath: string]>(
     (filePath) => ({
-      filePath,
+      filePath: makeFilePath(filePath),
     }),
     readTextFileRequestSchema,
     readTextFileResponseSchema,
   ),
   ggGrantMediaSourceCapability: defineValidatedBridgeRequest<
-    { filePath: string },
-    string,
+    { filePath: FilePath },
+    DesktopCapabilityToken,
     [filePath: string]
   >(
-    (filePath) => ({ filePath }),
+    (filePath) => ({ filePath: makeFilePath(filePath) }),
     mediaSourceCapabilityBridgeParamsSchema,
     desktopCapabilityTokenSchema,
   ),
   ggResolveMediaSourceURL: defineValidatedBridgeRequest<
-    { filePath: string; capabilityToken: string },
-    string,
+    { filePath: FilePath; capabilityToken: DesktopCapabilityToken },
+    OutputUrl,
     [filePath: string, capabilityToken: string]
   >(
     (filePath, capabilityToken) => ({
-      filePath,
-      capabilityToken,
+      filePath: makeFilePath(filePath),
+      capabilityToken: makeDesktopCapabilityToken(capabilityToken),
     }),
     resolveMediaSourceURLRequestSchema,
     resolveMediaSourceURLResponseSchema,
   ),
   ggGrantCapturePreviewCapability: defineValidatedBridgeRequest<
-    { captureSessionId: string },
-    string,
+    { captureSessionId: CaptureSessionId },
+    DesktopCapabilityToken,
     [captureSessionId: string]
   >(
-    (captureSessionId) => ({ captureSessionId }),
+    (captureSessionId) => ({ captureSessionId: makeCaptureSessionId(captureSessionId) }),
     capturePreviewCapabilityBridgeParamsSchema,
     desktopCapabilityTokenSchema,
   ),
   ggResolveCapturePreviewURL: defineValidatedBridgeRequest<
-    { captureSessionId: string; capabilityToken: string },
-    string,
+    { captureSessionId: CaptureSessionId; capabilityToken: DesktopCapabilityToken },
+    OutputUrl,
     [captureSessionId: string, capabilityToken: string]
   >(
-    (captureSessionId, capabilityToken) => ({ captureSessionId, capabilityToken }),
+    (captureSessionId, capabilityToken) => ({
+      captureSessionId: makeCaptureSessionId(captureSessionId),
+      capabilityToken: makeDesktopCapabilityToken(capabilityToken),
+    }),
     resolveCapturePreviewURLRequestSchema,
     resolveCapturePreviewURLResponseSchema,
   ),

--- a/apps/desktop-electrobun/tests/app-runtime.test.ts
+++ b/apps/desktop-electrobun/tests/app-runtime.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "vitest";
 import { Effect, Fiber, Layer, Schema } from "effect";
+import { captureSessionIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import {
   captureStatusResultSchema,
   type CaptureStatusResult,
@@ -16,10 +17,10 @@ import { makeDesktopAppRuntime } from "../src/bun/app/AppRuntime";
 
 function makeCaptureStatus(overrides: Partial<CaptureStatusResult> = {}): CaptureStatusResult {
   const isRunning = overrides.isRunning === true;
-  return {
+  return captureStatusResultSchema.make({
     isRunning,
     isRecording: false,
-    ...(isRunning ? { captureSessionId: "capture-session-1" } : {}),
+    ...(isRunning ? { captureSessionId: captureSessionIdSchema.make("capture-session-1") } : {}),
     recordingDurationSeconds: 0,
     telemetry: {
       sourceDroppedFrames: 0,
@@ -31,7 +32,7 @@ function makeCaptureStatus(overrides: Partial<CaptureStatusResult> = {}): Captur
       writerAppendMs: 0,
     },
     ...overrides,
-  };
+  });
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));

--- a/apps/desktop-electrobun/tests/capture-benchmark.test.ts
+++ b/apps/desktop-electrobun/tests/capture-benchmark.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { windowIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import {
   benchmarkSceneWindow,
   collectBenchmarkFailures,
@@ -151,7 +152,7 @@ describe("capture benchmark policy", () => {
         displays: [],
         windows: [
           {
-            id: 41,
+            id: windowIdSchema.make(41),
             title: "package.json — guerillaglass",
             appName: "Code",
             width: 2200,
@@ -162,7 +163,7 @@ describe("capture benchmark policy", () => {
             supportedCaptureFrameRates: [24, 30, 60],
           },
           {
-            id: 55,
+            id: windowIdSchema.make(55),
             title: "GG Capture Benchmark",
             appName: "Guerillaglass",
             width: 1440,

--- a/apps/desktop-electrobun/tests/capture-target-label.test.ts
+++ b/apps/desktop-electrobun/tests/capture-target-label.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "vitest";
+import { windowIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import { formatCaptureTargetLabelFromMetadata } from "@studio/view-model/captureTargetLabelFormatter";
 
 const formatInteger = (value: number): string => String(Math.trunc(value));
@@ -37,7 +38,7 @@ describe("capture target label", () => {
       formatCaptureTargetLabelFromMetadata({
         metadata: {
           source: "window",
-          window: { id: 42, appName: "Xcode", title: "Simulator" },
+          window: { id: windowIdSchema.make(42), appName: "Xcode", title: "Simulator" },
           contentRect: { x: 0, y: 0, width: 1280, height: 720 },
           pixelScale: 2,
         },

--- a/apps/desktop-electrobun/tests/engine-api.test.ts
+++ b/apps/desktop-electrobun/tests/engine-api.test.ts
@@ -1,6 +1,11 @@
 import { Effect, Layer } from "effect";
 import { beforeEach, describe, expect, test } from "vitest";
-import { reviewIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
+import {
+  reviewAuthTokenSchema,
+  reviewIdSchema,
+  timelineSegmentIdSchema,
+} from "@guerillaglass/engine-contract/schema-primitives";
+import { timelineDocumentSchema } from "@guerillaglass/engine-contract/shared/valueObjects";
 import {
   desktopApi,
   engineApi,
@@ -474,19 +479,23 @@ describe("renderer engine bridge", () => {
       },
     });
 
-    const timeline = {
+    const timeline = timelineDocumentSchema.make({
       version: 2 as const,
       items: [
         {
           kind: "clip" as const,
-          id: "clip-a",
+          id: timelineSegmentIdSchema.make("clip-a"),
           sourceAssetId: "recording" as const,
           sourceStartSeconds: 0,
           sourceEndSeconds: 1,
         },
-        { kind: "gap" as const, id: "gap-a", durationSeconds: 0.5 },
+        {
+          kind: "gap" as const,
+          id: timelineSegmentIdSchema.make("gap-a"),
+          durationSeconds: 0.5,
+        },
       ],
-    };
+    });
 
     await engineApi.runExport({
       outputURL: "/tmp/out.mp4",
@@ -572,7 +581,7 @@ describe("renderer engine bridge", () => {
       const handlers = createEngineBridgeHandlers({ runtime });
 
       const response = await handlers.ggReviewSessionSnapshot({
-        authToken: "token",
+        authToken: reviewAuthTokenSchema.make("token"),
         reviewId: reviewIdSchema.make("review-123"),
       });
 

--- a/apps/desktop-electrobun/tests/inspector-context.test.ts
+++ b/apps/desktop-electrobun/tests/inspector-context.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, test } from "vitest";
+import { exportPresetSchema } from "@guerillaglass/engine-contract/domains/export";
+import { exportPresetIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import {
   emptyInspectorSelection,
   normalizeInspectorSelection,
@@ -71,14 +73,16 @@ describe("inspector context", () => {
   });
 
   test("builds export preset selection from preset data", () => {
-    const selection = selectionFromPreset({
-      id: "preset-id",
-      name: "1080p",
-      width: 1920,
-      height: 1080,
-      fileType: "mp4",
-      fps: 60,
-    });
+    const selection = selectionFromPreset(
+      exportPresetSchema.make({
+        id: exportPresetIdSchema.make("preset-id"),
+        name: "1080p",
+        width: 1920,
+        height: 1080,
+        fileType: "mp4",
+        fps: 60,
+      }),
+    );
     expect(selection).toEqual({
       kind: "exportPreset",
       presetId: "preset-id",

--- a/apps/desktop-electrobun/tests/preferred-display-selection.test.ts
+++ b/apps/desktop-electrobun/tests/preferred-display-selection.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, test } from "vitest";
-import type { SourcesResult } from "@guerillaglass/engine-contract/domains/sources";
+import {
+  displaySourceSchema,
+  type SourcesResult,
+} from "@guerillaglass/engine-contract/domains/sources";
+import { displayIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import {
   pickPreferredDisplayId,
   resolveSelectedDisplayId,
 } from "@studio/domain/preferredDisplaySelection";
 
 function makeDisplaySource(
-  overrides: Partial<SourcesResult["displays"][number]>,
+  overrides: Omit<Partial<SourcesResult["displays"][number]>, "id"> & { id?: number },
 ): SourcesResult["displays"][number] {
-  return {
-    id: 0,
+  const { id = 0, ...rest } = overrides;
+  return displaySourceSchema.make({
+    id: displayIdSchema.make(id),
     displayName: "Display",
     isPrimary: false,
     width: 1920,
@@ -17,8 +22,8 @@ function makeDisplaySource(
     pixelScale: 2,
     refreshHz: 60,
     supportedCaptureFrameRates: [24, 30, 60],
-    ...overrides,
-  };
+    ...rest,
+  });
 }
 
 describe("preferred display selection", () => {

--- a/apps/desktop-electrobun/tests/preferred-window-selection.test.ts
+++ b/apps/desktop-electrobun/tests/preferred-window-selection.test.ts
@@ -1,15 +1,20 @@
 import { describe, expect, test } from "vitest";
-import type { SourcesResult } from "@guerillaglass/engine-contract/domains/sources";
+import {
+  windowSourceSchema,
+  type SourcesResult,
+} from "@guerillaglass/engine-contract/domains/sources";
+import { windowIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import {
   pickPreferredWindowId,
   resolveSelectedWindowId,
 } from "@studio/domain/preferredWindowSelection";
 
 function makeWindowSource(
-  overrides: Partial<SourcesResult["windows"][number]>,
+  overrides: Omit<Partial<SourcesResult["windows"][number]>, "id"> & { id?: number },
 ): SourcesResult["windows"][number] {
-  return {
-    id: 0,
+  const { id = 0, ...rest } = overrides;
+  return windowSourceSchema.make({
+    id: windowIdSchema.make(id),
     title: "",
     appName: "App",
     width: 1280,
@@ -17,8 +22,8 @@ function makeWindowSource(
     isOnScreen: true,
     refreshHz: 60,
     supportedCaptureFrameRates: [24, 30, 60],
-    ...overrides,
-  };
+    ...rest,
+  });
 }
 
 describe("preferred window selection", () => {

--- a/apps/desktop-electrobun/tests/review-gateway.test.ts
+++ b/apps/desktop-electrobun/tests/review-gateway.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Exit, Option } from "effect";
+import {
+  reviewAuthTokenSchema,
+  reviewIdSchema,
+} from "@guerillaglass/engine-contract/schema-primitives";
 import { ReviewBridgeError } from "@shared/errors/desktopErrors";
 import { makeReviewGateway } from "../src/bun/review/service";
 
@@ -27,8 +31,8 @@ describe("review gateway service", () => {
 
       const exit = yield* Effect.exit(
         gateway.sessionSnapshot({
-          authToken: "token",
-          reviewId: "review-123",
+          authToken: reviewAuthTokenSchema.make("token"),
+          reviewId: reviewIdSchema.make("review-123"),
         }),
       );
       expectReviewBridgeError(exit, "REVIEW_BRIDGE_URL_MISSING");
@@ -43,8 +47,8 @@ describe("review gateway service", () => {
 
       const exit = yield* Effect.exit(
         gateway.sessionSnapshot({
-          authToken: "   ",
-          reviewId: "review-123",
+          authToken: reviewAuthTokenSchema.make("   "),
+          reviewId: reviewIdSchema.make("review-123"),
         }),
       );
       expectReviewBridgeError(exit, "REVIEW_AUTH_TOKEN_MISSING");
@@ -68,8 +72,8 @@ describe("review gateway service", () => {
 
       const exit = yield* Effect.exit(
         gateway.sessionSnapshot({
-          authToken: "token",
-          reviewId: "review-123",
+          authToken: reviewAuthTokenSchema.make("token"),
+          reviewId: reviewIdSchema.make("review-123"),
         }),
       );
       expectReviewBridgeError(exit, "REVIEW_REQUEST_FAILED");

--- a/apps/desktop-electrobun/tests/security-capabilities.test.ts
+++ b/apps/desktop-electrobun/tests/security-capabilities.test.ts
@@ -1,5 +1,6 @@
 import { Effect, Exit } from "effect";
 import { describe, expect, test } from "vitest";
+import { desktopCapabilityTokenSchema } from "@shared/bridge/desktopBridgeContract";
 import { CapabilityTokenError } from "@shared/errors/desktopErrors";
 import {
   deserializeBridgeError,
@@ -31,7 +32,7 @@ describe("desktop capability grants", () => {
     await expect(
       Effect.runPromise(
         service.consume({
-          token: "missing",
+          token: desktopCapabilityTokenSchema.make("missing"),
           scope: "review:mutate",
           subject: "review:abc",
         }),

--- a/apps/desktop-electrobun/tests/studio-data-queries.test.ts
+++ b/apps/desktop-electrobun/tests/studio-data-queries.test.ts
@@ -1,4 +1,9 @@
 import { describe, expect, test } from "vitest";
+import { captureStatusResultSchema } from "@guerillaglass/engine-contract/domains/capture";
+import {
+  captureSessionIdSchema,
+  recordingUrlSchema,
+} from "@guerillaglass/engine-contract/schema-primitives";
 import {
   captureStatusResultsEqual,
   parseCaptureStatusEvent,
@@ -48,12 +53,12 @@ describe("studio capture status stream events", () => {
   });
 
   test("treats structurally identical capture status payloads as unchanged", () => {
-    const previous = {
+    const previous = captureStatusResultSchema.make({
       isRunning: true,
       isRecording: false,
-      captureSessionId: "capture-session-1",
+      captureSessionId: captureSessionIdSchema.make("capture-session-1"),
       recordingDurationSeconds: 12.5,
-      recordingURL: "/tmp/recording.mov",
+      recordingURL: recordingUrlSchema.make("/tmp/recording.mov"),
       lastRecordingTelemetry: {
         sourceDroppedFrames: 2,
         writerDroppedFrames: 0,
@@ -78,7 +83,7 @@ describe("studio capture status stream events", () => {
         recordQueueLagMs: 0.18,
         writerAppendMs: 1.11,
       },
-    };
+    });
     const next = structuredClone(previous);
 
     expect(captureStatusResultsEqual(previous, next)).toBe(true);

--- a/apps/desktop-electrobun/tests/timeline-commands.test.ts
+++ b/apps/desktop-electrobun/tests/timeline-commands.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "vitest";
-import type { TimelineDocument } from "@guerillaglass/engine-contract/shared/valueObjects";
+import { timelineSegmentIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
+import type {
+  TimelineClipItem,
+  TimelineDocument,
+  TimelineGapItem,
+} from "@guerillaglass/engine-contract/shared/valueObjects";
 import {
   deleteTimelineItems,
   liftTimelineItems,
@@ -8,10 +13,14 @@ import {
   splitTimelineClipAtProgramTime,
 } from "@studio/domain/timelineCommands";
 
-function makeTimeline(items: TimelineDocument["items"]): TimelineDocument {
+type TimelineItemInput =
+  | (Omit<TimelineClipItem, "id"> & { id: string })
+  | (Omit<TimelineGapItem, "id"> & { id: string });
+
+function makeTimeline(items: TimelineItemInput[]): TimelineDocument {
   return {
     version: 2,
-    items,
+    items: items.map((item) => ({ ...item, id: timelineSegmentIdSchema.make(item.id) })),
   };
 }
 

--- a/apps/desktop-electrobun/tests/timeline-model.test.ts
+++ b/apps/desktop-electrobun/tests/timeline-model.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, test } from "vitest";
-import type { InputEvent } from "@guerillaglass/engine-contract/shared/valueObjects";
+import { timelineSegmentIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
+import type {
+  InputEvent,
+  TimelineClipItem,
+  TimelineDocument,
+  TimelineGapItem,
+} from "@guerillaglass/engine-contract/shared/valueObjects";
 import {
   buildEventWaveform,
   buildEventMarkers,
@@ -14,6 +20,17 @@ import {
   remapInputEventsToProgramTime,
   secondsToPixels,
 } from "@studio/domain/timelineDomainModel";
+
+type TimelineItemInput =
+  | (Omit<TimelineClipItem, "id"> & { id: string })
+  | (Omit<TimelineGapItem, "id"> & { id: string });
+
+function makeTimeline(items: TimelineItemInput[]): TimelineDocument {
+  return {
+    version: 2,
+    items: items.map((item) => ({ ...item, id: timelineSegmentIdSchema.make(item.id) })),
+  };
+}
 
 describe("timeline model", () => {
   test("converts between seconds and pixels with clamping", () => {
@@ -88,26 +105,23 @@ describe("timeline model", () => {
   });
 
   test("identifies gaps by program time before source remapping", () => {
-    const timeline = {
-      version: 2 as const,
-      items: [
-        {
-          kind: "clip" as const,
-          id: "clip-a",
-          sourceAssetId: "recording" as const,
-          sourceStartSeconds: 0,
-          sourceEndSeconds: 1,
-        },
-        { kind: "gap" as const, id: "gap-a", durationSeconds: 1 },
-        {
-          kind: "clip" as const,
-          id: "clip-b",
-          sourceAssetId: "recording" as const,
-          sourceStartSeconds: 3,
-          sourceEndSeconds: 4,
-        },
-      ],
-    };
+    const timeline = makeTimeline([
+      {
+        kind: "clip" as const,
+        id: "clip-a",
+        sourceAssetId: "recording" as const,
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 1,
+      },
+      { kind: "gap" as const, id: "gap-a", durationSeconds: 1 },
+      {
+        kind: "clip" as const,
+        id: "clip-b",
+        sourceAssetId: "recording" as const,
+        sourceStartSeconds: 3,
+        sourceEndSeconds: 4,
+      },
+    ]);
 
     const items = compileTimelineItems(timeline);
 
@@ -118,25 +132,22 @@ describe("timeline model", () => {
   });
 
   test("compiles timeline segments into program ranges and remaps events", () => {
-    const timeline = {
-      version: 2 as const,
-      items: [
-        {
-          kind: "clip" as const,
-          id: "segment-a",
-          sourceAssetId: "recording" as const,
-          sourceStartSeconds: 2,
-          sourceEndSeconds: 4,
-        },
-        {
-          kind: "clip" as const,
-          id: "segment-b",
-          sourceAssetId: "recording" as const,
-          sourceStartSeconds: 6,
-          sourceEndSeconds: 7.5,
-        },
-      ],
-    };
+    const timeline = makeTimeline([
+      {
+        kind: "clip" as const,
+        id: "segment-a",
+        sourceAssetId: "recording" as const,
+        sourceStartSeconds: 2,
+        sourceEndSeconds: 4,
+      },
+      {
+        kind: "clip" as const,
+        id: "segment-b",
+        sourceAssetId: "recording" as const,
+        sourceStartSeconds: 6,
+        sourceEndSeconds: 7.5,
+      },
+    ]);
     const compiled = compileTimelineSegments(timeline);
     const events: InputEvent[] = [
       { type: "cursorMoved", timestamp: 2.5, position: { x: 10, y: 10 } },

--- a/apps/desktop-electrobun/tests/timeline-playback-model.test.ts
+++ b/apps/desktop-electrobun/tests/timeline-playback-model.test.ts
@@ -1,13 +1,27 @@
 import { describe, expect, test } from "vitest";
-import type { TimelineDocument } from "@guerillaglass/engine-contract/shared/valueObjects";
+import { timelineSegmentIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
+import type {
+  TimelineClipItem,
+  TimelineGapItem,
+} from "@guerillaglass/engine-contract/shared/valueObjects";
 import { compileTimelineItems } from "@studio/domain/timelineDomainModel";
 import {
   findNextPlayableClipAfterProgramTime,
   resolveTimelinePlaybackAtProgramTime,
 } from "@studio/domain/timelinePlaybackModel";
 
-function compile(timeline: TimelineDocument) {
-  return compileTimelineItems(timeline);
+type TimelineItemInput =
+  | (Omit<TimelineClipItem, "id"> & { id: string })
+  | (Omit<TimelineGapItem, "id"> & { id: string });
+
+function compile(timeline: { version: 2; items: TimelineItemInput[] }) {
+  return compileTimelineItems({
+    ...timeline,
+    items: timeline.items.map((item) => ({
+      ...item,
+      id: timelineSegmentIdSchema.make(item.id),
+    })),
+  });
 }
 
 describe("timeline playback model", () => {

--- a/apps/desktop-electrobun/tests/ui/editor-export-timeline.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/editor-export-timeline.browser.test.tsx
@@ -3,6 +3,7 @@ import { createRoot, type Root } from "react-dom/client";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { HotkeysProvider } from "@tanstack/react-hotkeys";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
+import { timelineSegmentIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import type { TimelineDocument } from "@guerillaglass/engine-contract/shared/valueObjects";
 import {
   useStudioController,
@@ -14,7 +15,7 @@ const initialTimeline: TimelineDocument = {
   items: [
     {
       kind: "clip",
-      id: "segment-0",
+      id: timelineSegmentIdSchema.make("segment-0"),
       sourceAssetId: "recording",
       sourceStartSeconds: 0,
       sourceEndSeconds: 4,

--- a/apps/desktop-electrobun/tests/ui/video-playback-gaps.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/video-playback-gaps.browser.test.tsx
@@ -1,30 +1,33 @@
 import { act, useRef } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { timelineSegmentIdSchema } from "@guerillaglass/engine-contract/schema-primitives";
 import { compileTimelineItems } from "../../src/mainview/app/studio/domain/timelineDomainModel";
 import { useVideoPlaybackSync } from "../../src/mainview/app/studio/hooks/useVideoPlaybackSync";
 import { createPlaybackTransportStore } from "../../src/mainview/app/studio/hooks/timeline/usePlaybackTransport";
 
+const segmentId = (value: string) => timelineSegmentIdSchema.make(value);
+
 const timelineItems = compileTimelineItems({
   version: 2,
   items: [
-    { kind: "gap", id: "leading", durationSeconds: 0.5 },
+    { kind: "gap", id: segmentId("leading"), durationSeconds: 0.5 },
     {
       kind: "clip",
-      id: "clip-a",
+      id: segmentId("clip-a"),
       sourceAssetId: "recording",
       sourceStartSeconds: 0,
       sourceEndSeconds: 1,
     },
-    { kind: "gap", id: "middle", durationSeconds: 1 },
+    { kind: "gap", id: segmentId("middle"), durationSeconds: 1 },
     {
       kind: "clip",
-      id: "clip-b",
+      id: segmentId("clip-b"),
       sourceAssetId: "recording",
       sourceStartSeconds: 1,
       sourceEndSeconds: 2,
     },
-    { kind: "gap", id: "trailing", durationSeconds: 0.5 },
+    { kind: "gap", id: segmentId("trailing"), durationSeconds: 0.5 },
   ],
 });
 const timelineDuration = 4;
@@ -170,14 +173,14 @@ describe("timeline preview across gaps", () => {
       items: [
         {
           kind: "clip",
-          id: "source-ending",
+          id: segmentId("source-ending"),
           sourceAssetId: "recording",
           sourceStartSeconds: 1,
           sourceEndSeconds: 2,
         },
         {
           kind: "clip",
-          id: "following",
+          id: segmentId("following"),
           sourceAssetId: "recording",
           sourceStartSeconds: 0,
           sourceEndSeconds: 1,
@@ -203,14 +206,14 @@ describe("timeline preview across gaps", () => {
       items: [
         {
           kind: "clip",
-          id: "second-source-first",
+          id: segmentId("second-source-first"),
           sourceAssetId: "recording",
           sourceStartSeconds: 1,
           sourceEndSeconds: 2,
         },
         {
           kind: "clip",
-          id: "first-source-second",
+          id: segmentId("first-source-second"),
           sourceAssetId: "recording",
           sourceStartSeconds: 0,
           sourceEndSeconds: 1,

--- a/engines/macos-swift/EngineService+GeneratedHelpers.swift
+++ b/engines/macos-swift/EngineService+GeneratedHelpers.swift
@@ -25,8 +25,8 @@ extension EngineService {
             isRecording: captureEngine.isRecording,
             captureSessionId: captureEngine.captureSessionID.map { .init(value1: $0) },
             recordingDurationSeconds: .init(value1: max(0, captureEngine.recordingDuration)),
-            recordingURL: captureEngine.recordingURL?.path,
-            eventsURL: currentEventsURL?.path,
+            recordingURL: (captureEngine.recordingURL?.path).map { .init(value1: $0) },
+            eventsURL: (currentEventsURL?.path).map { .init(value1: $0) },
             telemetry: telemetry()
         )
     }
@@ -75,8 +75,10 @@ extension EngineService {
     func projectState() -> Components.Schemas.ProjectState {
         .init(
             projectPath: currentProjectURL.map { .init(value1: $0.path) },
-            recordingURL: projectRecordingURL()?.path ?? captureEngine.recordingURL?.path,
-            eventsURL: projectEventsURL()?.path ?? currentEventsURL?.path,
+            recordingURL: (projectRecordingURL()?.path ?? captureEngine.recordingURL?.path).map {
+                .init(value1: $0)
+            },
+            eventsURL: (projectEventsURL()?.path ?? currentEventsURL?.path).map { .init(value1: $0) },
             autoZoom: autoZoomState(),
             timeline: timelineState(),
             agentAnalysis: agentAnalysisState()

--- a/engines/protocol-swift/Sources/EngineProtocol/openapi.json
+++ b/engines/protocol-swift/Sources/EngineProtocol/openapi.json
@@ -3602,7 +3602,12 @@
             ]
           },
           "recordingURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "captureMetadata": {
             "type": "object",
@@ -3701,7 +3706,12 @@
             "$ref": "#/components/schemas/EngineBadRequestError"
           },
           "eventsURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "lastRecordingTelemetry": {
             "$ref": "#/components/schemas/CaptureTelemetry"
@@ -4207,10 +4217,20 @@
             ]
           },
           "recordingURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "eventsURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "lastRecordingTelemetry": {
             "$ref": "#/components/schemas/CaptureTelemetry"

--- a/packages/engine-client/src/service.ts
+++ b/packages/engine-client/src/service.ts
@@ -22,7 +22,21 @@ import type {
 } from "@guerillaglass/engine-contract/domains/project";
 import type { SourcesResult } from "@guerillaglass/engine-contract/domains/sources";
 import type { CapabilitiesResult, PingResult } from "@guerillaglass/engine-contract/domains/system";
-import { EngineHttpApi } from "@guerillaglass/engine-contract/httpApi";
+import {
+  agentApplyPayloadSchema,
+  agentPreflightPayloadSchema,
+  agentRunPayloadSchema,
+  captureStartCurrentWindowPayloadSchema,
+  captureStartDisplayPayloadSchema,
+  captureStartWindowPayloadSchema,
+  EngineHttpApi,
+  exportRunCutPlanPayloadSchema,
+  exportRunPayloadSchema,
+  projectOpenPayloadSchema,
+  projectSavePayloadSchema,
+  recordingStartPayloadSchema,
+} from "@guerillaglass/engine-contract/httpApi";
+import type { AgentJobId, ExportJobId } from "@guerillaglass/engine-contract/schema-primitives";
 import * as BunHttpClient from "@effect/platform-bun/BunHttpClient";
 import * as BunServices from "@effect/platform-bun/BunServices";
 import { Context, Effect, Layer } from "effect";
@@ -35,47 +49,57 @@ import { makeEngineHttpProcess, type EngineHttpProcessOptions } from "./process/
 /**
  * Input for Agent Mode preflight checks.
  */
-export type AgentPreflightRequest = Record<string, unknown>;
+export type AgentPreflightRequest = typeof agentPreflightPayloadSchema.Type;
 
 /**
  * Input for creating an Agent Mode job.
  */
-export type AgentRunRequest = Record<string, unknown>;
+export type AgentRunRequest = typeof agentRunPayloadSchema.Type;
 
 /**
  * Input for applying an Agent Mode job result.
  */
-export type AgentApplyRequest = Record<string, unknown>;
+export type AgentApplyRequest = typeof agentApplyPayloadSchema.Type;
 
 /**
  * Input for capture start commands.
  */
-export type CaptureStartRequest = Record<string, unknown>;
+export type CaptureStartDisplayRequest = typeof captureStartDisplayPayloadSchema.Type;
+
+/**
+ * Input for capture start-current-window commands.
+ */
+export type CaptureStartCurrentWindowRequest = typeof captureStartCurrentWindowPayloadSchema.Type;
+
+/**
+ * Input for capture start-window commands.
+ */
+export type CaptureStartWindowRequest = typeof captureStartWindowPayloadSchema.Type;
 
 /**
  * Input for starting a recording session.
  */
-export type RecordingStartRequest = Record<string, unknown>;
+export type RecordingStartRequest = typeof recordingStartPayloadSchema.Type;
 
 /**
  * Input for standard export jobs.
  */
-export type ExportRunRequest = Record<string, unknown>;
+export type ExportRunRequest = typeof exportRunPayloadSchema.Type;
 
 /**
  * Input for export jobs created from Agent Mode cut plans.
  */
-export type ExportRunCutPlanRequest = Record<string, unknown>;
+export type ExportRunCutPlanRequest = typeof exportRunCutPlanPayloadSchema.Type;
 
 /**
  * Input for opening a project from disk.
  */
-export type ProjectOpenRequest = Record<string, unknown>;
+export type ProjectOpenRequest = typeof projectOpenPayloadSchema.Type;
 
 /**
  * Input for saving current project state.
  */
-export type ProjectSaveRequest = Record<string, unknown>;
+export type ProjectSaveRequest = typeof projectSavePayloadSchema.Type;
 
 /**
  * Generated low-level client shape derived directly from `EngineHttpApi`.
@@ -107,12 +131,12 @@ export type EngineClientService = {
   /**
    * Calls `GET /v1/agent/runs/{jobId}`.
    */
-  readonly agentStatus: (jobId: string) => Effect.Effect<AgentStatusResult, EngineClientError>;
+  readonly agentStatus: (jobId: AgentJobId) => Effect.Effect<AgentStatusResult, EngineClientError>;
   /**
    * Calls `POST /v1/agent/runs/{jobId}/apply`.
    */
   readonly agentApply: (
-    jobId: string,
+    jobId: AgentJobId,
     request: AgentApplyRequest,
   ) => Effect.Effect<ActionResult, EngineClientError>;
   /**
@@ -143,19 +167,19 @@ export type EngineClientService = {
    * Calls `POST /v1/capture/start-display`.
    */
   readonly captureStartDisplay: (
-    request: CaptureStartRequest,
+    request: CaptureStartDisplayRequest,
   ) => Effect.Effect<CaptureStatusResult, EngineClientError>;
   /**
    * Calls `POST /v1/capture/start-current-window`.
    */
   readonly captureStartCurrentWindow: (
-    request: CaptureStartRequest,
+    request: CaptureStartCurrentWindowRequest,
   ) => Effect.Effect<CaptureStatusResult, EngineClientError>;
   /**
    * Calls `POST /v1/capture/start-window`.
    */
   readonly captureStartWindow: (
-    request: CaptureStartRequest,
+    request: CaptureStartWindowRequest,
   ) => Effect.Effect<CaptureStatusResult, EngineClientError>;
   /**
    * Calls `POST /v1/capture/stop`.
@@ -198,7 +222,7 @@ export type EngineClientService = {
   /**
    * Calls `GET /v1/exports/{jobId}`.
    */
-  readonly exportGet: (jobId: string) => Effect.Effect<ExportRunResult, EngineClientError>;
+  readonly exportGet: (jobId: ExportJobId) => Effect.Effect<ExportRunResult, EngineClientError>;
   /**
    * Calls `GET /v1/project/current`.
    */
@@ -265,8 +289,7 @@ export function makeRawEngineHttpApiClient(
  * @returns The low-level EngineClient service implementation.
  */
 export function makeEngineClientService(rawClient: RawEngineHttpApiClient): EngineClientService {
-  // oxlint-disable-next-line typescript/no-explicit-any -- Effect HttpApiClient currently exposes a generated callable group shape that TypeScript cannot preserve here.
-  const client = rawClient as any;
+  const client = rawClient;
   return {
     systemPing: asClientEffect(client.system.systemPing({})),
     engineCapabilities: asClientEffect(client.system.engineCapabilities({})),

--- a/packages/engine-client/src/services/AgentService.ts
+++ b/packages/engine-client/src/services/AgentService.ts
@@ -4,6 +4,7 @@ import type {
   AgentStatusResult,
 } from "@guerillaglass/engine-contract/domains/agent";
 import type { ActionResult } from "@guerillaglass/engine-contract/domains/permissions";
+import type { AgentJobId } from "@guerillaglass/engine-contract/schema-primitives";
 import { Context, Effect, Layer } from "effect";
 import type { EngineClientError } from "../errors";
 import {
@@ -30,12 +31,12 @@ export type AgentServiceShape = {
   /**
    * Polls Agent Mode job status.
    */
-  readonly status: (jobId: string) => Effect.Effect<AgentStatusResult, EngineClientError>;
+  readonly status: (jobId: AgentJobId) => Effect.Effect<AgentStatusResult, EngineClientError>;
   /**
    * Applies Agent Mode job output to the current project.
    */
   readonly apply: (
-    jobId: string,
+    jobId: AgentJobId,
     request: AgentApplyRequest,
   ) => Effect.Effect<ActionResult, EngineClientError>;
 };

--- a/packages/engine-client/src/services/CaptureService.ts
+++ b/packages/engine-client/src/services/CaptureService.ts
@@ -9,7 +9,12 @@ import {
   captureOperationFailuresTotal,
   captureOperationsTotal,
 } from "../metrics";
-import { EngineClient, type CaptureStartRequest } from "../service";
+import {
+  EngineClient,
+  type CaptureStartCurrentWindowRequest,
+  type CaptureStartDisplayRequest,
+  type CaptureStartWindowRequest,
+} from "../service";
 
 /**
  * Domain service for capture lifecycle and polling operations.
@@ -19,19 +24,19 @@ export type CaptureServiceShape = {
    * Starts capture for a display source.
    */
   readonly startDisplay: (
-    request: CaptureStartRequest,
+    request: CaptureStartDisplayRequest,
   ) => Effect.Effect<CaptureStatusResult, EngineClientError>;
   /**
    * Starts capture for the current foreground window.
    */
   readonly startCurrentWindow: (
-    request: CaptureStartRequest,
+    request: CaptureStartCurrentWindowRequest,
   ) => Effect.Effect<CaptureStatusResult, EngineClientError>;
   /**
    * Starts capture for a specific window source.
    */
   readonly startWindow: (
-    request: CaptureStartRequest,
+    request: CaptureStartWindowRequest,
   ) => Effect.Effect<CaptureStatusResult, EngineClientError>;
   /**
    * Stops the active capture session.
@@ -78,7 +83,10 @@ const captureOperation = <A, E>(
 
 const captureStartOperation = (
   operation: string,
-  request: CaptureStartRequest,
+  request:
+    | CaptureStartDisplayRequest
+    | CaptureStartCurrentWindowRequest
+    | CaptureStartWindowRequest,
   effect: Effect.Effect<CaptureStatusResult, EngineClientError>,
 ): Effect.Effect<CaptureStatusResult, EngineClientError> =>
   captureOperation(operation, effect).pipe(

--- a/packages/engine-client/src/services/ExportService.ts
+++ b/packages/engine-client/src/services/ExportService.ts
@@ -3,6 +3,7 @@ import type {
   ExportRunCutPlanResult,
   ExportRunResult,
 } from "@guerillaglass/engine-contract/domains/export";
+import type { ExportJobId } from "@guerillaglass/engine-contract/schema-primitives";
 import { Context, Effect, Layer } from "effect";
 import type { EngineClientError } from "../errors";
 import { EngineClient, type ExportRunCutPlanRequest, type ExportRunRequest } from "../service";
@@ -28,7 +29,7 @@ export type ExportServiceShape = {
   /**
    * Polls an export job.
    */
-  readonly get: (jobId: string) => Effect.Effect<ExportRunResult, EngineClientError>;
+  readonly get: (jobId: ExportJobId) => Effect.Effect<ExportRunResult, EngineClientError>;
 };
 
 /**

--- a/packages/engine-client/tests/service.test.ts
+++ b/packages/engine-client/tests/service.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "vitest";
 import { Effect, Layer, Option, Redacted } from "effect";
 import { HttpClient, HttpClientRequest, Headers } from "effect/unstable/http";
+import {
+  agentJobIdSchema,
+  agentPreflightTokenSchema,
+  displayIdSchema,
+  exportJobIdSchema,
+  exportPresetIdSchema,
+  outputUrlSchema,
+  projectPathSchema,
+  windowIdSchema,
+} from "@guerillaglass/engine-contract/schema-primitives";
 import { SystemService, layerSystemService } from "../src/services/SystemService";
 import {
   EngineClient,
@@ -88,37 +98,56 @@ describe("EngineClient service", () => {
     await Promise.all([
       Effect.runPromise(client.systemPing),
       Effect.runPromise(client.engineCapabilities),
-      Effect.runPromise(client.agentPreflight({ transcript: "ok" })),
-      Effect.runPromise(client.agentRun({ prompt: "cut" })),
-      Effect.runPromise(client.agentStatus("agent-job")),
-      Effect.runPromise(client.agentApply("agent-job", { confirmed: true })),
+      Effect.runPromise(client.agentPreflight({})),
+      Effect.runPromise(
+        client.agentRun({ preflightToken: agentPreflightTokenSchema.make("preflight-token") }),
+      ),
+      Effect.runPromise(client.agentStatus(agentJobIdSchema.make("agent-job"))),
+      Effect.runPromise(
+        client.agentApply(agentJobIdSchema.make("agent-job"), { destructiveIntent: true }),
+      ),
       Effect.runPromise(client.permissionsGet),
       Effect.runPromise(client.permissionsRequestScreenRecording),
       Effect.runPromise(client.permissionsRequestMicrophone),
       Effect.runPromise(client.permissionsRequestInputMonitoring),
       Effect.runPromise(client.permissionsOpenInputMonitoringSettings),
       Effect.runPromise(client.sourcesList),
-      Effect.runPromise(client.captureStartDisplay({ displayId: 1 })),
+      Effect.runPromise(client.captureStartDisplay({ displayId: displayIdSchema.make(1) })),
       Effect.runPromise(client.captureStartCurrentWindow({})),
-      Effect.runPromise(client.captureStartWindow({ windowId: 2 })),
+      Effect.runPromise(client.captureStartWindow({ windowId: windowIdSchema.make(2) })),
       Effect.runPromise(client.captureStop),
       Effect.runPromise(client.captureStatus),
       Effect.runPromise(client.capturePreviewFrame),
       Effect.runPromise(client.recordingStart({ trackInputEvents: true })),
       Effect.runPromise(client.recordingStop),
       Effect.runPromise(client.exportInfo),
-      Effect.runPromise(client.exportRun({ outputURL: "file:///tmp/out.mp4" })),
-      Effect.runPromise(client.exportRunCutPlan({ jobId: "agent-job" })),
-      Effect.runPromise(client.exportGet("export-job")),
+      Effect.runPromise(
+        client.exportRun({
+          outputURL: outputUrlSchema.make("file:///tmp/out.mp4"),
+          presetId: exportPresetIdSchema.make("mp4-1080p"),
+        }),
+      ),
+      Effect.runPromise(
+        client.exportRunCutPlan({
+          outputURL: outputUrlSchema.make("file:///tmp/cut-plan.mp4"),
+          presetId: exportPresetIdSchema.make("mp4-1080p"),
+          jobId: agentJobIdSchema.make("agent-job"),
+        }),
+      ),
+      Effect.runPromise(client.exportGet(exportJobIdSchema.make("export-job"))),
       Effect.runPromise(client.projectCurrent),
-      Effect.runPromise(client.projectOpen({ projectURL: "file:///tmp/project.ggproj" })),
-      Effect.runPromise(client.projectSave({ projectURL: "file:///tmp/project.ggproj" })),
+      Effect.runPromise(
+        client.projectOpen({ projectPath: projectPathSchema.make("/tmp/project.ggproj") }),
+      ),
+      Effect.runPromise(
+        client.projectSave({ projectPath: projectPathSchema.make("/tmp/project.ggproj") }),
+      ),
       Effect.runPromise(client.projectRecents(5)),
     ]);
 
     expect(calls).toContainEqual({
       name: "agent.agentApply",
-      request: { params: { jobId: "agent-job" }, payload: { confirmed: true } },
+      request: { params: { jobId: "agent-job" }, payload: { destructiveIntent: true } },
     });
     expect(calls).toContainEqual({
       name: "export.exportGet",

--- a/packages/engine-contract/AGENTS.md
+++ b/packages/engine-contract/AGENTS.md
@@ -7,6 +7,7 @@ This package is the source of truth for the native engine wire protocol. Domain 
 ## Rules
 
 - Define reusable constrained values in domain/shared schema modules rather than duplicating validation.
+- Use Effect v4 `Schema.brand` for domain identities (IDs, tokens, paths, and URL/path handles). Decode or construct brands at trust boundaries; do not erase them back to plain `string`/`number` inside contract and engine-client services.
 - Keep transport errors explicit and serializable.
 - Add encoding/decoding and operation-shape tests for contract changes.
 - Do not hand-edit `generated/engine.openapi.json`.

--- a/packages/engine-contract/generated/engine.openapi.json
+++ b/packages/engine-contract/generated/engine.openapi.json
@@ -3602,7 +3602,12 @@
             ]
           },
           "recordingURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "captureMetadata": {
             "type": "object",
@@ -3701,7 +3706,12 @@
             "$ref": "#/components/schemas/EngineBadRequestError"
           },
           "eventsURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "lastRecordingTelemetry": {
             "$ref": "#/components/schemas/CaptureTelemetry"
@@ -4207,10 +4217,20 @@
             ]
           },
           "recordingURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "eventsURL": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
           },
           "lastRecordingTelemetry": {
             "$ref": "#/components/schemas/CaptureTelemetry"

--- a/packages/engine-contract/src/domains/capture.ts
+++ b/packages/engine-contract/src/domains/capture.ts
@@ -1,6 +1,6 @@
 import { Schema } from "effect";
 import { NonEmptyString, NonNegativeInt, NonNegativeNumber } from "../shared/helpers";
-import { captureSessionIdSchema } from "../schema-primitives";
+import { captureSessionIdSchema, eventsUrlSchema, recordingUrlSchema } from "../schema-primitives";
 import { captureMetadataSchema } from "../shared/valueObjects";
 import { EngineBadRequestError } from "../errors";
 
@@ -37,10 +37,10 @@ export const captureStatusResultSchema = Schema.Struct({
   isRecording: Schema.Boolean,
   captureSessionId: Schema.optionalKey(captureSessionIdSchema),
   recordingDurationSeconds: NonNegativeNumber,
-  recordingURL: Schema.optionalKey(Schema.String),
+  recordingURL: Schema.optionalKey(recordingUrlSchema),
   captureMetadata: Schema.optionalKey(captureMetadataSchema),
   lastError: Schema.optionalKey(EngineBadRequestError),
-  eventsURL: Schema.optionalKey(Schema.String),
+  eventsURL: Schema.optionalKey(eventsUrlSchema),
   lastRecordingTelemetry: Schema.optionalKey(captureTelemetrySchema),
   telemetry: captureTelemetrySchema,
 }).annotate({ identifier: "CaptureStatusResult" });

--- a/packages/engine-contract/src/domains/project.ts
+++ b/packages/engine-contract/src/domains/project.ts
@@ -1,6 +1,11 @@
 import { Schema } from "effect";
 import { IsoDateTime, NonEmptyString } from "../shared/helpers";
-import { agentJobIdSchema, projectPathSchema } from "../schema-primitives";
+import {
+  agentJobIdSchema,
+  eventsUrlSchema,
+  projectPathSchema,
+  recordingUrlSchema,
+} from "../schema-primitives";
 import {
   autoZoomSettingsSchema,
   captureMetadataSchema,
@@ -24,8 +29,8 @@ export const projectAgentAnalysisSummarySchema = Schema.Struct({
  */
 export const projectStateSchema = Schema.Struct({
   projectPath: Schema.optionalKey(projectPathSchema),
-  recordingURL: Schema.optionalKey(Schema.String),
-  eventsURL: Schema.optionalKey(Schema.String),
+  recordingURL: Schema.optionalKey(recordingUrlSchema),
+  eventsURL: Schema.optionalKey(eventsUrlSchema),
   lastRecordingTelemetry: Schema.optionalKey(captureTelemetrySchema),
   autoZoom: autoZoomSettingsSchema,
   timeline: timelineDocumentSchema,

--- a/packages/engine-contract/src/domains/sources.ts
+++ b/packages/engine-contract/src/domains/sources.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect";
-import { NonEmptyString, NonNegativeInt, PositiveInt, PositiveNumber } from "../shared/helpers";
+import { displayIdSchema, windowIdSchema } from "../schema-primitives";
+import { NonEmptyString, PositiveInt, PositiveNumber } from "../shared/helpers";
 
 /**
  * Supported capture frame rates for all engines.
@@ -20,7 +21,7 @@ export const captureFrameRateSchema = Schema.Literals(captureFrameRates);
  * Display capture source descriptor.
  */
 export const displaySourceSchema = Schema.Struct({
-  id: NonNegativeInt,
+  id: displayIdSchema,
   displayName: NonEmptyString,
   isPrimary: Schema.Boolean,
   width: PositiveInt,
@@ -34,7 +35,7 @@ export const displaySourceSchema = Schema.Struct({
  * Window capture source descriptor.
  */
 export const windowSourceSchema = Schema.Struct({
-  id: NonNegativeInt,
+  id: windowIdSchema,
   title: Schema.String,
   appName: Schema.String,
   width: PositiveNumber,

--- a/packages/engine-contract/src/httpApi.ts
+++ b/packages/engine-contract/src/httpApi.ts
@@ -2,16 +2,17 @@ import { HttpApi, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi"
 import { Schema } from "effect";
 import {
   agentJobIdSchema,
+  agentPreflightTokenSchema,
+  displayIdSchema,
   exportJobIdSchema,
   exportPresetIdSchema,
   outputUrlSchema,
   projectPathSchema,
+  windowIdSchema,
 } from "./schema-primitives";
 import {
   RuntimeBudgetMinutesSchema,
   ProjectRecentsLimitSchema,
-  NonEmptyString,
-  NonNegativeInt,
   NonNegativeNumber,
 } from "./shared/helpers";
 import { autoZoomSettingsSchema, timelineDocumentSchema } from "./shared/valueObjects";
@@ -46,7 +47,7 @@ export const agentPreflightPayloadSchema = Schema.Struct({
 }).annotate({ identifier: "AgentPreflightPayload" });
 
 export const agentRunPayloadSchema = Schema.Struct({
-  preflightToken: NonEmptyString,
+  preflightToken: agentPreflightTokenSchema,
   runtimeBudgetMinutes: Schema.optionalKey(RuntimeBudgetMinutesSchema),
   transcriptionProvider: Schema.optionalKey(transcriptionProviderSchema),
   importedTranscriptPath: Schema.optionalKey(projectPathSchema),
@@ -58,7 +59,7 @@ export const agentApplyPayloadSchema = Schema.Struct({
 }).annotate({ identifier: "AgentApplyPayload" });
 
 export const captureStartDisplayPayloadSchema = Schema.Struct({
-  displayId: Schema.optionalKey(NonNegativeInt),
+  displayId: Schema.optionalKey(displayIdSchema),
   enableMic: Schema.optionalKey(Schema.Boolean),
   enablePreview: Schema.optionalKey(Schema.Boolean),
   captureFps: Schema.optionalKey(captureFrameRateSchema),
@@ -71,7 +72,7 @@ export const captureStartCurrentWindowPayloadSchema = Schema.Struct({
 }).annotate({ identifier: "CaptureStartCurrentWindowPayload" });
 
 export const captureStartWindowPayloadSchema = Schema.Struct({
-  windowId: NonNegativeInt,
+  windowId: windowIdSchema,
   enableMic: Schema.optionalKey(Schema.Boolean),
   enablePreview: Schema.optionalKey(Schema.Boolean),
   captureFps: Schema.optionalKey(captureFrameRateSchema),

--- a/packages/engine-contract/src/schema-primitives.ts
+++ b/packages/engine-contract/src/schema-primitives.ts
@@ -1,75 +1,95 @@
 import { Schema } from "effect";
-import { IsoDateTime, NonEmptyString } from "./shared/helpers";
+import { IsoDateTime, NonEmptyString, NonNegativeInt } from "./shared/helpers";
 
 /**
  * Opaque identifier for an active capture session.
  */
-export const captureSessionIdSchema = NonEmptyString;
+export const captureSessionIdSchema = NonEmptyString.pipe(Schema.brand("CaptureSessionId"));
 
 /**
  * Filesystem path to a GuerillaGlass project document.
  */
-export const projectPathSchema = NonEmptyString;
+export const projectPathSchema = NonEmptyString.pipe(Schema.brand("ProjectPath"));
 
 /**
  * Filesystem path to a local file that has been granted to the desktop host.
  */
-export const filePathSchema = NonEmptyString;
+export const filePathSchema = NonEmptyString.pipe(Schema.brand("FilePath"));
 
 /**
  * File URL or path identifying where an exported render should be written.
  */
-export const outputUrlSchema = NonEmptyString;
+export const outputUrlSchema = NonEmptyString.pipe(Schema.brand("OutputUrl"));
+
+/**
+ * File URL or path identifying a captured recording.
+ */
+export const recordingUrlSchema = NonEmptyString.pipe(Schema.brand("RecordingUrl"));
+
+/**
+ * File URL or path identifying an engine-produced input event log.
+ */
+export const eventsUrlSchema = NonEmptyString.pipe(Schema.brand("EventsUrl"));
 
 /**
  * Stable identifier for an engine-supported export preset.
  */
-export const exportPresetIdSchema = NonEmptyString;
+export const exportPresetIdSchema = NonEmptyString.pipe(Schema.brand("ExportPresetId"));
 
 /**
  * Stable identifier for a timeline segment.
  */
-export const timelineSegmentIdSchema = NonEmptyString;
+export const timelineSegmentIdSchema = NonEmptyString.pipe(Schema.brand("TimelineSegmentId"));
 
 /**
  * Opaque identifier for an asynchronous Agent Mode job.
  */
-export const agentJobIdSchema = NonEmptyString;
+export const agentJobIdSchema = NonEmptyString.pipe(Schema.brand("AgentJobId"));
 
 /**
  * Opaque token returned by Agent Mode preflight.
  */
-export const agentPreflightTokenSchema = NonEmptyString;
+export const agentPreflightTokenSchema = NonEmptyString.pipe(Schema.brand("AgentPreflightToken"));
 
 /**
  * Opaque identifier for an asynchronous export job.
  */
-export const exportJobIdSchema = NonEmptyString;
+export const exportJobIdSchema = NonEmptyString.pipe(Schema.brand("ExportJobId"));
 
 /**
  * Opaque review identifier used by the desktop review bridge.
  */
-export const reviewIdSchema = NonEmptyString;
+export const reviewIdSchema = NonEmptyString.pipe(Schema.brand("ReviewId"));
 
 /**
  * Opaque review comment identifier used by the desktop review bridge.
  */
-export const reviewCommentIdSchema = NonEmptyString;
+export const reviewCommentIdSchema = NonEmptyString.pipe(Schema.brand("ReviewCommentId"));
 
 /**
  * Opaque review user identifier used by the desktop review bridge.
  */
-export const reviewUserIdSchema = NonEmptyString;
+export const reviewUserIdSchema = NonEmptyString.pipe(Schema.brand("ReviewUserId"));
 
 /**
  * Review authentication token accepted by host-side review bridge requests.
  */
-export const reviewAuthTokenSchema = NonEmptyString;
+export const reviewAuthTokenSchema = NonEmptyString.pipe(Schema.brand("ReviewAuthToken"));
 
 /**
  * Filesystem path to an engine-produced artifact.
  */
-export const artifactPathSchema = NonEmptyString;
+export const artifactPathSchema = NonEmptyString.pipe(Schema.brand("ArtifactPath"));
+
+/**
+ * Native display identifier from the capture subsystem.
+ */
+export const displayIdSchema = NonNegativeInt.pipe(Schema.brand("DisplayId"));
+
+/**
+ * Native window identifier from the capture subsystem.
+ */
+export const windowIdSchema = NonNegativeInt.pipe(Schema.brand("WindowId"));
 
 /**
  * ISO-8601 date-time string used by bridge contracts.
@@ -80,3 +100,42 @@ export const isoDateTimeSchema = IsoDateTime;
  * Legacy JSON-RPC request identifier retained only for migration tooling.
  */
 export const jsonRpcIdSchema = Schema.Union([Schema.String, Schema.Number]);
+
+/** Branded capture session identifier. */
+export type CaptureSessionId = typeof captureSessionIdSchema.Type;
+/** Branded project path. */
+export type ProjectPath = typeof projectPathSchema.Type;
+/** Branded local file path. */
+export type FilePath = typeof filePathSchema.Type;
+/** Branded export output URL or path. */
+export type OutputUrl = typeof outputUrlSchema.Type;
+/** Branded recording URL or path. */
+export type RecordingUrl = typeof recordingUrlSchema.Type;
+/** Branded input-event log URL or path. */
+export type EventsUrl = typeof eventsUrlSchema.Type;
+/** Branded export preset identifier. */
+export type ExportPresetId = typeof exportPresetIdSchema.Type;
+/** Branded timeline segment identifier. */
+export type TimelineSegmentId = typeof timelineSegmentIdSchema.Type;
+/** Branded Agent Mode job identifier. */
+export type AgentJobId = typeof agentJobIdSchema.Type;
+/** Branded Agent Mode preflight token. */
+export type AgentPreflightToken = typeof agentPreflightTokenSchema.Type;
+/** Branded export job identifier. */
+export type ExportJobId = typeof exportJobIdSchema.Type;
+/** Branded hosted review identifier. */
+export type ReviewId = typeof reviewIdSchema.Type;
+/** Branded hosted review comment identifier. */
+export type ReviewCommentId = typeof reviewCommentIdSchema.Type;
+/** Branded hosted review user identifier. */
+export type ReviewUserId = typeof reviewUserIdSchema.Type;
+/** Branded hosted review authentication token. */
+export type ReviewAuthToken = typeof reviewAuthTokenSchema.Type;
+/** Branded engine artifact path. */
+export type ArtifactPath = typeof artifactPathSchema.Type;
+/** Branded native display identifier. */
+export type DisplayId = typeof displayIdSchema.Type;
+/** Branded native window identifier. */
+export type WindowId = typeof windowIdSchema.Type;
+/** Branded ISO-8601 timestamp. */
+export type IsoDateTime = typeof isoDateTimeSchema.Type;

--- a/packages/engine-contract/src/shared/helpers.ts
+++ b/packages/engine-contract/src/shared/helpers.ts
@@ -8,7 +8,9 @@ export const NonEmptyString = Schema.NonEmptyString;
 /**
  * ISO-8601 date-time string used for wire-safe timestamps.
  */
-export const IsoDateTime = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T/));
+export const IsoDateTime = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T/)).pipe(
+  Schema.brand("IsoDateTime"),
+);
 
 /**
  * Integer constrained to values greater than or equal to zero.

--- a/packages/engine-contract/src/shared/valueObjects.ts
+++ b/packages/engine-contract/src/shared/valueObjects.ts
@@ -1,9 +1,9 @@
 import { Schema } from "effect";
-import { IsoDateTime, NonNegativeInt, NonNegativeNumber, PositiveNumber } from "./helpers";
-import { timelineSegmentIdSchema } from "../schema-primitives";
+import { IsoDateTime, NonNegativeNumber, PositiveNumber } from "./helpers";
+import { timelineSegmentIdSchema, windowIdSchema } from "../schema-primitives";
 
 const captureWindowSchema = Schema.Struct({
-  id: NonNegativeInt,
+  id: windowIdSchema,
   title: Schema.String,
   appName: Schema.String,
 });

--- a/packages/engine-contract/tests/branded-primitives.test.ts
+++ b/packages/engine-contract/tests/branded-primitives.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, expectTypeOf, test } from "vitest";
+import { Schema } from "effect";
+import {
+  agentJobIdSchema,
+  agentPreflightTokenSchema,
+  artifactPathSchema,
+  captureSessionIdSchema,
+  displayIdSchema,
+  eventsUrlSchema,
+  exportJobIdSchema,
+  exportPresetIdSchema,
+  filePathSchema,
+  isoDateTimeSchema,
+  outputUrlSchema,
+  projectPathSchema,
+  recordingUrlSchema,
+  reviewAuthTokenSchema,
+  reviewCommentIdSchema,
+  reviewIdSchema,
+  reviewUserIdSchema,
+  timelineSegmentIdSchema,
+  windowIdSchema,
+  type FilePath,
+  type ProjectPath,
+} from "../src/schema-primitives";
+
+const acceptsProjectPath = (_value: ProjectPath): void => undefined;
+
+const brandedSchemas = [
+  [captureSessionIdSchema, "CaptureSessionId"],
+  [projectPathSchema, "ProjectPath"],
+  [filePathSchema, "FilePath"],
+  [outputUrlSchema, "OutputUrl"],
+  [recordingUrlSchema, "RecordingUrl"],
+  [eventsUrlSchema, "EventsUrl"],
+  [exportPresetIdSchema, "ExportPresetId"],
+  [timelineSegmentIdSchema, "TimelineSegmentId"],
+  [agentJobIdSchema, "AgentJobId"],
+  [agentPreflightTokenSchema, "AgentPreflightToken"],
+  [exportJobIdSchema, "ExportJobId"],
+  [reviewIdSchema, "ReviewId"],
+  [reviewCommentIdSchema, "ReviewCommentId"],
+  [reviewUserIdSchema, "ReviewUserId"],
+  [reviewAuthTokenSchema, "ReviewAuthToken"],
+  [artifactPathSchema, "ArtifactPath"],
+  [displayIdSchema, "DisplayId"],
+  [windowIdSchema, "WindowId"],
+  [isoDateTimeSchema, "IsoDateTime"],
+] as const;
+
+describe("branded schema primitives", () => {
+  test.each(brandedSchemas)("records nominal brand metadata", (schema, brand) => {
+    expect(Schema.resolveAnnotations(schema)?.brands).toContain(brand);
+  });
+
+  test("preserves the underlying runtime constraints", () => {
+    expect(() => recordingUrlSchema.make("")).toThrow();
+    expect(() => displayIdSchema.make(-1)).toThrow();
+  });
+
+  test("keeps brands decoded-only while preserving wire encodings", () => {
+    const projectPath = Schema.decodeUnknownSync(projectPathSchema)("/tmp/project.ggproj");
+    expect(projectPath).toBe("/tmp/project.ggproj");
+    expect(Schema.encodeSync(projectPathSchema)(projectPath)).toBe("/tmp/project.ggproj");
+    expectTypeOf(projectPath).toEqualTypeOf<ProjectPath>();
+  });
+
+  test("prevents structurally identical domain values from being mixed", () => {
+    const projectPath = projectPathSchema.make("/tmp/project.ggproj");
+    const filePath = filePathSchema.make("/tmp/recording.mov");
+    acceptsProjectPath(projectPath);
+    // @ts-expect-error FilePath and ProjectPath are intentionally nominally distinct.
+    const invalidProjectPath: ProjectPath = filePath;
+    expect(invalidProjectPath).toBe(filePath);
+    expectTypeOf(filePath).toEqualTypeOf<FilePath>();
+  });
+});

--- a/packages/review-protocol/src/index.ts
+++ b/packages/review-protocol/src/index.ts
@@ -9,10 +9,12 @@ import { Schema } from "effect";
 function greaterThanOrEqualTo(minimum: number) {
   return Schema.check<Schema.Schema<number>>(Schema.isGreaterThanOrEqualTo(minimum));
 }
-const isoDateTimeSchema = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T/));
-const reviewCommentIdSchema = Schema.NonEmptyString;
-const reviewIdSchema = Schema.NonEmptyString;
-const reviewUserIdSchema = Schema.NonEmptyString;
+export const isoDateTimeSchema = Schema.String.check(Schema.isPattern(/^\d{4}-\d{2}-\d{2}T/)).pipe(
+  Schema.brand("IsoDateTime"),
+);
+export const reviewCommentIdSchema = Schema.NonEmptyString.pipe(Schema.brand("ReviewCommentId"));
+export const reviewIdSchema = Schema.NonEmptyString.pipe(Schema.brand("ReviewId"));
+export const reviewUserIdSchema = Schema.NonEmptyString.pipe(Schema.brand("ReviewUserId"));
 
 /** Core review enums and shared entities used across snapshot, mutation, and event payloads. */
 /** Canonical review workflow statuses used in Deliver review. */
@@ -67,7 +69,7 @@ export const reviewCommentSchema = Schema.Struct({
   authorName: Schema.NonEmptyString,
   body: Schema.NonEmptyString,
   frameNumber: Schema.NullOr(Schema.Int.pipe(greaterThanOrEqualTo(0))),
-  timestampSeconds: Schema.NullOr(Schema.Number.pipe(greaterThanOrEqualTo(0))),
+  timestampSeconds: Schema.NullOr(Schema.Finite.pipe(greaterThanOrEqualTo(0))),
   resolved: Schema.Boolean,
   createdAt: isoDateTimeSchema,
   updatedAt: isoDateTimeSchema,
@@ -97,7 +99,7 @@ export const reviewCreateCommentRequestSchema = Schema.Struct({
   reviewId: reviewIdSchema,
   body: Schema.NonEmptyString,
   frameNumber: Schema.optional(Schema.Int.pipe(greaterThanOrEqualTo(0))),
-  timestampSeconds: Schema.optional(Schema.Number.pipe(greaterThanOrEqualTo(0))),
+  timestampSeconds: Schema.optional(Schema.Finite.pipe(greaterThanOrEqualTo(0))),
   parentCommentId: Schema.optional(reviewCommentIdSchema),
 });
 
@@ -162,6 +164,14 @@ export const reviewBridgeEventSchema = Schema.Union([
 ]);
 
 /** Inferred TypeScript aliases for consumers that only need the review data model. */
+/** Branded hosted review identifier. */
+export type ReviewId = typeof reviewIdSchema.Type;
+/** Branded hosted review comment identifier. */
+export type ReviewCommentId = typeof reviewCommentIdSchema.Type;
+/** Branded hosted review user identifier. */
+export type ReviewUserId = typeof reviewUserIdSchema.Type;
+/** Branded ISO-8601 timestamp. */
+export type IsoDateTime = typeof isoDateTimeSchema.Type;
 /** Type alias for ReviewWorkflowStatus. */
 export type ReviewWorkflowStatus = typeof reviewWorkflowStatusSchema.Type;
 /** Type alias for ReviewRole. */


### PR DESCRIPTION
## Summary
- adopt Effect v4 `Schema.brand` for contract identities: jobs, sessions, timeline items, review entities, tokens, paths/URL handles, displays/windows, and ISO timestamps
- carry branded types through engine-client domain services, desktop bridge params, review gateway calls, capture benchmarking, and capability grants
- replace permissive `Record<string, unknown>` engine-client request aliases with exact request types inferred from the Effect `HttpApi` payload schemas
- remove the obsolete `rawClient as any` workaround; Effect beta.101's generated `HttpApiClient` shape typechecks directly
- use the existing branded Agent preflight token schema and distinct display/window ID schemas in endpoint payloads
- make recording/event URL handles non-empty and update generated OpenAPI plus Swift wrappers
- add runtime metadata/constraint/wire tests and compile-time nominal non-assignability coverage
- document the branded-identity rule in agent and review guidance

## Audit findings fixed
- all contract identity schemas were aliases of the same `NonEmptyString`, so project paths, auth tokens, job IDs, preset IDs, and review IDs were structurally interchangeable
- engine-client requests accepted arbitrary records; existing tests passed nonexistent fields such as `prompt`, `transcript`, `confirmed`, and `projectURL`
- status/apply/export service methods erased job brands back to plain strings
- desktop capability tokens and hosted review IDs were erased at bridge/service boundaries
- capture display/window IDs were interchangeable numbers
- Agent run used a generic non-empty string instead of `agentPreflightTokenSchema`

## Validation
- `bun run gate`
- `bun run protocol:typecheck`
- `bun run protocol:check-determinism`
- `bun run desktop:build`
- `bun run web:build`
- `cargo test --workspace --all-targets`
- `swift test`
- desktop unit tests: 209 passed
- desktop browser tests: 27 passed
- engine-contract tests: 37 passed
- engine-client tests: 24 passed
