### PR TITLE
refactor(effect): stabilize on Node platform services

### DIFF
--- a/.github/workflows/full_gate.yml
+++ b/.github/workflows/full_gate.yml
@@ -40,6 +40,9 @@ jobs:
         env:
           SKIP_DESKTOP_TESTS: "1"
 
+      - name: Desktop Node media server integration
+        run: cd apps/desktop-electrobun && bun run test:vitest:ci -- --run tests/media-server-node-integration.test.ts
+
       - name: Install coverage dependencies
         run: brew install jq
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ Documents named `ENGINE_CONTRACT_V2_*` and `MIGRATION.md` preserve migration his
 8. User-visible strings must use the shared localization source. Do not hand-edit generated `src/paraglide` output.
 9. Cross-platform shells must not claim capabilities that their native implementation does not provide.
 10. Prefer enforcing repeated review feedback with schemas, generators, lint rules, tests, or CI rather than prose alone.
+11. Bun is the only JavaScript package manager. The Electrobun host uses `@effect/platform-node` rather than `@effect/platform-bun` for runtime stability.
+12. Application path, filesystem, and cryptographic operations use Effect's `Path`, `FileSystem`, and `Crypto` services with platform layers at composition roots; do not add direct `node:path`, `node:fs`, or `node:crypto` dependencies to domain/application services.
 
 ## Generated and owned files
 

--- a/REVIEW.md
+++ b/REVIEW.md
@@ -11,12 +11,13 @@ Use this rubric for human and agent review. Report concrete defects with file/li
 - **Tests:** Tests assert externally meaningful behavior and would fail before the fix.
 - **Documentation:** Active roadmap state and operational guidance match the implementation.
 - **Security:** File paths, bearer tokens, loopback origins, symlinks, and untrusted payloads retain defensive validation.
-- **Dependencies:** Manifest, lockfile, generated templates, and vendor pins remain aligned.
+- **Dependencies:** Manifest, lockfile, generated templates, and vendor pins remain aligned. Bun remains the only JavaScript package manager, and Effect runtime integrations use `@effect/platform-node` rather than `@effect/platform-bun`.
 
 ## Desktop and UI
 
 - Host/renderer bridge handlers remain typed and thin.
-- Long-lived Bun resources are scoped through the existing Effect runtime.
+- Long-lived host resources are scoped through the existing Effect runtime and Node platform layer.
+- Application path, filesystem, and cryptographic operations depend on Effect `Path`, `FileSystem`, and `Crypto` services rather than direct Node core imports.
 - User-visible text comes from `messages/*.json`; both `en-US` and `de-DE` are updated.
 - Controls are keyboard reachable, have visible focus, expose names/state, and respect reduced motion.
 - Shortcuts use the shared registry and honor user overrides/conflict validation.

--- a/Scripts/capture_benchmark.ts
+++ b/Scripts/capture_benchmark.ts
@@ -3,7 +3,7 @@ import { mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import process from "node:process";
-import * as BunServices from "../apps/desktop-electrobun/node_modules/@effect/platform-bun/dist/BunServices.js";
+import * as NodeServices from "../apps/desktop-electrobun/node_modules/@effect/platform-node/dist/NodeServices.js";
 import * as Effect from "../apps/desktop-electrobun/node_modules/effect/dist/Effect.js";
 import * as Exit from "../apps/desktop-electrobun/node_modules/effect/dist/Exit.js";
 import * as ManagedRuntime from "../apps/desktop-electrobun/node_modules/effect/dist/ManagedRuntime.js";
@@ -735,7 +735,7 @@ type BenchmarkProcess = {
 };
 
 async function runProcessEffect<A, E, R>(effect: Effect.Effect<A, E, R>) {
-  return await Effect.runPromise(effect.pipe(Effect.provide(BunServices.layer)) as never);
+  return await Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer)) as never);
 }
 
 async function spawnBenchmarkProcess(

--- a/Scripts/coverage_check.sh
+++ b/Scripts/coverage_check.sh
@@ -132,7 +132,8 @@ if needs_scope typescript; then
     bun run test:vitest:ci -- --coverage \
       --exclude tests/parity-e2e.test.ts \
       --exclude tests/native-http-launch-security.test.ts \
-      --exclude tests/macos-engine-lifecycle.test.ts
+      --exclude tests/macos-engine-lifecycle.test.ts \
+      --exclude tests/media-server-node-integration.test.ts
   ) 2>&1 | tee "$TS_REPORT"
 
   ENGINE_CLIENT_TS_REPORT="$COVERAGE_DIR/engine-client-typescript-coverage.txt"

--- a/Scripts/repository_invariants.test.ts
+++ b/Scripts/repository_invariants.test.ts
@@ -78,6 +78,18 @@ describe("repository invariants", () => {
     expect(result.stderr).toContain("workspace Effect runtime versions are not aligned");
   });
 
+  test("rejects platform-bun dependencies and non-Bun lockfiles", () => {
+    writeFixture(
+      "apps/web/package.json",
+      JSON.stringify({ dependencies: { "@effect/platform-bun": "4.0.0-beta.101" } }),
+    );
+    writeFixture("package-lock.json", "{}\n");
+    const result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("must use @effect/platform-node");
+    expect(result.stderr).toContain("unsupported package-manager lockfile present");
+  });
+
   test("reports vendor drift when the Effect submodule is initialized", () => {
     writeFixture(
       "vendor/effect/packages/effect/package.json",

--- a/Scripts/repository_invariants.ts
+++ b/Scripts/repository_invariants.ts
@@ -31,6 +31,7 @@ for (const guide of requiredGuides) {
 }
 
 checkEffectVersionAlignment();
+checkJavaScriptRuntimePolicy();
 checkGeneratedRustDependencyOwnership();
 checkLocalizationParity();
 checkMarkdownLinks();
@@ -50,6 +51,7 @@ console.log(
     ? "- Effect runtime packages are aligned and match the initialized vendor submodule"
     : "- Effect runtime packages are aligned (vendor comparison skipped; submodule not initialized)",
 );
+console.log("- Bun is the only package manager and Effect uses the Node platform adapter");
 console.log("- generated Rust dependency table matches the generator template");
 console.log("- localization keys and placeholders match across supported locales");
 console.log("- inline local Markdown file links resolve");
@@ -60,7 +62,7 @@ function checkEffectVersionAlignment(): void {
     ...workspaceManifestPaths("apps"),
     ...workspaceManifestPaths("packages"),
   ];
-  const runtimePackageNames = new Set(["effect", "@effect/platform-bun", "@effect/vitest"]);
+  const runtimePackageNames = new Set(["effect", "@effect/platform-node", "@effect/vitest"]);
   const versions = new Map<string, Array<string>>();
 
   for (const manifestPath of manifestPaths) {
@@ -116,6 +118,39 @@ function checkEffectVersionAlignment(): void {
     failures.push(
       `workspace Effect runtime version ${workspaceVersion} does not match vendor/effect ${vendorVersion}`,
     );
+  }
+}
+
+function checkJavaScriptRuntimePolicy(): void {
+  for (const forbiddenLockfile of ["package-lock.json", "pnpm-lock.yaml", "yarn.lock"]) {
+    if (existsSync(join(root, forbiddenLockfile))) {
+      failures.push(`unsupported package-manager lockfile present: ${forbiddenLockfile}`);
+    }
+  }
+
+  const manifestPaths = [
+    "package.json",
+    ...workspaceManifestPaths("apps"),
+    ...workspaceManifestPaths("packages"),
+  ];
+  for (const manifestPath of manifestPaths) {
+    const manifest = readJson(join(root, manifestPath));
+    for (const dependencyGroup of [
+      manifest.dependencies,
+      manifest.devDependencies,
+      manifest.peerDependencies,
+      manifest.optionalDependencies,
+    ]) {
+      if (
+        dependencyGroup &&
+        typeof dependencyGroup === "object" &&
+        "@effect/platform-bun" in dependencyGroup
+      ) {
+        failures.push(
+          `${manifestPath} must use @effect/platform-node instead of @effect/platform-bun`,
+        );
+      }
+    }
   }
 }
 

--- a/apps/desktop-electrobun/README.md
+++ b/apps/desktop-electrobun/README.md
@@ -23,7 +23,7 @@ Key points:
 - Electrobun shell resources are scoped behind `DesktopShell`.
 - Bridge handlers delegate to `HostBridgeService` / `ProjectSession`; they do not own business logic.
 - Engine sidecars are spawned with Effect process primitives and connected through authenticated loopback HTTP.
-- Media playback uses tokenized loopback URLs served by Effect HTTP routes and `BunHttpServer.layer`.
+- Media playback uses tokenized loopback URLs served by Effect HTTP routes and `NodeHttpServer.layer` under Electrobun's Bun executable.
 - Localization is generated from root Paraglide/Inlang messages into ignored `src/paraglide` output.
 
 ## Prerequisites

--- a/apps/desktop-electrobun/package.json
+++ b/apps/desktop-electrobun/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.6.0",
-    "@effect/platform-bun": "4.0.0-beta.101",
+    "@effect/platform-node": "4.0.0-beta.101",
     "@fontsource-variable/inter": "^5.3.0",
     "@guerillaglass/engine-client": "workspace:*",
     "@guerillaglass/engine-contract": "workspace:*",

--- a/apps/desktop-electrobun/src/bun/app/AppLayer.ts
+++ b/apps/desktop-electrobun/src/bun/app/AppLayer.ts
@@ -2,6 +2,7 @@ import {
   captureStatusResultSchema,
   type CaptureStatusResult,
 } from "@guerillaglass/engine-contract/domains/capture";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Exit, Layer, Schema, Cause } from "effect";
 import { AgentService } from "@guerillaglass/engine-client/services/AgentService";
 import { CaptureService } from "@guerillaglass/engine-client/services/CaptureService";
@@ -176,8 +177,11 @@ export function makeLayerDesktopApp(options: DesktopAppLayerOptions) {
   );
 
   if (options.enableCaptureStatusPolling === false) {
-    return servicesLayer;
+    return servicesLayer.pipe(Layer.provide(NodeServices.layer));
   }
 
-  return makeCaptureStatusPollingLayer(options).pipe(Layer.provideMerge(servicesLayer));
+  return makeCaptureStatusPollingLayer(options).pipe(
+    Layer.provideMerge(servicesLayer),
+    Layer.provide(NodeServices.layer),
+  );
 }

--- a/apps/desktop-electrobun/src/bun/app/AppLogging.ts
+++ b/apps/desktop-electrobun/src/bun/app/AppLogging.ts
@@ -1,4 +1,4 @@
-import * as BunServices from "@effect/platform-bun/BunServices";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Config, Duration, Effect, Layer, Logger, Metric, References } from "effect";
 import { DevTools } from "effect/unstable/devtools";
 import { platform, release } from "node:os";
@@ -69,8 +69,8 @@ const loggerLayer = Layer.unwrap(
       ),
     );
 
-    return Logger.layer([consoleLogger, ...fileLoggers]).pipe(Layer.provide(BunServices.layer));
-  }).pipe(Effect.provide(BunServices.layer)),
+    return Logger.layer([consoleLogger, ...fileLoggers]).pipe(Layer.provide(NodeServices.layer));
+  }).pipe(Effect.provide(NodeServices.layer)),
 );
 
 /** Desktop backend logging policy: structured JSON in production, verbose diagnostics in dev. */
@@ -198,5 +198,5 @@ export const layerDesktopProcessDiagnostics = Layer.effectDiscard(
         process.removeListener("exit", onExit);
       }),
     );
-  }).pipe(Effect.provide(BunServices.layer)),
+  }).pipe(Effect.provide(NodeServices.layer)),
 );

--- a/apps/desktop-electrobun/src/bun/app/index.ts
+++ b/apps/desktop-electrobun/src/bun/app/index.ts
@@ -1,5 +1,5 @@
-import * as BunRuntime from "@effect/platform-bun/BunRuntime";
-import * as BunServices from "@effect/platform-bun/BunServices";
+import * as NodeRuntime from "@effect/platform-node/NodeRuntime";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Layer, Metric } from "effect";
 import { layerEngineClientBun } from "@guerillaglass/engine-client/service";
 import { layerEngineDomainServices } from "@guerillaglass/engine-client/services/domainServices";
@@ -60,8 +60,8 @@ async function bootstrapApp() {
   desktopAppRuntime = await makeDesktopAppRuntime({
     desktopShellLayer: layerDesktopShellFromConfig,
     engineDomainServicesLayer: guardedEngineDomainServicesLayer,
-    desktopTempDirectoryLayer: layerDesktopTempDirectory.pipe(Layer.provide(BunServices.layer)),
-    projectSessionLayer: layerProjectSession.pipe(Layer.provide(BunServices.layer)),
+    desktopTempDirectoryLayer: layerDesktopTempDirectory.pipe(Layer.provide(NodeServices.layer)),
+    projectSessionLayer: layerProjectSession.pipe(Layer.provide(NodeServices.layer)),
   });
 
   try {
@@ -186,7 +186,7 @@ const desktopMainEffect = Effect.scoped(
 ).pipe(
   Effect.ensuring(disposeDesktopAppEffect),
   Metric.enableRuntimeMetrics,
-  Effect.provide(Layer.mergeAll(BunServices.layer, layerAppLogging, layerEffectDevTools)),
+  Effect.provide(Layer.mergeAll(NodeServices.layer, layerAppLogging, layerEffectDevTools)),
 );
 
-BunRuntime.runMain(desktopMainEffect);
+NodeRuntime.runMain(desktopMainEffect);

--- a/apps/desktop-electrobun/src/bun/media/MediaRegistry.ts
+++ b/apps/desktop-electrobun/src/bun/media/MediaRegistry.ts
@@ -1,6 +1,5 @@
 import path from "node:path";
-import { randomUUID } from "node:crypto";
-import { Context, Effect, FileSystem, Layer, Option, Ref } from "effect";
+import { Context, Crypto, Effect, FileSystem, Layer, Option, Ref } from "effect";
 import type { CapturePreviewFrameResult } from "@guerillaglass/engine-contract/domains/capture";
 import { messageFromUnknownError } from "@guerillaglass/engine-client/errors";
 import { MediaServerError } from "../../shared/errors/desktopErrors";
@@ -123,78 +122,77 @@ function normalizeMediaPath(
   });
 }
 
-export const makeMediaRegistryService: Effect.Effect<MediaRegistryService> = Effect.gen(
-  function* () {
-    const tokensRef = yield* Ref.make(new Map<string, TokenEntry>());
+export const makeMediaRegistryService = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const tokensRef = yield* Ref.make(new Map<string, TokenEntry>());
 
-    const insertToken = (entry: TokenEntry) =>
-      Effect.gen(function* () {
-        const token = randomUUID();
-        const now = Date.now();
-        yield* Ref.update(tokensRef, (tokens) => {
-          const next = pruneTokenMap(tokens, now);
-          next.set(token, entry);
-          return next;
-        });
-        return token;
+  const insertToken = (entry: TokenEntry) =>
+    Effect.gen(function* () {
+      const token = yield* crypto.randomUUIDv4.pipe(Effect.orDie);
+      const now = Date.now();
+      yield* Ref.update(tokensRef, (tokens) => {
+        const next = pruneTokenMap(tokens, now);
+        next.set(token, entry);
+        return next;
       });
-
-    return MediaRegistry.of({
-      registerMediaFile: (filePath) =>
-        normalizeMediaPath(filePath).pipe(
-          Effect.flatMap((normalizedPath) => {
-            const now = Date.now();
-            return insertToken({
-              kind: "file",
-              filePath: normalizedPath,
-              createdAt: now,
-              lastAccessedAt: now,
-            });
-          }),
-        ),
-
-      registerCapturePreview: (loadPreviewFrame) => {
-        const now = Date.now();
-        return insertToken({
-          kind: "capturePreview",
-          createdAt: now,
-          lastAccessedAt: now,
-          loadPreviewFrame,
-          cachedFrameId: null,
-          cachedJPEGBytes: null,
-        });
-      },
-
-      resolveToken: (token) =>
-        Ref.modify(tokensRef, (tokens) => {
-          const now = Date.now();
-          const next = pruneTokenMap(tokens, now);
-          const entry = next.get(token);
-          if (!entry || isTokenExpired(entry, now)) {
-            next.delete(token);
-            return [Option.none<TokenEntry>(), next];
-          }
-          const refreshedEntry = { ...entry, lastAccessedAt: now } as TokenEntry;
-          next.set(token, refreshedEntry);
-          return [Option.some(refreshedEntry), next];
-        }),
-
-      updatePreviewCache: (token, frameId, jpegBytes) =>
-        Ref.update(tokensRef, (tokens) => {
-          const entry = tokens.get(token);
-          if (!entry || entry.kind !== "capturePreview") {
-            return tokens;
-          }
-          const next = new Map(tokens);
-          next.set(token, {
-            ...entry,
-            cachedFrameId: frameId,
-            cachedJPEGBytes: jpegBytes,
-          });
-          return next;
-        }),
+      return token;
     });
-  },
-);
+
+  return MediaRegistry.of({
+    registerMediaFile: (filePath) =>
+      normalizeMediaPath(filePath).pipe(
+        Effect.flatMap((normalizedPath) => {
+          const now = Date.now();
+          return insertToken({
+            kind: "file",
+            filePath: normalizedPath,
+            createdAt: now,
+            lastAccessedAt: now,
+          });
+        }),
+      ),
+
+    registerCapturePreview: (loadPreviewFrame) => {
+      const now = Date.now();
+      return insertToken({
+        kind: "capturePreview",
+        createdAt: now,
+        lastAccessedAt: now,
+        loadPreviewFrame,
+        cachedFrameId: null,
+        cachedJPEGBytes: null,
+      });
+    },
+
+    resolveToken: (token) =>
+      Ref.modify(tokensRef, (tokens) => {
+        const now = Date.now();
+        const next = pruneTokenMap(tokens, now);
+        const entry = next.get(token);
+        if (!entry || isTokenExpired(entry, now)) {
+          next.delete(token);
+          return [Option.none<TokenEntry>(), next];
+        }
+        const refreshedEntry = { ...entry, lastAccessedAt: now } as TokenEntry;
+        next.set(token, refreshedEntry);
+        return [Option.some(refreshedEntry), next];
+      }),
+
+    updatePreviewCache: (token, frameId, jpegBytes) =>
+      Ref.update(tokensRef, (tokens) => {
+        const entry = tokens.get(token);
+        if (!entry || entry.kind !== "capturePreview") {
+          return tokens;
+        }
+        const next = new Map(tokens);
+        next.set(token, {
+          ...entry,
+          cachedFrameId: frameId,
+          cachedJPEGBytes: jpegBytes,
+        });
+        return next;
+      }),
+  });
+});
 
 export const layerMediaRegistry = Layer.effect(MediaRegistry, makeMediaRegistryService);

--- a/apps/desktop-electrobun/src/bun/media/service.ts
+++ b/apps/desktop-electrobun/src/bun/media/service.ts
@@ -1,7 +1,7 @@
+import { createServer } from "node:http";
 import path from "node:path";
-import { randomUUID } from "node:crypto";
-import * as BunHttpServer from "@effect/platform-bun/BunHttpServer";
-import { Context, Effect, FileSystem, Layer } from "effect";
+import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
+import { Context, Crypto, Effect, FileSystem, Layer } from "effect";
 import { HttpRouter, HttpServer } from "effect/unstable/http";
 import type { CapturePreviewFrameResult } from "@guerillaglass/engine-contract/domains/capture";
 import { AppConfig } from "../app/AppConfig";
@@ -44,27 +44,27 @@ export const layerMediaSourceServiceCore = Layer.effect(
   Effect.gen(function* () {
     const registry = yield* MediaRegistry;
     const server = yield* HttpServer.HttpServer;
+    const crypto = yield* Crypto.Crypto;
     const fs = yield* FileSystem.FileSystem;
     const tempDirectory = yield* DesktopTempDirectory;
     const origin = yield* originFromAddress(server.address);
 
     const snapshotMediaFile = (filePath: string) =>
-      Effect.tryPromise({
-        try: () => {
-          const extension = path.extname(filePath).toLowerCase();
-          const destinationPath = path.join(
-            tempDirectory.path,
-            `media-${randomUUID()}${extension}`,
-          );
-          return copySafeFileSnapshot(filePath, destinationPath);
-        },
-        catch: (cause) =>
-          new MediaServerError({
-            code: "MEDIA_FILE_MISSING",
-            description: "Unable to create safe media snapshot.",
-            cause,
-          }),
-      });
+      Effect.gen(function* () {
+        const extension = path.extname(filePath).toLowerCase();
+        const id = yield* crypto.randomUUIDv4;
+        const destinationPath = path.join(tempDirectory.path, `media-${id}${extension}`);
+        return yield* Effect.tryPromise(() => copySafeFileSnapshot(filePath, destinationPath));
+      }).pipe(
+        Effect.mapError(
+          (cause) =>
+            new MediaServerError({
+              code: "MEDIA_FILE_MISSING",
+              description: "Unable to create safe media snapshot.",
+              cause,
+            }),
+        ),
+      );
 
     return MediaSourceService.of({
       resolveMediaSourceURL: (filePath) =>
@@ -86,8 +86,8 @@ export const layerMediaSourceServiceCore = Layer.effect(
   }),
 );
 
-const layerMediaHttpServer = BunHttpServer.layer({
-  hostname: "127.0.0.1",
+const layerMediaHttpServer = NodeHttpServer.layer(createServer, {
+  host: "127.0.0.1",
   port: 0,
   gracefulShutdownTimeout: "2 seconds",
 });
@@ -99,8 +99,11 @@ const layerServedMediaRoutes = HttpRouter.serve(layerMediaHttpRoutes, {
 
 /** Builds the scoped media source layer and owns media HTTP server shutdown. */
 export function makeLayerMediaSourceService() {
+  const mediaInfrastructureLayer = layerMediaRegistry.pipe(
+    Layer.provideMerge(layerMediaHttpServer),
+  );
   return Layer.mergeAll(layerMediaSourceServiceCore, layerServedMediaRoutes).pipe(
-    Layer.provideMerge(Layer.mergeAll(layerMediaRegistry, layerMediaHttpServer)),
+    Layer.provideMerge(mediaInfrastructureLayer),
   ) as Layer.Layer<MediaSourceService, never, AppConfig | DesktopTempDirectory>;
 }
 

--- a/apps/desktop-electrobun/src/bun/security/DesktopCapabilities.ts
+++ b/apps/desktop-electrobun/src/bun/security/DesktopCapabilities.ts
@@ -1,5 +1,4 @@
-import { randomBytes } from "node:crypto";
-import { Context, Effect, Layer, Redacted } from "effect";
+import { Context, Crypto, Effect, Encoding, Layer, Redacted } from "effect";
 import {
   desktopCapabilityTokenSchema,
   type DesktopCapabilityToken,
@@ -63,18 +62,15 @@ const defaultIdleTtlMsByScope: Record<DesktopCapabilityScope, number> = {
   "capture:resolve-preview-url": 15 * 1000,
 };
 
-function makeOpaqueToken(): DesktopCapabilityToken {
-  return desktopCapabilityTokenSchema.make(randomBytes(32).toString("base64url"));
-}
-
 function tokenError(description: string): CapabilityTokenError {
   return new CapabilityTokenError({ code: "CAPABILITY_TOKEN_INVALID", description });
 }
 
 /** Local opaque capability-token registry for privileged host bridge operations. */
-export function makeCapabilityGrantService(
+export const makeCapabilityGrantService = Effect.fn("CapabilityGrantService.make")(function* (
   options: { maxEntries?: number } = {},
-): CapabilityGrantServiceShape {
+) {
+  const crypto = yield* Crypto.Crypto;
   const maxEntries = Math.max(1, options.maxEntries ?? 1024);
   const records = new Map<string, CapabilityRecord>();
 
@@ -94,32 +90,35 @@ export function makeCapabilityGrantService(
   }
 
   return {
-    mint: (params) =>
-      Effect.try({
-        try: () => {
-          const subject = params.subject.trim();
-          if (subject.length === 0) {
-            throw tokenError("Capability subject is required.");
-          }
-          prune();
-          const token = makeOpaqueToken();
-          const now = Date.now();
-          const ttlMs = Math.max(1, params.ttlMs ?? defaultTtlMsByScope[params.scope]);
-          const idleTtlMs = Math.max(1, params.idleTtlMs ?? defaultIdleTtlMsByScope[params.scope]);
-          records.set(token, {
-            token: Redacted.make(token, { label: "desktop-capability-token" }),
-            scope: params.scope,
-            subject,
-            expiresAt: now + ttlMs,
-            idleExpiresAt: now + idleTtlMs,
-            idleTtlMs,
-            singleUse: params.singleUse ?? false,
-          });
-          return token;
-        },
-        catch: (error) => error as CapabilityTokenError,
+    mint: (params: MintCapabilityParams) =>
+      Effect.gen(function* () {
+        const subject = params.subject.trim();
+        if (subject.length === 0) {
+          return yield* tokenError("Capability subject is required.");
+        }
+        prune();
+        const token = desktopCapabilityTokenSchema.make(
+          Encoding.encodeBase64Url(
+            yield* crypto
+              .randomBytes(32)
+              .pipe(Effect.mapError(() => tokenError("Unable to mint capability token."))),
+          ),
+        );
+        const now = Date.now();
+        const ttlMs = Math.max(1, params.ttlMs ?? defaultTtlMsByScope[params.scope]);
+        const idleTtlMs = Math.max(1, params.idleTtlMs ?? defaultIdleTtlMsByScope[params.scope]);
+        records.set(token, {
+          token: Redacted.make(token, { label: "desktop-capability-token" }),
+          scope: params.scope,
+          subject,
+          expiresAt: now + ttlMs,
+          idleExpiresAt: now + idleTtlMs,
+          idleTtlMs,
+          singleUse: params.singleUse ?? false,
+        });
+        return token;
       }),
-    consume: ({ token, scope, subject }) =>
+    consume: ({ token, scope, subject }: ConsumeCapabilityParams) =>
       Effect.try({
         try: () => {
           prune();
@@ -147,11 +146,11 @@ export function makeCapabilityGrantService(
         },
         catch: (error) => error as CapabilityTokenError,
       }),
-    revoke: (token) => Effect.sync(() => void records.delete(token.trim())),
-  };
-}
+    revoke: (token: DesktopCapabilityToken) => Effect.sync(() => void records.delete(token.trim())),
+  } satisfies CapabilityGrantServiceShape;
+});
 
-export const layerCapabilityGrantService = Layer.succeed(
+export const layerCapabilityGrantService = Layer.effect(
   CapabilityGrantService,
   makeCapabilityGrantService(),
 );

--- a/apps/desktop-electrobun/tests/engine-client.test.ts
+++ b/apps/desktop-electrobun/tests/engine-client.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "vitest";
 import { layerEngineClientBun } from "@guerillaglass/engine-client/service";
 
 describe("engine client package surface", () => {
-  test("exposes Bun-backed native HTTP client layer", () => {
+  test("exposes the Node-platform native HTTP client layer under Bun", () => {
     expect(layerEngineClientBun).toBeDefined();
   });
 });

--- a/apps/desktop-electrobun/tests/macos-engine-lifecycle.test.ts
+++ b/apps/desktop-electrobun/tests/macos-engine-lifecycle.test.ts
@@ -1,6 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
-import * as BunServices from "@effect/platform-bun/BunServices";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Stream } from "effect";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import { describe, expect, test } from "vitest";
@@ -42,7 +42,7 @@ async function runCommand(command: string, args: readonly string[], timeoutMs = 
           Effect.succeed({ exitCode: -1, stderr: "command timed out", stdout: "" }),
         ),
       ),
-    ).pipe(Effect.provide(BunServices.layer)),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
 }
 

--- a/apps/desktop-electrobun/tests/media-server-node-integration.test.ts
+++ b/apps/desktop-electrobun/tests/media-server-node-integration.test.ts
@@ -1,0 +1,65 @@
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "vitest";
+import { Effect, Layer } from "effect";
+import { AppConfig, type DesktopAppConfig } from "../src/bun/app/AppConfig";
+import { MediaSourceService, makeLayerMediaSourceService } from "../src/bun/media/service";
+import { DesktopTempDirectory } from "../src/bun/security/DesktopTempDirectory";
+
+const testAppConfig: DesktopAppConfig = {
+  captureBenchmarkEnabled: false,
+  studioDiagnosticsEnabled: false,
+  mediaServerDebugLoggingEnabled: false,
+  devServerPort: 5173,
+  nodeEnv: "test",
+  electrobunBuild: null,
+  allowCustomEnginePath: false,
+  enginePath: null,
+  engineExpectedSha256: null,
+  engineExpectedTeamId: null,
+  engineSigningRequirement: null,
+  macosCodeSignatureHelperPath: null,
+  windowsAuthenticodeHelperPath: null,
+  windowsExpectedPublisherSha256Thumbprint: null,
+  windowsExpectedPublisherSubject: null,
+  windowsAllowOfflineRevocation: false,
+  engineRequireCurrentUserOwner: false,
+  engineRejectWorldWritable: true,
+  tempDirectory: null,
+  reviewConvexUrl: null,
+};
+
+describe("Node media server integration", () => {
+  test("starts, serves, and stops the real server composition", async () => {
+    const testDirectory = mkdtempSync(path.join(os.tmpdir(), "gg-node-media-server-"));
+    const sourcePath = path.join(testDirectory, "source.mov");
+    writeFileSync(sourcePath, "node-media-server-fixture");
+    const layer = makeLayerMediaSourceService().pipe(
+      Layer.provideMerge(Layer.succeed(DesktopTempDirectory, { path: testDirectory })),
+      Layer.provide(Layer.succeed(AppConfig, testAppConfig)),
+    );
+
+    try {
+      const mediaURL = await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const service = yield* MediaSourceService;
+            const url = yield* service.resolveMediaSourceURL(sourcePath);
+            const response = yield* Effect.promise(() =>
+              fetch(url, { headers: { connection: "close" } }),
+            );
+            expect(response.status).toBe(200);
+            const body = yield* Effect.promise(() => response.text());
+            expect(body).toBe("node-media-server-fixture");
+            return url;
+          }).pipe(Effect.provide(layer)),
+        ),
+      );
+
+      await expect(fetch(mediaURL)).rejects.toThrow();
+    } finally {
+      rmSync(testDirectory, { recursive: true, force: true });
+    }
+  }, 10_000);
+});

--- a/apps/desktop-electrobun/tests/media-server.test.ts
+++ b/apps/desktop-electrobun/tests/media-server.test.ts
@@ -1,7 +1,7 @@
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm, writeFile } from "node:fs/promises";
-import * as BunFileSystem from "@effect/platform-bun/BunFileSystem";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "vitest";
 import { Cause, Effect, Layer, Option } from "effect";
 import { HttpPlatform, HttpRouter } from "effect/unstable/http";
@@ -28,8 +28,8 @@ function mediaAppLayer(registry: MediaRegistry["Service"]) {
   return Layer.mergeAll(
     layerMediaHttpRoutes,
     Layer.succeed(MediaRegistry, registry),
-    HttpPlatform.layer.pipe(Layer.provide(BunFileSystem.layer)),
-    BunFileSystem.layer,
+    HttpPlatform.layer.pipe(Layer.provide(NodeServices.layer)),
+    NodeServices.layer,
   );
 }
 
@@ -61,7 +61,7 @@ function firstFailure(cause: Cause.Cause<unknown>): unknown {
 function effectTest(name: string, effect: () => Effect.Effect<void, unknown, unknown>): void {
   it(name, async () => {
     await Effect.runPromise(
-      effect().pipe(Effect.provide(BunFileSystem.layer)) as Effect.Effect<void, unknown, never>,
+      effect().pipe(Effect.provide(NodeServices.layer)) as Effect.Effect<void, unknown, never>,
     );
   });
 }

--- a/apps/desktop-electrobun/tests/media-source-service.test.ts
+++ b/apps/desktop-electrobun/tests/media-source-service.test.ts
@@ -6,14 +6,42 @@ import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Layer, Option } from "effect";
 import { HttpServer } from "effect/unstable/http";
 import { MediaRegistry, layerMediaRegistry } from "../src/bun/media/MediaRegistry";
-import { MediaSourceService, layerMediaSourceServiceCore } from "../src/bun/media/service";
+import {
+  MediaSourceService,
+  layerMediaSourceServiceCore,
+  makeLayerMediaSourceService,
+} from "../src/bun/media/service";
 import { MediaServerError } from "@shared/errors/desktopErrors";
+import { AppConfig, type DesktopAppConfig } from "../src/bun/app/AppConfig";
 import { DesktopTempDirectory } from "../src/bun/security/DesktopTempDirectory";
 
 function firstFailure(cause: Cause.Cause<unknown>): unknown {
   const error = Cause.findErrorOption(cause);
   return Option.isSome(error) ? error.value : Cause.squash(cause);
 }
+
+const testAppConfig: DesktopAppConfig = {
+  captureBenchmarkEnabled: false,
+  studioDiagnosticsEnabled: false,
+  mediaServerDebugLoggingEnabled: false,
+  devServerPort: 5173,
+  nodeEnv: "test",
+  electrobunBuild: null,
+  allowCustomEnginePath: false,
+  enginePath: null,
+  engineExpectedSha256: null,
+  engineExpectedTeamId: null,
+  engineSigningRequirement: null,
+  macosCodeSignatureHelperPath: null,
+  windowsAuthenticodeHelperPath: null,
+  windowsExpectedPublisherSha256Thumbprint: null,
+  windowsExpectedPublisherSubject: null,
+  windowsAllowOfflineRevocation: false,
+  engineRequireCurrentUserOwner: false,
+  engineRejectWorldWritable: true,
+  tempDirectory: null,
+  reviewConvexUrl: null,
+};
 
 describe("media source service", () => {
   it.effect("fails layer acquisition with a typed error for non-TCP HTTP servers", () =>
@@ -42,6 +70,36 @@ describe("media source service", () => {
       }
     }),
   );
+
+  it("starts, serves, and stops the real Node media server composition", async () => {
+    const testDirectory = mkdtempSync(path.join(os.tmpdir(), "gg-node-media-server-"));
+    const sourcePath = path.join(testDirectory, "source.mov");
+    writeFileSync(sourcePath, "node-media-server-fixture");
+    const layer = makeLayerMediaSourceService().pipe(
+      Layer.provideMerge(Layer.succeed(DesktopTempDirectory, { path: testDirectory })),
+      Layer.provide(Layer.succeed(AppConfig, testAppConfig)),
+    );
+
+    try {
+      const mediaURL = await Effect.runPromise(
+        Effect.scoped(
+          Effect.gen(function* () {
+            const service = yield* MediaSourceService;
+            const url = yield* service.resolveMediaSourceURL(sourcePath);
+            const response = yield* Effect.promise(() => fetch(url));
+            expect(response.status).toBe(200);
+            const body = yield* Effect.promise(() => response.text());
+            expect(body).toBe("node-media-server-fixture");
+            return url;
+          }).pipe(Effect.provide(layer)),
+        ),
+      );
+
+      await expect(fetch(mediaURL)).rejects.toThrow();
+    } finally {
+      rmSync(testDirectory, { recursive: true, force: true });
+    }
+  });
 
   it("mints loopback media and preview URLs from the scoped HTTP server address", async () => {
     const layer = layerMediaSourceServiceCore.pipe(

--- a/apps/desktop-electrobun/tests/media-source-service.test.ts
+++ b/apps/desktop-electrobun/tests/media-source-service.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import * as BunFileSystem from "@effect/platform-bun/BunFileSystem";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Layer, Option } from "effect";
 import { HttpServer } from "effect/unstable/http";
@@ -21,7 +21,7 @@ describe("media source service", () => {
       const layer = layerMediaSourceServiceCore.pipe(
         Layer.provideMerge(layerMediaRegistry),
         Layer.provideMerge(Layer.succeed(DesktopTempDirectory, { path: os.tmpdir() })),
-        Layer.provide(BunFileSystem.layer),
+        Layer.provide(NodeServices.layer),
         Layer.provide(
           Layer.succeed(HttpServer.HttpServer, {
             address: { _tag: "UnixAddress", path: "/tmp/guerillaglass-media.sock" },
@@ -47,7 +47,7 @@ describe("media source service", () => {
     const layer = layerMediaSourceServiceCore.pipe(
       Layer.provideMerge(layerMediaRegistry),
       Layer.provideMerge(Layer.succeed(DesktopTempDirectory, { path: os.tmpdir() })),
-      Layer.provide(BunFileSystem.layer),
+      Layer.provide(NodeServices.layer),
       Layer.provide(
         Layer.succeed(HttpServer.HttpServer, {
           address: { _tag: "TcpAddress", hostname: "127.0.0.1", port: 43_210 },

--- a/apps/desktop-electrobun/tests/media-source-service.test.ts
+++ b/apps/desktop-electrobun/tests/media-source-service.test.ts
@@ -99,7 +99,7 @@ describe("media source service", () => {
     } finally {
       rmSync(testDirectory, { recursive: true, force: true });
     }
-  });
+  }, 10_000);
 
   it("mints loopback media and preview URLs from the scoped HTTP server address", async () => {
     const layer = layerMediaSourceServiceCore.pipe(

--- a/apps/desktop-electrobun/tests/media-source-service.test.ts
+++ b/apps/desktop-electrobun/tests/media-source-service.test.ts
@@ -6,42 +6,14 @@ import { describe, expect, it } from "@effect/vitest";
 import { Cause, Effect, Layer, Option } from "effect";
 import { HttpServer } from "effect/unstable/http";
 import { MediaRegistry, layerMediaRegistry } from "../src/bun/media/MediaRegistry";
-import {
-  MediaSourceService,
-  layerMediaSourceServiceCore,
-  makeLayerMediaSourceService,
-} from "../src/bun/media/service";
+import { MediaSourceService, layerMediaSourceServiceCore } from "../src/bun/media/service";
 import { MediaServerError } from "@shared/errors/desktopErrors";
-import { AppConfig, type DesktopAppConfig } from "../src/bun/app/AppConfig";
 import { DesktopTempDirectory } from "../src/bun/security/DesktopTempDirectory";
 
 function firstFailure(cause: Cause.Cause<unknown>): unknown {
   const error = Cause.findErrorOption(cause);
   return Option.isSome(error) ? error.value : Cause.squash(cause);
 }
-
-const testAppConfig: DesktopAppConfig = {
-  captureBenchmarkEnabled: false,
-  studioDiagnosticsEnabled: false,
-  mediaServerDebugLoggingEnabled: false,
-  devServerPort: 5173,
-  nodeEnv: "test",
-  electrobunBuild: null,
-  allowCustomEnginePath: false,
-  enginePath: null,
-  engineExpectedSha256: null,
-  engineExpectedTeamId: null,
-  engineSigningRequirement: null,
-  macosCodeSignatureHelperPath: null,
-  windowsAuthenticodeHelperPath: null,
-  windowsExpectedPublisherSha256Thumbprint: null,
-  windowsExpectedPublisherSubject: null,
-  windowsAllowOfflineRevocation: false,
-  engineRequireCurrentUserOwner: false,
-  engineRejectWorldWritable: true,
-  tempDirectory: null,
-  reviewConvexUrl: null,
-};
 
 describe("media source service", () => {
   it.effect("fails layer acquisition with a typed error for non-TCP HTTP servers", () =>
@@ -70,36 +42,6 @@ describe("media source service", () => {
       }
     }),
   );
-
-  it("starts, serves, and stops the real Node media server composition", async () => {
-    const testDirectory = mkdtempSync(path.join(os.tmpdir(), "gg-node-media-server-"));
-    const sourcePath = path.join(testDirectory, "source.mov");
-    writeFileSync(sourcePath, "node-media-server-fixture");
-    const layer = makeLayerMediaSourceService().pipe(
-      Layer.provideMerge(Layer.succeed(DesktopTempDirectory, { path: testDirectory })),
-      Layer.provide(Layer.succeed(AppConfig, testAppConfig)),
-    );
-
-    try {
-      const mediaURL = await Effect.runPromise(
-        Effect.scoped(
-          Effect.gen(function* () {
-            const service = yield* MediaSourceService;
-            const url = yield* service.resolveMediaSourceURL(sourcePath);
-            const response = yield* Effect.promise(() => fetch(url));
-            expect(response.status).toBe(200);
-            const body = yield* Effect.promise(() => response.text());
-            expect(body).toBe("node-media-server-fixture");
-            return url;
-          }).pipe(Effect.provide(layer)),
-        ),
-      );
-
-      await expect(fetch(mediaURL)).rejects.toThrow();
-    } finally {
-      rmSync(testDirectory, { recursive: true, force: true });
-    }
-  }, 10_000);
 
   it("mints loopback media and preview URLs from the scoped HTTP server address", async () => {
     const layer = layerMediaSourceServiceCore.pipe(

--- a/apps/desktop-electrobun/tests/native-http-launch-security.test.ts
+++ b/apps/desktop-electrobun/tests/native-http-launch-security.test.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
-import * as BunServices from "@effect/platform-bun/BunServices";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Exit, Redacted, Scope, Stream } from "effect";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import type { ChildProcessHandle } from "effect/unstable/process/ChildProcessSpawner";
@@ -65,7 +65,7 @@ async function runCommand(command: string, args: readonly string[], cwd = repoRo
         ]);
         return { exitCode, stderr, stdout };
       }),
-    ).pipe(Effect.provide(BunServices.layer)),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
 }
 
@@ -91,7 +91,7 @@ async function launchEngine(fixture: EngineFixture): Promise<LaunchedEngine> {
           HOME: tempRoot,
           USERPROFILE: tempRoot,
         },
-      }).pipe(Scope.provide(scope), Effect.provide(BunServices.layer)),
+      }).pipe(Scope.provide(scope), Effect.provide(NodeServices.layer)),
     );
     expect(launched.address.host).toBe("127.0.0.1");
     expect(launched.address.port).toBeGreaterThan(0);

--- a/apps/desktop-electrobun/tests/parity-e2e.test.ts
+++ b/apps/desktop-electrobun/tests/parity-e2e.test.ts
@@ -1,4 +1,4 @@
-import * as BunServices from "@effect/platform-bun/BunServices";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -61,7 +61,7 @@ async function buildNativeEngine(manifestPath: string): Promise<void> {
         );
         return yield* handle.exitCode.pipe(Effect.map((exitCode) => ({ exitCode, stderr })));
       }),
-    ).pipe(Effect.provide(BunServices.layer)),
+    ).pipe(Effect.provide(NodeServices.layer)),
   );
   if (result.exitCode !== 0) {
     throw new Error(`Failed to build ${manifestPath}\n${result.stderr}`);

--- a/apps/desktop-electrobun/tests/security-capabilities.test.ts
+++ b/apps/desktop-electrobun/tests/security-capabilities.test.ts
@@ -1,3 +1,4 @@
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect, Exit } from "effect";
 import { describe, expect, test } from "vitest";
 import { desktopCapabilityTokenSchema } from "@shared/bridge/desktopBridgeContract";
@@ -10,7 +11,9 @@ import { makeCapabilityGrantService } from "../src/bun/security/DesktopCapabilit
 
 describe("desktop capability grants", () => {
   test("accepts a valid token for the matching scope and subject", async () => {
-    const service = makeCapabilityGrantService();
+    const service = await Effect.runPromise(
+      makeCapabilityGrantService().pipe(Effect.provide(NodeServices.layer)),
+    );
     const token = await Effect.runPromise(
       service.mint({ scope: "media:resolve-source", subject: "media:/tmp/recording.mov" }),
     );
@@ -27,7 +30,9 @@ describe("desktop capability grants", () => {
   });
 
   test("rejects missing or unknown tokens", async () => {
-    const service = makeCapabilityGrantService();
+    const service = await Effect.runPromise(
+      makeCapabilityGrantService().pipe(Effect.provide(NodeServices.layer)),
+    );
 
     await expect(
       Effect.runPromise(
@@ -41,7 +46,9 @@ describe("desktop capability grants", () => {
   });
 
   test("rejects wrong scopes and wrong subjects", async () => {
-    const service = makeCapabilityGrantService();
+    const service = await Effect.runPromise(
+      makeCapabilityGrantService().pipe(Effect.provide(NodeServices.layer)),
+    );
     const token = await Effect.runPromise(
       service.mint({ scope: "media:resolve-source", subject: "media:/tmp/recording.mov" }),
     );
@@ -68,7 +75,9 @@ describe("desktop capability grants", () => {
   });
 
   test("enforces single-use tokens", async () => {
-    const service = makeCapabilityGrantService();
+    const service = await Effect.runPromise(
+      makeCapabilityGrantService().pipe(Effect.provide(NodeServices.layer)),
+    );
     const token = await Effect.runPromise(
       service.mint({ scope: "review:mutate", subject: "review:abc", singleUse: true }),
     );
@@ -95,7 +104,9 @@ describe("desktop capability grants", () => {
   });
 
   test("rejects expired tokens", async () => {
-    const service = makeCapabilityGrantService();
+    const service = await Effect.runPromise(
+      makeCapabilityGrantService().pipe(Effect.provide(NodeServices.layer)),
+    );
     const token = await Effect.runPromise(
       service.mint({ scope: "capture:resolve-preview-url", subject: "capture:abc", ttlMs: 1 }),
     );

--- a/bun.lock
+++ b/bun.lock
@@ -30,7 +30,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@base-ui/react": "^1.6.0",
-        "@effect/platform-bun": "4.0.0-beta.101",
+        "@effect/platform-node": "4.0.0-beta.101",
         "@fontsource-variable/inter": "^5.3.0",
         "@guerillaglass/engine-client": "workspace:*",
         "@guerillaglass/engine-contract": "workspace:*",
@@ -137,7 +137,7 @@
       "name": "@guerillaglass/engine-client",
       "version": "1.0.0",
       "dependencies": {
-        "@effect/platform-bun": "4.0.0-beta.101",
+        "@effect/platform-node": "4.0.0-beta.101",
         "@guerillaglass/engine-contract": "workspace:*",
         "effect": "4.0.0-beta.101",
       },
@@ -334,7 +334,7 @@
 
     "@effect/language-service": ["@effect/language-service@0.87.1", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-kcljlJmEgqg5mFAM6UShJYJjMqJb3TbHHxrK8Qoubvwugc0aVWpRkbdgQvK5b17puOt3BKXXKOmcV+oQt0oQqQ=="],
 
-    "@effect/platform-bun": ["@effect/platform-bun@4.0.0-beta.101", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.101" }, "peerDependencies": { "effect": "^4.0.0-beta.101" } }, "sha512-7cSiwufNCjO1d296KMjHjqFA1oDRVZMZEyYMzdqPvAdIhNQj16U+xZfMdeJuUb6/WouEWWultkhcCK5ysdxIcQ=="],
+    "@effect/platform-node": ["@effect/platform-node@4.0.0-beta.101", "", { "dependencies": { "@effect/platform-node-shared": "^4.0.0-beta.101", "mime": "^4.1.0", "undici": "^8.7.0" }, "peerDependencies": { "effect": "^4.0.0-beta.101", "ioredis": "^5.7.0" } }, "sha512-pClk7dmMtHgM6Byu7CzGfrPvZ1/4BwmrRlCg2Op+iJozMkwVUxq8v4beK8b9SvxsliJjHZFznjvkVLX7LQjBqw=="],
 
     "@effect/platform-node-shared": ["@effect/platform-node-shared@4.0.0-beta.101", "", { "dependencies": { "@types/ws": "^8.18.1", "ws": "^8.21.0" }, "peerDependencies": { "effect": "^4.0.0-beta.101" } }, "sha512-g4L7XiyJSNJLJVhlslyg2zBCQsoKQf1y1gd+Yfd+3wD9ymC+m7ymbd/5FGqnT1aXV6E2AwRr4D/R1eyRUikvWQ=="],
 
@@ -453,6 +453,8 @@
     "@inlang/recommend-sherlock": ["@inlang/recommend-sherlock@0.2.1", "", { "dependencies": { "comment-json": "^4.2.3" } }, "sha512-ckv8HvHy/iTqaVAEKrr+gnl+p3XFNwe5D2+6w6wJk2ORV2XkcRkKOJ/XsTUJbPSiyi4PI+p+T3bqbmNx/rDUlg=="],
 
     "@inlang/sdk": ["@inlang/sdk@2.10.2", "", { "dependencies": { "@lix-js/sdk": "0.4.10", "@sinclair/typebox": "^0.31.17", "kysely": "^0.28.12", "sqlite-wasm-kysely": "0.3.0", "uuid": "^14.0.0" } }, "sha512-O1ki72SNK6LPagaGrvlioBb1mWKvump7cO7P85hfGZjdFTmDdn3icI0A6MvaBsB3P9KQHAjzyubnN1OslGufTw=="],
+
+    "@ioredis/commands": ["@ioredis/commands@1.10.0", "", {}, "sha512-UmeW7z4LfctwoQ5wkhVzgq8tXkreED2xZGpX+Bg+zA+WJFZCT6c062AfCK/Dfk81xZnnwdhJCUMkitihRaoC2Q=="],
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
@@ -1118,6 +1120,8 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
+    "cluster-key-slot": ["cluster-key-slot@1.1.1", "", {}, "sha512-rwHwUfXL40Chm1r08yrhU3qpUvdVlgkKNeyeGPOxnW8/SyVDvgRaed/Uz54AqWNaTCAThlj6QAs3TZcKI0xDEw=="],
+
     "cmdk": ["cmdk@1.1.1", "", { "dependencies": { "@radix-ui/react-compose-refs": "^1.1.1", "@radix-ui/react-dialog": "^1.1.6", "@radix-ui/react-id": "^1.1.0", "@radix-ui/react-primitive": "^2.0.2" }, "peerDependencies": { "react": "^18 || ^19 || ^19.0.0-rc", "react-dom": "^18 || ^19 || ^19.0.0-rc" } }, "sha512-Vsv7kFaXm+ptHDMZ7izaRsP70GgrW9NBNGswt9OZaVBLlE0SNpDq8eu/VGXyF9r7M0azK3Wy7OlYXsuyYLFzHg=="],
 
     "code-block-writer": ["code-block-writer@13.0.3", "", {}, "sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg=="],
@@ -1193,6 +1197,8 @@
     "defu": ["defu@6.1.4", "", {}, "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="],
 
     "degenerator": ["degenerator@5.0.1", "", { "dependencies": { "ast-types": "^0.13.4", "escodegen": "^2.1.0", "esprima": "^4.0.1" } }, "sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ=="],
+
+    "denque": ["denque@2.1.0", "", {}, "sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw=="],
 
     "depd": ["depd@2.0.0", "", {}, "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="],
 
@@ -1424,6 +1430,8 @@
 
     "ini": ["ini@7.0.0", "", {}, "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w=="],
 
+    "ioredis": ["ioredis@5.11.1", "", { "dependencies": { "@ioredis/commands": "1.10.0", "cluster-key-slot": "1.1.1", "debug": "4.4.3", "denque": "2.1.0", "redis-errors": "1.2.0", "redis-parser": "3.0.0", "standard-as-callback": "2.1.0" } }, "sha512-ehuGcf94bQXhfagULNXrJdfnWO38v070jxSx/qE87Kjzmu2fU7ro5EFAb+OPituLqgfyuQaym5DlrNydW2sJ9A=="],
+
     "ip-address": ["ip-address@10.0.1", "", {}, "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA=="],
 
     "ipaddr.js": ["ipaddr.js@1.9.1", "", {}, "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="],
@@ -1569,6 +1577,8 @@
     "meshoptimizer": ["meshoptimizer@1.1.1", "", {}, "sha512-oRFNWJRDA/WTrVj7NWvqa5HqE1t9MYDj2VaWirQCzCCrAd2GHrqR/sQezCxiWATPNlKTcRaPRHPJwIRoPBAp5g=="],
 
     "micromatch": ["micromatch@4.0.8", "", { "dependencies": { "braces": "^3.0.3", "picomatch": "^2.3.1" } }, "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA=="],
+
+    "mime": ["mime@4.1.0", "", { "bin": { "mime": "bin/cli.js" } }, "sha512-X5ju04+cAzsojXKes0B/S4tcYtFAJ6tTMuSPBEn9CPGlrWr8Fiw7qYeLT0XyH80HSoAoqWCaz+MWKh22P7G1cw=="],
 
     "mime-db": ["mime-db@1.54.0", "", {}, "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ=="],
 
@@ -1762,6 +1772,10 @@
 
     "recast": ["recast@0.23.11", "", { "dependencies": { "ast-types": "^0.16.1", "esprima": "~4.0.0", "source-map": "~0.6.1", "tiny-invariant": "^1.3.3", "tslib": "^2.0.1" } }, "sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA=="],
 
+    "redis-errors": ["redis-errors@1.2.0", "", {}, "sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w=="],
+
+    "redis-parser": ["redis-parser@3.0.0", "", { "dependencies": { "redis-errors": "^1.0.0" } }, "sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A=="],
+
     "remeda": ["remeda@2.33.6", "", {}, "sha512-tazDGH7s75kUPGBKLvhgBEHMgW+TdDFhjUAMdQj57IoWz6HsGa5D2RX5yDUz6IIqiRRvZiaEHzCzWdTeixc/Kg=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
@@ -1850,6 +1864,8 @@
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 
+    "standard-as-callback": ["standard-as-callback@2.1.0", "", {}, "sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A=="],
+
     "statuses": ["statuses@2.0.2", "", {}, "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw=="],
 
     "std-env": ["std-env@4.0.0", "", {}, "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ=="],
@@ -1936,7 +1952,7 @@
 
     "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
 
-    "undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
+    "undici": ["undici@8.9.0", "", {}, "sha512-aWZpUj7XoGonMClx4gdDRfgBjqeA+F473aDmROQQbM9n6PRfK/u1q/a0X4wMTgcHfT8H6fpbt98PFuDUwFg2YA=="],
 
     "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
@@ -2392,6 +2408,8 @@
 
     "istanbul-lib-report/supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
+    "jsdom/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
+
     "launch-editor/shell-quote": ["shell-quote@1.8.3", "", {}, "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw=="],
 
     "log-symbols/is-unicode-supported": ["is-unicode-supported@1.3.0", "", {}, "sha512-43r2mRvz+8JRIKnWJ+3j8JtjRKZ6GmjzfaE/qiBJnikNnYv/6bagRJ1kUhNk8R5EX/GkobD+r+sfxCPJsiKBLQ=="],
@@ -2429,6 +2447,8 @@
     "shadcn/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
 
     "shadcn/commander": ["commander@14.0.3", "", {}, "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw=="],
+
+    "shadcn/undici": ["undici@7.27.2", "", {}, "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA=="],
 
     "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -67,7 +67,7 @@ Production Bun transport:
 - Spawns sidecars with Effect process primitives.
 - Requires `GG_ENGINE_TRANSPORT=http` and per-process bearer auth.
 - Reads the `guerillaglass.engine.http.ready` readiness envelope from stdout.
-- Connects over authenticated loopback HTTP through `@effect/platform-bun/BunHttpClient`.
+- Connects over authenticated loopback HTTP through `@effect/platform-node/NodeHttpClient` running under Electrobun's Bun executable.
 - Does not perform generic RPC retries.
 - Does not automatically restart native engines.
 - Logs/spans process spawn, readiness, HTTP requests, protocol errors, stderr, and shutdown.
@@ -85,7 +85,7 @@ Implementation:
 - `MediaRegistry` owns token state in an Effect `Ref<Map<...>>`.
 - `MediaHttpRoutes` owns `/media/*` and `/health` Effect HTTP routes.
 - `MediaSourceService` mints URLs from `HttpServer.address`.
-- `makeLayerMediaSourceService` composes registry + routes + `BunHttpServer.layer`.
+- `makeLayerMediaSourceService` composes registry + routes + `NodeHttpServer.layer`; the Node platform adapter is used for stability while Bun remains the package manager and Electrobun host executable.
 - File responses use `HttpServerResponse.file`/`HttpPlatform` and support `GET`, `HEAD`, byte ranges, and defensive headers.
 - Capture preview URLs serve live JPEG frames with cached fallback frames.
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -2,17 +2,18 @@
 
 This document summarizes the desktop observability stack implemented for Guerillaglass. It is based on the installed/vendored Effect v4 APIs:
 
-- `effect@4.0.0-beta.78`
-- `@effect/platform-bun@4.0.0-beta.78`
+- `effect@4.0.0-beta.101`
+- `@effect/platform-node@4.0.0-beta.101`
 - `effect/unstable/devtools`
 - `effect/unstable/observability` researched but not currently wired
 
 ## Overview
 
-The desktop Bun host is now Effect/Bun-native at the process edge:
+The desktop host runs in Electrobun's Bun executable while using Effect's Node platform adapter for a more stable process edge:
 
-- `BunRuntime.runMain(...)` owns the root process Effect.
-- `BunServices.layer` provides Bun-backed platform services such as `FileSystem`, `Path`, `Terminal`, and `Stdio`.
+- `NodeRuntime.runMain(...)` owns the root process Effect.
+- `NodeServices.layer` provides platform services such as `FileSystem`, `Path`, `Crypto`, `Terminal`, and `Stdio`.
+- Bun remains the only JavaScript package manager; using the Node platform adapter does not introduce npm, pnpm, or Yarn.
 - `Logger` routes console and file logs.
 - `Metric` records application and runtime metrics.
 - `Effect.withSpan(...)` emits tracing spans for DevTools-compatible consumers.
@@ -22,9 +23,9 @@ The desktop Bun host is now Effect/Bun-native at the process edge:
 
 | Region | Sector | Area | Implemented signals | Files / APIs |
 |---|---|---|---|---|
-| Runtime Foundation | Bun / Effect entrypoint | Process root | App runs through `BunRuntime.runMain`; platform services via `BunServices.layer`; runtime/fiber metrics enabled | `apps/desktop-electrobun/src/bun/app/index.ts`; `BunRuntime.runMain`; `BunServices.layer`; `Metric.enableRuntimeMetrics` |
+| Runtime Foundation | Electrobun Bun executable / Effect Node adapter | Process root | App runs through `NodeRuntime.runMain`; platform services via `NodeServices.layer`; runtime/fiber metrics enabled | `apps/desktop-electrobun/src/bun/app/index.ts`; `NodeRuntime.runMain`; `NodeServices.layer`; `Metric.enableRuntimeMetrics` |
 | Logging | Logger routing | Console logs | Dev uses `Logger.consolePretty()`; production uses `Logger.consoleJson` | `apps/desktop-electrobun/src/bun/app/AppLogging.ts`; `Logger.consolePretty`; `Logger.consoleJson` |
-| Logging | Logger routing | File logs | JSONL file logging via `Logger.formatJson.pipe(Logger.toFile(...))` | `AppLogging.ts`; `Logger.toFile`; `BunServices.layer` |
+| Logging | Logger routing | File logs | JSONL file logging via `Logger.formatJson.pipe(Logger.toFile(...))` | `AppLogging.ts`; `Logger.toFile`; `NodeServices.layer` |
 | Logging | Log destinations | System log | Primary log path: `~/Library/Logs/Guerillaglass/desktop-electrobun.log` | `apps/desktop-electrobun/src/bun/app/AppLogPaths.ts` |
 | Logging | Log destinations | Repo dev log | Dev mirror: `.tmp/desktop-electrobun.log`; disabled in production; override via `GG_DESKTOP_REPO_LOG_PATH`; disable via `GG_DESKTOP_REPO_LOG=0` | `AppLogPaths.ts` |
 | Logging | Log level policy | Minimum log level | Dev / diagnostics: `Debug`; production: `Warn` | `AppLogging.ts`; `References.MinimumLogLevel` |

--- a/packages/engine-client/package.json
+++ b/packages/engine-client/package.json
@@ -28,7 +28,7 @@
     "typecheck": "tsc --noEmit -p tsconfig.json"
   },
   "dependencies": {
-    "@effect/platform-bun": "4.0.0-beta.101",
+    "@effect/platform-node": "4.0.0-beta.101",
     "@guerillaglass/engine-contract": "workspace:*",
     "effect": "4.0.0-beta.101"
   },

--- a/packages/engine-client/src/process/launchBun.ts
+++ b/packages/engine-client/src/process/launchBun.ts
@@ -1,5 +1,15 @@
-import { stat } from "node:fs/promises";
-import { Deferred, Duration, Effect, Metric, Option, Redacted, Scope, Stream } from "effect";
+import {
+  Crypto,
+  Deferred,
+  Duration,
+  Effect,
+  FileSystem,
+  Metric,
+  Option,
+  Redacted,
+  Scope,
+  Stream,
+} from "effect";
 import * as ChildProcess from "effect/unstable/process/ChildProcess";
 import type {
   ChildProcessHandle,
@@ -71,13 +81,13 @@ export type EngineHttpProcess = {
  *
  * @returns A random bearer token wrapped in `Redacted`.
  */
-export function makeEngineBearerToken(): Redacted.Redacted<string> {
-  const bytes = new Uint8Array(32);
-  crypto.getRandomValues(bytes);
+export const makeEngineBearerToken = Effect.gen(function* () {
+  const crypto = yield* Crypto.Crypto;
+  const bytes = yield* crypto.randomBytes(32);
   return Redacted.make(Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(""), {
     label: "engine-http-bearer-token",
   });
-}
+});
 
 /**
  * Resolves the native engine path from explicit options or `GG_ENGINE_PATH`.
@@ -85,7 +95,9 @@ export function makeEngineBearerToken(): Redacted.Redacted<string> {
  * @param enginePath - Explicit engine path supplied by the caller.
  * @returns An effect that succeeds with an executable path.
  */
-export function resolveEnginePath(enginePath?: string): Effect.Effect<string, EngineProcessError> {
+export function resolveEnginePath(
+  enginePath?: string,
+): Effect.Effect<string, EngineProcessError, FileSystem.FileSystem> {
   return Effect.gen(function* () {
     const configuredPath =
       enginePath === undefined
@@ -108,18 +120,18 @@ export function resolveEnginePath(enginePath?: string): Effect.Effect<string, En
       });
     }
     const path = resolved.trim();
-    const fileStat = yield* Effect.tryPromise({
-      try: () => stat(path),
-      catch: (cause) =>
-        cause instanceof EngineProcessError
-          ? cause
-          : new EngineProcessError({
-              code: "ENGINE_PATH_UNAVAILABLE",
-              message: "Unable to resolve engine executable path.",
-              cause,
-            }),
-    });
-    if (!fileStat.isFile()) {
+    const fs = yield* FileSystem.FileSystem;
+    const fileStat = yield* fs.stat(path).pipe(
+      Effect.mapError(
+        (cause) =>
+          new EngineProcessError({
+            code: "ENGINE_PATH_UNAVAILABLE",
+            message: "Unable to resolve engine executable path.",
+            cause,
+          }),
+      ),
+    );
+    if (fileStat.type !== "File") {
       return yield* new EngineProcessError({
         code: "ENGINE_PATH_UNAVAILABLE",
         message: `Engine executable path does not point to a regular file: ${path}`,
@@ -311,7 +323,11 @@ function cleanupStaleEngineProcesses(
  */
 export function makeEngineHttpProcess(
   options: EngineHttpProcessOptions = {},
-): Effect.Effect<EngineHttpProcess, EngineProcessError, ChildProcessSpawner | Scope.Scope> {
+): Effect.Effect<
+  EngineHttpProcess,
+  EngineProcessError,
+  ChildProcessSpawner | Crypto.Crypto | FileSystem.FileSystem | Scope.Scope
+> {
   return Effect.gen(function* () {
     const processConfig = yield* EngineProcessConfig.pipe(
       Effect.mapError(
@@ -336,7 +352,16 @@ export function makeEngineHttpProcess(
       }
     }
     const [command, args] = resolveEngineCommand(enginePath);
-    const bearerToken = makeEngineBearerToken();
+    const bearerToken = yield* makeEngineBearerToken.pipe(
+      Effect.mapError(
+        (cause) =>
+          new EngineProcessError({
+            code: "ENGINE_SPAWN_FAILED",
+            message: "Unable to generate an engine bearer token.",
+            cause,
+          }),
+      ),
+    );
     yield* Effect.logInfo("spawning engine process").pipe(
       Effect.annotateLogs({
         command: commandText(command, args),

--- a/packages/engine-client/src/process/trust.ts
+++ b/packages/engine-client/src/process/trust.ts
@@ -1,6 +1,4 @@
-import { createHash } from "node:crypto";
-import { lstat, readFile, stat } from "node:fs/promises";
-import { Effect } from "effect";
+import { Crypto, Effect, FileSystem, Option } from "effect";
 import { EngineProcessError } from "../errors";
 
 /**
@@ -72,60 +70,63 @@ function timingSafeEqualHex(left: string, right: string): boolean {
 export function validateEngineExecutableTrust(
   enginePath: string,
   policy: EngineExecutableTrustPolicy | undefined,
-): Effect.Effect<void, EngineProcessError> {
+): Effect.Effect<void, EngineProcessError, Crypto.Crypto | FileSystem.FileSystem> {
   if (policy?.enabled !== true) {
     return Effect.void;
   }
 
-  return Effect.tryPromise({
-    try: async () => {
-      const linkStat = await lstat(enginePath);
-      if ((policy.rejectSymlinkExecutable ?? true) && linkStat.isSymbolicLink()) {
-        throw new EngineProcessError({
+  return Effect.gen(function* () {
+    const fs = yield* FileSystem.FileSystem;
+    const crypto = yield* Crypto.Crypto;
+    const linkTarget = yield* fs.readLink(enginePath).pipe(Effect.option);
+    if ((policy.rejectSymlinkExecutable ?? true) && Option.isSome(linkTarget)) {
+      return yield* new EngineProcessError({
+        code: "ENGINE_TRUST_REJECTED",
+        message: "Engine executable must not be a symbolic link in trusted mode.",
+      });
+    }
+
+    const fileStat = yield* fs.stat(enginePath);
+    if (fileStat.type !== "File") {
+      return yield* new EngineProcessError({
+        code: "ENGINE_TRUST_REJECTED",
+        message: "Engine executable path must point to a regular file.",
+      });
+    }
+
+    if ((policy.rejectWorldWritable ?? true) && (fileStat.mode & 0o022) !== 0) {
+      return yield* new EngineProcessError({
+        code: "ENGINE_TRUST_REJECTED",
+        message: "Engine executable must not be group- or world-writable in trusted mode.",
+      });
+    }
+
+    if (policy.requireCurrentUserOwner === true && typeof process.getuid === "function") {
+      const currentUid = process.getuid();
+      if (!Option.contains(fileStat.uid, currentUid)) {
+        return yield* new EngineProcessError({
           code: "ENGINE_TRUST_REJECTED",
-          message: "Engine executable must not be a symbolic link in trusted mode.",
+          message: "Engine executable must be owned by the current user in trusted mode.",
         });
       }
+    }
 
-      const fileStat = await stat(enginePath);
-      if (!fileStat.isFile()) {
-        throw new EngineProcessError({
+    const expectedSha256 = policy.expectedSha256?.trim();
+    if (expectedSha256) {
+      const bytes = yield* fs.readFile(enginePath);
+      const digest = yield* crypto.digest("SHA-256", bytes);
+      const actualSha256 = Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join(
+        "",
+      );
+      if (!timingSafeEqualHex(actualSha256, expectedSha256)) {
+        return yield* new EngineProcessError({
           code: "ENGINE_TRUST_REJECTED",
-          message: "Engine executable path must point to a regular file.",
+          message: "Engine executable SHA-256 digest does not match the trusted allowlist.",
         });
       }
-
-      if ((policy.rejectWorldWritable ?? true) && (fileStat.mode & 0o022) !== 0) {
-        throw new EngineProcessError({
-          code: "ENGINE_TRUST_REJECTED",
-          message: "Engine executable must not be group- or world-writable in trusted mode.",
-        });
-      }
-
-      if (policy.requireCurrentUserOwner === true && typeof process.getuid === "function") {
-        const currentUid = process.getuid();
-        if (fileStat.uid !== currentUid) {
-          throw new EngineProcessError({
-            code: "ENGINE_TRUST_REJECTED",
-            message: "Engine executable must be owned by the current user in trusted mode.",
-          });
-        }
-      }
-
-      const expectedSha256 = policy.expectedSha256?.trim();
-      if (expectedSha256) {
-        const actualSha256 = createHash("sha256")
-          .update(await readFile(enginePath))
-          .digest("hex");
-        if (!timingSafeEqualHex(actualSha256, expectedSha256)) {
-          throw new EngineProcessError({
-            code: "ENGINE_TRUST_REJECTED",
-            message: "Engine executable SHA-256 digest does not match the trusted allowlist.",
-          });
-        }
-      }
-    },
-    catch: (cause) =>
+    }
+  }).pipe(
+    Effect.mapError((cause) =>
       cause instanceof EngineProcessError
         ? cause
         : new EngineProcessError({
@@ -133,5 +134,6 @@ export function validateEngineExecutableTrust(
             message: "Unable to verify engine executable trust.",
             cause,
           }),
-  });
+    ),
+  );
 }

--- a/packages/engine-client/src/service.ts
+++ b/packages/engine-client/src/service.ts
@@ -37,8 +37,8 @@ import {
   recordingStartPayloadSchema,
 } from "@guerillaglass/engine-contract/httpApi";
 import type { AgentJobId, ExportJobId } from "@guerillaglass/engine-contract/schema-primitives";
-import * as BunHttpClient from "@effect/platform-bun/BunHttpClient";
-import * as BunServices from "@effect/platform-bun/BunServices";
+import * as NodeHttpClient from "@effect/platform-node/NodeHttpClient";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Context, Effect, Layer } from "effect";
 import { HttpClient, HttpClientRequest } from "effect/unstable/http";
 import { HttpApiClient } from "effect/unstable/httpapi";
@@ -366,7 +366,7 @@ export const layerEngineClientFromConfig = Layer.effect(
 );
 
 /**
- * Bun-backed layer that launches a scoped native engine process and provides `EngineClient`.
+ * Node-platform-backed layer that launches a scoped native engine process under Bun and provides `EngineClient`.
  *
  * @param options - Native engine process launch options.
  * @returns A scoped layer providing {@link EngineClient}.
@@ -377,15 +377,13 @@ export function layerEngineClientBun(
   return Layer.effect(
     EngineClient,
     Effect.gen(function* () {
-      const engineProcess = yield* makeEngineHttpProcess(options).pipe(
-        Effect.provide(BunServices.layer),
-      );
+      const engineProcess = yield* makeEngineHttpProcess(options);
       const rawClient = yield* makeRawEngineHttpApiClient({
         baseUrl: engineProcess.baseUrl,
         bearerToken: engineProcess.bearerToken,
         requestTimeoutMs: 30_000,
-      }).pipe(Effect.provide(BunHttpClient.layer));
+      });
       return EngineClient.of(makeEngineClientService(rawClient));
     }),
-  );
+  ).pipe(Layer.provide(NodeServices.layer), Layer.provide(NodeHttpClient.layerNodeHttp));
 }

--- a/packages/engine-client/tests/process-config.test.ts
+++ b/packages/engine-client/tests/process-config.test.ts
@@ -1,7 +1,7 @@
 import { chmod, mkdir, mkdtemp, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import * as BunServices from "@effect/platform-bun/BunServices";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { describe, expect, test } from "vitest";
 import { ConfigProvider, Effect, Exit, Option, Redacted } from "effect";
 import { EngineProcessConfig } from "../src/process/config";
@@ -10,6 +10,12 @@ import {
   makeEngineHttpProcess,
   resolveEnginePath,
 } from "../src/process/launchBun";
+
+function resolveEnginePathExit(enginePath: string) {
+  return Effect.runPromise(
+    Effect.exit(resolveEnginePath(enginePath)).pipe(Effect.provide(NodeServices.layer)),
+  );
+}
 
 describe("engine process config", () => {
   test("loads launch inputs from the active ConfigProvider", async () => {
@@ -36,7 +42,10 @@ describe("engine process config", () => {
     const provider = ConfigProvider.fromEnv({ env: { GG_ENGINE_PATH: enginePath } });
 
     const resolved = await Effect.runPromise(
-      resolveEnginePath().pipe(Effect.provideService(ConfigProvider.ConfigProvider, provider)),
+      resolveEnginePath().pipe(
+        Effect.provideService(ConfigProvider.ConfigProvider, provider),
+        Effect.provide(NodeServices.layer),
+      ),
     );
 
     expect(resolved).toBe(enginePath);
@@ -47,7 +56,9 @@ describe("engine process config", () => {
     const enginePath = join(dir, "engine");
     await writeFile(enginePath, "#!/bin/sh\n");
 
-    await expect(Effect.runPromise(resolveEnginePath(enginePath))).resolves.toBe(enginePath);
+    await expect(
+      Effect.runPromise(resolveEnginePath(enginePath).pipe(Effect.provide(NodeServices.layer))),
+    ).resolves.toBe(enginePath);
   });
 
   test("rejects blank, missing, and directory engine paths", async () => {
@@ -55,13 +66,13 @@ describe("engine process config", () => {
     const engineDirectory = join(dir, "engine-dir");
     await mkdir(engineDirectory);
 
-    const blank = await Effect.runPromise(Effect.exit(resolveEnginePath("   ")));
+    const blank = await resolveEnginePathExit("   ");
     expect(Exit.isFailure(blank)).toBe(true);
 
-    const missing = await Effect.runPromise(Effect.exit(resolveEnginePath(join(dir, "missing"))));
+    const missing = await resolveEnginePathExit(join(dir, "missing"));
     expect(Exit.isFailure(missing)).toBe(true);
 
-    const directory = await Effect.runPromise(Effect.exit(resolveEnginePath(engineDirectory)));
+    const directory = await resolveEnginePathExit(engineDirectory);
     expect(Exit.isFailure(directory)).toBe(true);
   });
 
@@ -76,7 +87,7 @@ describe("engine process config", () => {
 
     const launched = await Effect.runPromise(
       Effect.scoped(makeEngineHttpProcess({ enginePath, readinessTimeoutMs: 1000 })).pipe(
-        Effect.provide(BunServices.layer),
+        Effect.provide(NodeServices.layer),
       ),
     );
 
@@ -94,7 +105,7 @@ describe("engine process config", () => {
     await expect(
       Effect.runPromise(
         Effect.scoped(makeEngineHttpProcess({ enginePath, readinessTimeoutMs: 1000 })).pipe(
-          Effect.provide(BunServices.layer),
+          Effect.provide(NodeServices.layer),
         ),
       ),
     ).rejects.toMatchObject({
@@ -102,8 +113,10 @@ describe("engine process config", () => {
     });
   });
 
-  test("creates redacted bearer tokens", () => {
-    const token = makeEngineBearerToken();
+  test("creates redacted bearer tokens", async () => {
+    const token = await Effect.runPromise(
+      makeEngineBearerToken.pipe(Effect.provide(NodeServices.layer)),
+    );
     expect(Redacted.value(token)).toMatch(/^[a-f0-9]{64}$/);
     expect(String(token)).not.toContain(Redacted.value(token));
   });

--- a/packages/engine-client/tests/trust.test.ts
+++ b/packages/engine-client/tests/trust.test.ts
@@ -3,6 +3,7 @@ import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { Effect } from "effect";
 import { validateEngineExecutableTrust } from "../src/process/trust";
 
@@ -15,7 +16,9 @@ async function executableFixture(label: string, contents = "#!/bin/sh\necho ok\n
 }
 
 async function expectTrustRejected(effect: ReturnType<typeof validateEngineExecutableTrust>) {
-  await expect(Effect.runPromise(effect)).rejects.toMatchObject({
+  await expect(
+    Effect.runPromise(effect.pipe(Effect.provide(NodeServices.layer))),
+  ).rejects.toMatchObject({
     code: "ENGINE_TRUST_REJECTED",
   });
 }
@@ -23,12 +26,18 @@ async function expectTrustRejected(effect: ReturnType<typeof validateEngineExecu
 describe("engine executable trust validation", () => {
   test("is skipped when trust policy is disabled", async () => {
     await expect(
-      Effect.runPromise(validateEngineExecutableTrust("/path/that/does/not/exist", undefined)),
+      Effect.runPromise(
+        validateEngineExecutableTrust("/path/that/does/not/exist", undefined).pipe(
+          Effect.provide(NodeServices.layer),
+        ),
+      ),
     ).resolves.toBeUndefined();
 
     await expect(
       Effect.runPromise(
-        validateEngineExecutableTrust("/path/that/does/not/exist", { enabled: false }),
+        validateEngineExecutableTrust("/path/that/does/not/exist", { enabled: false }).pipe(
+          Effect.provide(NodeServices.layer),
+        ),
       ),
     ).resolves.toBeUndefined();
   });
@@ -43,7 +52,7 @@ describe("engine executable trust validation", () => {
           enabled: true,
           expectedSha256: `sha256:${digest.toUpperCase()}`,
           requireCurrentUserOwner: true,
-        }),
+        }).pipe(Effect.provide(NodeServices.layer)),
       ),
     ).resolves.toBeUndefined();
   });


### PR DESCRIPTION
## Summary
- remove `@effect/platform-bun` and standardize the Electrobun host/client/tests on Effect v4 `@effect/platform-node` beta.101 while Bun remains the only package manager and host executable
- use scoped `NodeRuntime`, `NodeServices`, `NodeHttpServer`, and `NodeHttpClient.layerNodeHttp`; keep the client transport layer alive for the complete engine-client lifetime
- migrate engine executable stat/trust/digest and bearer/capability/media token generation to Effect `FileSystem` and `Crypto` services
- use Effect `Encoding.encodeBase64Url` for capability tokens
- add repository invariants rejecting platform-bun dependencies and npm/pnpm/Yarn lockfiles
- update architecture, observability, agent, and review policy

## Runtime finding fixed
`NodeHttpClient.layerUndici` passed unit/parity tests but failed after Electrobun packaging with `ReferenceError: exports_Undici is not defined`. The real packaged-app gate caught it. `NodeHttpClient.layerNodeHttp` works in the packaged Bun executable and retains scoped client resources correctly.

## Follow-up
A dedicated immediately-following migration will remove remaining direct `node:path`/`node:fs` imports from desktop application services and scripts. The descriptor-level `O_NOFOLLOW` snapshot path needs an explicit security-preserving platform adapter because Effect v4 `FileSystem.open` does not expose a no-follow flag; this PR does not weaken that protection.

## Validation
- `bun run gate`
- `bun run desktop:test:runtime` — packaged app/engine/renderer/window/cleanup passed; zero fatal patterns
- `bun run desktop:test` — 209 unit/integration + 27 browser tests passed
- `bun run desktop:test:e2e`
- engine-client: 24 tests passed
- `bun run repo:check`
- `bun run repo:test` — 9 tests passed
- `bun run docs:check`
