### PR TITLE
refactor(effect): enforce platform service boundaries

### DIFF
--- a/Scripts/repository_invariants.test.ts
+++ b/Scripts/repository_invariants.test.ts
@@ -92,12 +92,22 @@ describe("repository invariants", () => {
 
   test("rejects direct Node path, filesystem, and crypto imports in application services", () => {
     writeFixture(
-      "apps/desktop-electrobun/src/bun/media/unsafe.ts",
+      "apps/desktop-electrobun/src/bun/media/unsafe-static.ts",
       'import path from "node:path";\nexport const value = path.resolve(".");\n',
+    );
+    writeFixture(
+      "apps/desktop-electrobun/src/bun/media/unsafe-require.ts",
+      'const fs = require("node:fs");\nexport const value = fs.existsSync(".");\n',
+    );
+    writeFixture(
+      "apps/desktop-electrobun/src/bun/media/unsafe-dynamic.ts",
+      "export const value = import(`node:crypto`);\n",
     );
     const result = runCheck();
     expect(result.exitCode).toBe(1);
-    expect(result.stderr).toContain("must use Effect Path, FileSystem, or Crypto services");
+    expect(result.stderr).toContain("unsafe-static.ts must use Effect Path");
+    expect(result.stderr).toContain("unsafe-require.ts must use Effect Path");
+    expect(result.stderr).toContain("unsafe-dynamic.ts must use Effect Path");
   });
 
   test("reports vendor drift when the Effect submodule is initialized", () => {

--- a/Scripts/repository_invariants.test.ts
+++ b/Scripts/repository_invariants.test.ts
@@ -96,6 +96,10 @@ describe("repository invariants", () => {
       'import path from "node:path";\nexport const value = path.resolve(".");\n',
     );
     writeFixture(
+      "apps/desktop-electrobun/src/bun/media/unsafe-side-effect.ts",
+      'import "node:fs";\nexport const value = true;\n',
+    );
+    writeFixture(
       "apps/desktop-electrobun/src/bun/media/unsafe-require.ts",
       'const fs = require("node:fs");\nexport const value = fs.existsSync(".");\n',
     );
@@ -106,6 +110,7 @@ describe("repository invariants", () => {
     const result = runCheck();
     expect(result.exitCode).toBe(1);
     expect(result.stderr).toContain("unsafe-static.ts must use Effect Path");
+    expect(result.stderr).toContain("unsafe-side-effect.ts must use Effect Path");
     expect(result.stderr).toContain("unsafe-require.ts must use Effect Path");
     expect(result.stderr).toContain("unsafe-dynamic.ts must use Effect Path");
   });

--- a/Scripts/repository_invariants.test.ts
+++ b/Scripts/repository_invariants.test.ts
@@ -90,6 +90,16 @@ describe("repository invariants", () => {
     expect(result.stderr).toContain("unsupported package-manager lockfile present");
   });
 
+  test("rejects direct Node path, filesystem, and crypto imports in application services", () => {
+    writeFixture(
+      "apps/desktop-electrobun/src/bun/media/unsafe.ts",
+      'import path from "node:path";\nexport const value = path.resolve(".");\n',
+    );
+    const result = runCheck();
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain("must use Effect Path, FileSystem, or Crypto services");
+  });
+
   test("reports vendor drift when the Effect submodule is initialized", () => {
     writeFixture(
       "vendor/effect/packages/effect/package.json",

--- a/Scripts/repository_invariants.ts
+++ b/Scripts/repository_invariants.ts
@@ -160,7 +160,8 @@ function checkEffectPlatformServiceBoundaries(): void {
   const allowedNodePlatformAdapters = new Set([
     "apps/desktop-electrobun/src/bun/security/fileAccess.ts",
   ]);
-  const forbiddenImport = /(?:from\s+|import\s*\()(["'])node:(?:path|fs(?:\/promises)?|crypto)\1/g;
+  const forbiddenImport =
+    /(?:from\s+|import\s*(?:\(\s*)?|require\s*\(\s*)(["'`])node:(?:path|fs(?:\/promises)?|crypto)\1/g;
 
   const applicationSourceRoots = ["apps", "packages"].flatMap((workspaceRoot) => {
     const absoluteWorkspaceRoot = join(root, workspaceRoot);

--- a/Scripts/repository_invariants.ts
+++ b/Scripts/repository_invariants.ts
@@ -32,6 +32,7 @@ for (const guide of requiredGuides) {
 
 checkEffectVersionAlignment();
 checkJavaScriptRuntimePolicy();
+checkEffectPlatformServiceBoundaries();
 checkGeneratedRustDependencyOwnership();
 checkLocalizationParity();
 checkMarkdownLinks();
@@ -52,6 +53,7 @@ console.log(
     : "- Effect runtime packages are aligned (vendor comparison skipped; submodule not initialized)",
 );
 console.log("- Bun is the only package manager and Effect uses the Node platform adapter");
+console.log("- application services use Effect Path, FileSystem, and Crypto boundaries");
 console.log("- generated Rust dependency table matches the generator template");
 console.log("- localization keys and placeholders match across supported locales");
 console.log("- inline local Markdown file links resolve");
@@ -150,6 +152,40 @@ function checkJavaScriptRuntimePolicy(): void {
           `${manifestPath} must use @effect/platform-node instead of @effect/platform-bun`,
         );
       }
+    }
+  }
+}
+
+function checkEffectPlatformServiceBoundaries(): void {
+  const allowedNodePlatformAdapters = new Set([
+    "apps/desktop-electrobun/src/bun/security/fileAccess.ts",
+  ]);
+  const forbiddenImport = /(?:from\s+|import\s*\()(["'])node:(?:path|fs(?:\/promises)?|crypto)\1/g;
+
+  const applicationSourceRoots = ["apps", "packages"].flatMap((workspaceRoot) => {
+    const absoluteWorkspaceRoot = join(root, workspaceRoot);
+    if (!existsSync(absoluteWorkspaceRoot)) {
+      return [];
+    }
+    return readdirSync(absoluteWorkspaceRoot, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => join(absoluteWorkspaceRoot, entry.name, "src"))
+      .filter(existsSync);
+  });
+
+  for (const absoluteSourceRoot of applicationSourceRoots) {
+    for (const sourcePath of collectSourceFiles(absoluteSourceRoot)) {
+      const repositoryPath = relative(root, sourcePath);
+      if (allowedNodePlatformAdapters.has(repositoryPath)) {
+        continue;
+      }
+      const source = readFileSync(sourcePath, "utf8");
+      if (forbiddenImport.test(source)) {
+        failures.push(
+          `${repositoryPath} must use Effect Path, FileSystem, or Crypto services instead of direct Node platform imports`,
+        );
+      }
+      forbiddenImport.lastIndex = 0;
     }
   }
 }
@@ -279,6 +315,22 @@ function placeholders(message: string): Array<string> {
     .map((match) => match[1] ?? "")
     .filter(Boolean)
     .sort();
+}
+
+function collectSourceFiles(directory: string): Array<string> {
+  const files: Array<string> = [];
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    if (entry.name === "node_modules" || entry.name === "paraglide") {
+      continue;
+    }
+    const entryPath = join(directory, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...collectSourceFiles(entryPath));
+    } else if (entry.isFile() && /\.[cm]?[jt]sx?$/.test(entry.name)) {
+      files.push(entryPath);
+    }
+  }
+  return files;
 }
 
 function collectMarkdownFiles(directory: string): Array<string> {

--- a/apps/desktop-electrobun/src/bun/app/index.ts
+++ b/apps/desktop-electrobun/src/bun/app/index.ts
@@ -50,7 +50,7 @@ const guardedEngineClientLayer = Layer.unwrap(
       },
     });
   }),
-);
+).pipe(Layer.provide(NodeServices.layer));
 
 const guardedEngineDomainServicesLayer = layerEngineDomainServices.pipe(
   Layer.provideMerge(guardedEngineClientLayer),

--- a/apps/desktop-electrobun/src/bun/media/MediaHttpRoutes.ts
+++ b/apps/desktop-electrobun/src/bun/media/MediaHttpRoutes.ts
@@ -1,5 +1,5 @@
 import { Buffer } from "node:buffer";
-import { Effect, FileSystem, Layer, Option } from "effect";
+import { Effect, FileSystem, Layer, Option, Path } from "effect";
 import {
   HttpPlatform,
   HttpRouter,
@@ -83,11 +83,11 @@ function textResponse(
   });
 }
 
-function mediaHeaders(filePath: string): Record<string, string> {
+function mediaHeaders(path: Path.Path, filePath: string): Record<string, string> {
   return {
     ...mediaSecurityHeaders(),
     "accept-ranges": "bytes",
-    "content-type": mediaTypeForPath(filePath),
+    "content-type": mediaTypeForPath(path, filePath),
   };
 }
 
@@ -187,10 +187,11 @@ function handleFileRequest(
 ): Effect.Effect<
   HttpServerResponse.HttpServerResponse,
   MediaServerError,
-  FileSystem.FileSystem | HttpPlatform.HttpPlatform
+  FileSystem.FileSystem | HttpPlatform.HttpPlatform | Path.Path
 > {
   return Effect.gen(function* () {
     const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     const info = yield* fs.stat(entry.filePath).pipe(
       Effect.mapError(
         (cause) =>
@@ -207,7 +208,7 @@ function handleFileRequest(
     }
 
     const size = Number(info.size);
-    const commonHeaders = mediaHeaders(entry.filePath);
+    const commonHeaders = mediaHeaders(path, entry.filePath);
     const rangeHeader = request.headers.range;
 
     if (!rangeHeader) {

--- a/apps/desktop-electrobun/src/bun/media/MediaRegistry.ts
+++ b/apps/desktop-electrobun/src/bun/media/MediaRegistry.ts
@@ -1,5 +1,4 @@
-import path from "node:path";
-import { Context, Crypto, Effect, FileSystem, Layer, Option, Ref } from "effect";
+import { Context, Crypto, Effect, FileSystem, Layer, Option, Path, Ref } from "effect";
 import type { CapturePreviewFrameResult } from "@guerillaglass/engine-contract/domains/capture";
 import { messageFromUnknownError } from "@guerillaglass/engine-client/errors";
 import { MediaServerError } from "../../shared/errors/desktopErrors";
@@ -74,6 +73,7 @@ function pruneTokenMap(tokens: Map<string, TokenEntry>, now: number): Map<string
 }
 
 function normalizeMediaPath(
+  path: Path.Path,
   filePath: string,
 ): Effect.Effect<string, MediaServerError, FileSystem.FileSystem> {
   return Effect.gen(function* () {
@@ -93,7 +93,7 @@ function normalizeMediaPath(
     }
 
     const normalizedPath = path.resolve(trimmedPath);
-    if (!isSupportedMediaPath(normalizedPath)) {
+    if (!isSupportedMediaPath(path, normalizedPath)) {
       return yield* new MediaServerError({
         code: "MEDIA_TYPE_UNSUPPORTED",
         description: "Unsupported media file format.",
@@ -124,6 +124,7 @@ function normalizeMediaPath(
 
 export const makeMediaRegistryService = Effect.gen(function* () {
   const crypto = yield* Crypto.Crypto;
+  const path = yield* Path.Path;
   const tokensRef = yield* Ref.make(new Map<string, TokenEntry>());
 
   const insertToken = (entry: TokenEntry) =>
@@ -140,7 +141,7 @@ export const makeMediaRegistryService = Effect.gen(function* () {
 
   return MediaRegistry.of({
     registerMediaFile: (filePath) =>
-      normalizeMediaPath(filePath).pipe(
+      normalizeMediaPath(path, filePath).pipe(
         Effect.flatMap((normalizedPath) => {
           const now = Date.now();
           return insertToken({

--- a/apps/desktop-electrobun/src/bun/media/policy.ts
+++ b/apps/desktop-electrobun/src/bun/media/policy.ts
@@ -1,4 +1,4 @@
-import path from "node:path";
+import type { Path } from "effect";
 
 const supportedMediaExtensions = [".mov", ".mp4", ".m4v", ".webm"] as const;
 
@@ -13,16 +13,16 @@ const mediaMimeByExtension: Record<string, string> = {
 };
 
 /** Returns the normalized extension for a media path. */
-export function mediaExtension(filePath: string): string {
+export function mediaExtension(path: Pick<Path.Path, "extname">, filePath: string): string {
   return path.extname(filePath).toLowerCase();
 }
 
 /** Returns whether the path extension is supported media. */
-export function isSupportedMediaPath(filePath: string): boolean {
-  return mediaExtensions.has(mediaExtension(filePath));
+export function isSupportedMediaPath(path: Pick<Path.Path, "extname">, filePath: string): boolean {
+  return mediaExtensions.has(mediaExtension(path, filePath));
 }
 
 /** Returns the response MIME type for a supported media path. */
-export function mediaTypeForPath(filePath: string): string {
-  return mediaMimeByExtension[mediaExtension(filePath)] ?? "application/octet-stream";
+export function mediaTypeForPath(path: Pick<Path.Path, "extname">, filePath: string): string {
+  return mediaMimeByExtension[mediaExtension(path, filePath)] ?? "application/octet-stream";
 }

--- a/apps/desktop-electrobun/src/bun/media/service.ts
+++ b/apps/desktop-electrobun/src/bun/media/service.ts
@@ -1,7 +1,6 @@
 import { createServer } from "node:http";
-import path from "node:path";
 import * as NodeHttpServer from "@effect/platform-node/NodeHttpServer";
-import { Context, Crypto, Effect, FileSystem, Layer } from "effect";
+import { Context, Crypto, Effect, FileSystem, Layer, Path } from "effect";
 import { HttpRouter, HttpServer } from "effect/unstable/http";
 import type { CapturePreviewFrameResult } from "@guerillaglass/engine-contract/domains/capture";
 import { AppConfig } from "../app/AppConfig";
@@ -46,6 +45,7 @@ export const layerMediaSourceServiceCore = Layer.effect(
     const server = yield* HttpServer.HttpServer;
     const crypto = yield* Crypto.Crypto;
     const fs = yield* FileSystem.FileSystem;
+    const path = yield* Path.Path;
     const tempDirectory = yield* DesktopTempDirectory;
     const origin = yield* originFromAddress(server.address);
 

--- a/apps/desktop-electrobun/src/bun/security/EngineExecutablePolicy.ts
+++ b/apps/desktop-electrobun/src/bun/security/EngineExecutablePolicy.ts
@@ -1,5 +1,4 @@
-import path from "node:path";
-import { Effect } from "effect";
+import { Effect, Path } from "effect";
 import { EngineProcessError } from "@guerillaglass/engine-client/errors";
 import { AppConfig, type DesktopAppConfig } from "../app/AppConfig";
 
@@ -18,7 +17,10 @@ function configuredWindowsAuthenticodeTrust(config: DesktopAppConfig): boolean {
   );
 }
 
-function validateStaticConfig(config: DesktopAppConfig): Effect.Effect<void, EngineProcessError> {
+function validateStaticConfig(
+  path: Path.Path,
+  config: DesktopAppConfig,
+): Effect.Effect<void, EngineProcessError> {
   return Effect.try({
     try: () => {
       const overridePath = config.enginePath?.trim();
@@ -72,8 +74,12 @@ function validateStaticConfig(config: DesktopAppConfig): Effect.Effect<void, Eng
 }
 
 /** Validates development-only native engine executable overrides before the engine layer starts. */
-export const validateEngineExecutablePolicy: Effect.Effect<void, EngineProcessError, AppConfig> =
-  Effect.gen(function* () {
-    const config = yield* AppConfig;
-    yield* validateStaticConfig(config);
-  });
+export const validateEngineExecutablePolicy: Effect.Effect<
+  void,
+  EngineProcessError,
+  AppConfig | Path.Path
+> = Effect.gen(function* () {
+  const config = yield* AppConfig;
+  const path = yield* Path.Path;
+  yield* validateStaticConfig(path, config);
+});

--- a/apps/desktop-electrobun/src/bun/security/FileAccessGrants.ts
+++ b/apps/desktop-electrobun/src/bun/security/FileAccessGrants.ts
@@ -1,5 +1,4 @@
-import path from "node:path";
-import { Context, Effect, Layer, Ref } from "effect";
+import { Context, Effect, Layer, Path, Ref } from "effect";
 import type { HostPathPickerMode } from "../../shared/bridge/desktopBridgeContract";
 
 export type FileAccessGrantKind = "project-open" | "project-save" | "export-directory";
@@ -23,18 +22,13 @@ export class FileAccessGrants extends Context.Service<FileAccessGrants, FileAcce
 
 const grantTtlMs = 30 * 60 * 1000;
 
-function normalizeGrantPath(filePath: string): string {
+function normalizeGrantPath(path: Path.Path, filePath: string): string {
   return path.resolve(filePath.trim());
 }
 
-function isPathWithinRoot(targetPath: string, rootPath: string): boolean {
+function isPathWithinRoot(path: Path.Path, targetPath: string, rootPath: string): boolean {
   const relative = path.relative(rootPath, targetPath);
   return relative === "" || (!relative.startsWith("..") && !path.isAbsolute(relative));
-}
-
-function grantPathForKind(kind: FileAccessGrantKind, filePath: string): string {
-  const normalizedPath = normalizeGrantPath(filePath);
-  return kind === "export-directory" ? normalizedPath : normalizedPath;
 }
 
 function grantKindForPickerMode(mode: HostPathPickerMode): FileAccessGrantKind {
@@ -49,6 +43,7 @@ function grantKindForPickerMode(mode: HostPathPickerMode): FileAccessGrantKind {
 }
 
 function grantMatchesPath(
+  path: Path.Path,
   grant: FileAccessGrant,
   kind: FileAccessGrantKind,
   filePath: string,
@@ -57,7 +52,7 @@ function grantMatchesPath(
     return false;
   }
   if (kind === "export-directory") {
-    return isPathWithinRoot(filePath, grant.path);
+    return isPathWithinRoot(path, filePath, grant.path);
   }
   return filePath === grant.path;
 }
@@ -65,17 +60,18 @@ function grantMatchesPath(
 export const layerFileAccessGrants = Layer.effect(
   FileAccessGrants,
   Effect.gen(function* () {
+    const path = yield* Path.Path;
     const grantsRef = yield* Ref.make(new Map<string, FileAccessGrant>());
 
     const grantPath = (kind: FileAccessGrantKind, filePath: string) =>
-      Effect.sync(() => normalizeGrantPath(filePath)).pipe(
+      Effect.sync(() => normalizeGrantPath(path, filePath)).pipe(
         Effect.flatMap((normalizedPath) =>
           Ref.update(grantsRef, (grants) => {
             const now = Date.now();
             const next = new Map(
               Array.from(grants.entries()).filter(([, grant]) => grant.expiresAt > now),
             );
-            const grantRoot = grantPathForKind(kind, normalizedPath);
+            const grantRoot = normalizedPath;
             next.set(`${kind}:${grantRoot}`, {
               kind,
               path: grantRoot,
@@ -91,12 +87,12 @@ export const layerFileAccessGrants = Layer.effect(
       grantPickedPath: (mode, filePath) => grantPath(grantKindForPickerMode(mode), filePath),
       grantPath,
       isGrantedPath: (kind, filePath) =>
-        Effect.sync(() => normalizeGrantPath(filePath)).pipe(
+        Effect.sync(() => normalizeGrantPath(path, filePath)).pipe(
           Effect.flatMap((normalizedPath) =>
             Ref.get(grantsRef).pipe(
               Effect.map((grants) =>
                 Array.from(grants.values()).some((grant) =>
-                  grantMatchesPath(grant, kind, normalizedPath),
+                  grantMatchesPath(path, grant, kind, normalizedPath),
                 ),
               ),
             ),

--- a/apps/desktop-electrobun/src/bun/security/ProjectExportPathPolicy.ts
+++ b/apps/desktop-electrobun/src/bun/security/ProjectExportPathPolicy.ts
@@ -1,6 +1,4 @@
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import { Context, Effect, Layer } from "effect";
+import { Context, Effect, Layer, Path } from "effect";
 import { FileAccessPolicyError } from "../../shared/errors/desktopErrors";
 import type { FileAccessGrantsService } from "./FileAccessGrants";
 import { FileAccessGrants } from "./FileAccessGrants";
@@ -25,28 +23,55 @@ export class ProjectExportPathPolicy extends Context.Service<
   ProjectExportPathPolicyService
 >()("@guerillaglass/desktop/ProjectExportPathPolicy") {}
 
-function normalizeLocalPath(value: string): string {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    throw new FileAccessPolicyError({
-      code: "FILE_PATH_REQUIRED",
-      description: "A file path is required.",
+function normalizeLocalPath(
+  path: Path.Path,
+  value: string,
+): Effect.Effect<string, FileAccessPolicyError> {
+  return Effect.gen(function* () {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return yield* new FileAccessPolicyError({
+        code: "FILE_PATH_REQUIRED",
+        description: "A file path is required.",
+      });
+    }
+    if (!/^file:\/\//i.test(trimmed)) {
+      return path.resolve(trimmed);
+    }
+    const url = yield* Effect.try({
+      try: () => new URL(trimmed),
+      catch: (cause) =>
+        new FileAccessPolicyError({
+          code: "LOCAL_FILE_URL_UNSUPPORTED",
+          description: "Only local file URLs are supported.",
+          cause,
+        }),
     });
-  }
-  if (!/^file:\/\//i.test(trimmed)) {
-    return path.resolve(trimmed);
-  }
-  const url = new URL(trimmed);
-  if (url.protocol !== "file:" || (url.hostname && url.hostname.toLowerCase() !== "localhost")) {
-    throw new FileAccessPolicyError({
-      code: "LOCAL_FILE_URL_UNSUPPORTED",
-      description: "Only local file URLs are supported.",
-    });
-  }
-  return path.resolve(fileURLToPath(url));
+    if (url.protocol !== "file:" || (url.hostname && url.hostname.toLowerCase() !== "localhost")) {
+      return yield* new FileAccessPolicyError({
+        code: "LOCAL_FILE_URL_UNSUPPORTED",
+        description: "Only local file URLs are supported.",
+      });
+    }
+    const localPath = yield* path.fromFileUrl(url).pipe(
+      Effect.mapError(
+        (cause) =>
+          new FileAccessPolicyError({
+            code: "LOCAL_FILE_URL_UNSUPPORTED",
+            description: "Only local file URLs are supported.",
+            cause,
+          }),
+      ),
+    );
+    return path.resolve(localPath);
+  });
 }
 
-function requireExtension(filePath: string, expected: string | ReadonlySet<string>): string {
+function requireExtension(
+  path: Path.Path,
+  filePath: string,
+  expected: string | ReadonlySet<string>,
+): string {
   const extension = path.extname(filePath).toLowerCase();
   const allowed = typeof expected === "string" ? extension === expected : expected.has(extension);
   if (!allowed) {
@@ -82,19 +107,24 @@ export const layerProjectExportPathPolicy = Layer.effect(
   ProjectExportPathPolicy,
   Effect.gen(function* () {
     const grants = yield* FileAccessGrants;
+    const path = yield* Path.Path;
 
     const validateProjectPath = (kind: "project-open" | "project-save", projectPath: string) =>
-      Effect.sync(() =>
-        requireExtension(normalizeLocalPath(projectPath), projectPackageExtension),
-      ).pipe(Effect.flatMap((normalizedPath) => requireGranted(grants, kind, normalizedPath)));
+      normalizeLocalPath(path, projectPath).pipe(
+        Effect.map((normalizedPath) =>
+          requireExtension(path, normalizedPath, projectPackageExtension),
+        ),
+        Effect.flatMap((normalizedPath) => requireGranted(grants, kind, normalizedPath)),
+      );
 
     return ProjectExportPathPolicy.of({
       validateProjectOpenPath: (projectPath) => validateProjectPath("project-open", projectPath),
       validateProjectSavePath: (projectPath) => validateProjectPath("project-save", projectPath),
       validateExportOutputPath: (outputURL) =>
-        Effect.sync(() =>
-          requireExtension(normalizeLocalPath(outputURL), exportFileExtensions),
-        ).pipe(
+        normalizeLocalPath(path, outputURL).pipe(
+          Effect.map((normalizedPath) =>
+            requireExtension(path, normalizedPath, exportFileExtensions),
+          ),
           Effect.flatMap((normalizedPath) =>
             requireGranted(grants, "export-directory", normalizedPath),
           ),

--- a/apps/desktop-electrobun/src/bun/security/fileAccess.ts
+++ b/apps/desktop-electrobun/src/bun/security/fileAccess.ts
@@ -144,7 +144,7 @@ export function resolveAllowedMediaFilePath(
   }
 
   const resolvedPath = path.resolve(normalizeLocalFilePathInput(filePath));
-  if (!isSupportedMediaPath(resolvedPath)) {
+  if (!isSupportedMediaPath(path, resolvedPath)) {
     throw new FileAccessPolicyError({
       code: "MEDIA_FILE_TYPE_UNSUPPORTED",
       description: "Only video media files can be read through the desktop bridge.",

--- a/apps/desktop-electrobun/tests/security-path-policy.test.ts
+++ b/apps/desktop-electrobun/tests/security-path-policy.test.ts
@@ -1,6 +1,8 @@
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 import { mkdtempSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
+import * as NodeServices from "@effect/platform-node/NodeServices";
 import { ConfigProvider, Effect, Layer } from "effect";
 import { afterEach, describe, expect, test, vi } from "vitest";
 import { AppConfig, layerAppConfig } from "../src/bun/app/AppConfig";
@@ -14,6 +16,7 @@ import { buildMainViewNavigationRules } from "../src/bun/security/DesktopNavigat
 
 const pathPolicyLayer = layerProjectExportPathPolicy.pipe(
   Layer.provideMerge(layerFileAccessGrants),
+  Layer.provide(NodeServices.layer),
 );
 
 afterEach(() => {
@@ -128,6 +131,39 @@ describe("project/export path grants", () => {
     );
 
     expect(normalized).toBe(path.resolve(outputPath));
+  });
+
+  test("normalizes local file URLs through the Effect Path service", async () => {
+    const projectPath = path.join(tmpdir(), "local-url.gglassproj");
+    const projectURL = pathToFileURL(projectPath);
+    projectURL.hostname = "localhost";
+
+    const normalized = await Effect.runPromise(
+      Effect.gen(function* () {
+        const grants = yield* FileAccessGrants;
+        const policy = yield* ProjectExportPathPolicy;
+        yield* grants.grantPath("project-open", projectPath);
+        return yield* policy.validateProjectOpenPath(projectURL.href);
+      }).pipe(Effect.provide(pathPolicyLayer)),
+    );
+
+    expect(normalized).toBe(path.resolve(projectPath));
+  });
+
+  test("rejects non-local file URL hosts", async () => {
+    const exit = await Effect.runPromise(
+      Effect.gen(function* () {
+        const policy = yield* ProjectExportPathPolicy;
+        return yield* Effect.exit(
+          policy.validateProjectOpenPath("file://remote.example/project.gglassproj"),
+        );
+      }).pipe(Effect.provide(pathPolicyLayer)),
+    );
+
+    expect(exit._tag).toBe("Failure");
+    if (exit._tag === "Failure") {
+      expect(String(exit.cause)).toContain("Only local file URLs are supported");
+    }
   });
 });
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -68,6 +68,8 @@ Production Bun transport:
 - Requires `GG_ENGINE_TRANSPORT=http` and per-process bearer auth.
 - Reads the `guerillaglass.engine.http.ready` readiness envelope from stdout.
 - Connects over authenticated loopback HTTP through `@effect/platform-node/NodeHttpClient` running under Electrobun's Bun executable.
+- Resolves application paths and performs ordinary filesystem and cryptographic operations through Effect `Path`, `FileSystem`, and `Crypto` services supplied by `NodeServices.layer` at composition roots.
+- Keeps descriptor-level symlink protection in `src/bun/security/fileAccess.ts` as an explicit Node platform adapter because Effect `FileSystem.open` does not currently expose `O_NOFOLLOW`; application services must not add other direct `node:path`, `node:fs`, or `node:crypto` imports.
 - Does not perform generic RPC retries.
 - Does not automatically restart native engines.
 - Logs/spans process spawn, readiness, HTTP requests, protocol errors, stderr, and shutdown.


### PR DESCRIPTION
## Summary
- route desktop application path operations through Effect's vendored `Path` service
- preserve descriptor-level `O_NOFOLLOW` handling as the single documented Node filesystem adapter
- enforce the boundary with repository invariants and regression tests

## Acceptance criteria
- application services under workspace `src` trees have no direct `node:path`, `node:fs`, or `node:crypto` imports
- media routing, registry normalization, file grants, project/export URL policy, and engine executable policy consume Effect `Path`
- local file URL behavior and non-local host rejection remain covered
- packaged Electrobun starts with the native Swift engine and media server

## Validation
- `bun run repo:check`
- `bun test Scripts/repository_invariants.test.ts`
- `bun run desktop:typecheck`
- focused media server/path policy tests
- `bun run gate:typescript`
- Rust and Swift portions of `bun run gate`
- `bun run desktop:acceptance`

## Runtime evidence
`.tmp/runtime-acceptance/latest/report.json` passed all startup, renderer, visible-window, fatal-log, and cleanup checks. Native screenshot remains unavailable without Screen Recording permission; no UI behavior changed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Enforces Effect platform-service boundaries across desktop application services.
- Routes path operations through Effect’s `Path` service and supplies `NodeServices.layer` at composition roots.
- Expands repository invariants and regression tests to detect forbidden direct Node platform imports.
- Documents the descriptor-level `O_NOFOLLOW` adapter exception and preserves local-file URL policy coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failures remain.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| Scripts/repository_invariants.ts | Adds source-tree enforcement for direct Node path, filesystem, and crypto imports, including the forms raised in prior review threads. |
| Scripts/repository_invariants.test.ts | Adds regression fixtures covering static, side-effect, CommonJS, and dynamic forbidden imports. |
| apps/desktop-electrobun/src/bun/security/ProjectExportPathPolicy.ts | Migrates local-path and file-URL normalization to Effect Path while preserving local-host validation. |
| apps/desktop-electrobun/src/bun/security/FileAccessGrants.ts | Migrates grant normalization and containment checks to the injected Effect Path service. |
| apps/desktop-electrobun/src/bun/app/index.ts | Provides Node platform services to the guarded engine-client layer. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(repo): cover side-effect Node impor..."](https://github.com/okikesolutions/guerillaglass/commit/71276748f4b718d1745accb449571261f21d4eaf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47014382)</sub>

<!-- /greptile_comment -->