### PR TITLE
feat(editor): render deterministic background framing

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -71,12 +71,12 @@ let package = Package(
         ),
         .target(
             name: "Rendering",
-            dependencies: ["Automation"],
+            dependencies: ["Automation", "Project"],
             path: "engines/macos-swift/modules/rendering"
         ),
         .target(
             name: "Export",
-            dependencies: ["Automation", "Rendering"],
+            dependencies: ["Automation", "Project", "Rendering"],
             path: "engines/macos-swift/modules/export"
         ),
         .testTarget(
@@ -91,7 +91,7 @@ let package = Package(
         ),
         .testTarget(
             name: "RenderingDeterminismTests",
-            dependencies: ["Rendering"],
+            dependencies: ["Project", "Rendering"],
             path: "Tests/renderingDeterminismTests"
         ),
         .testTarget(
@@ -101,7 +101,7 @@ let package = Package(
         ),
         .testTarget(
             name: "ExportTests",
-            dependencies: ["Export"],
+            dependencies: ["Export", "Project"],
             path: "Tests/exportTests"
         )
     ]

--- a/Scripts/coverage_check.sh
+++ b/Scripts/coverage_check.sh
@@ -210,7 +210,13 @@ fi
 
 if needs_scope swift; then
   echo "==> swift coverage report"
-  swift test --enable-code-coverage >/dev/null
+  swift_test_log="$COVERAGE_DIR/swift-test.log"
+  if ! swift test --enable-code-coverage >"$swift_test_log" 2>&1; then
+    echo "Swift coverage test run failed; full test output follows:" >&2
+    cat "$swift_test_log" >&2
+    exit 1
+  fi
+  rm -f "$swift_test_log"
   swift_cov_path="$(swift test --enable-code-coverage --show-codecov-path | tail -n 1)"
   SWIFT_REPORT="$COVERAGE_DIR/swift-summary.json"
   cp "$swift_cov_path" "$SWIFT_REPORT"

--- a/Tests/exportTests/ExportPipelineTests.swift
+++ b/Tests/exportTests/ExportPipelineTests.swift
@@ -374,9 +374,7 @@ final class ExportPipelineTests: XCTestCase {
             at: 0.25,
             normalizedPoint: CGPoint(x: 0.02, y: 0.02)
         )
-        XCTAssertEqual(stageColor.redComponent, 32 / 255, accuracy: 0.08)
-        XCTAssertEqual(stageColor.greenComponent, 64 / 255, accuracy: 0.08)
-        XCTAssertEqual(stageColor.blueComponent, 96 / 255, accuracy: 0.08)
+        assertEncodedColor(stageColor, equalsSRGB8: (red: 32, green: 64, blue: 96))
 
         let videoTracks = try await exportedAsset.loadTracks(withMediaType: .video)
         let videoTrack = try XCTUnwrap(videoTracks.first)
@@ -391,14 +389,14 @@ final class ExportPipelineTests: XCTestCase {
         )
 
         let cardCenter = try sampleColor(in: exportedAsset, at: 0.25)
-        XCTAssertLessThan(cardCenter.redComponent, 0.08)
+        XCTAssertLessThan(cardCenter.redComponent, 0.20)
         XCTAssertGreaterThan(cardCenter.blueComponent, 0.85)
-        XCTAssertGreaterThan(cardCenter.blueComponent, cardCenter.greenComponent * 3)
+        XCTAssertGreaterThan(cardCenter.blueComponent, cardCenter.greenComponent * 2.5)
 
         let roundedCorner = try sampleColor(
             in: exportedAsset,
             at: 0.25,
-            normalizedPoint: CGPoint(x: 0.061, y: 0.061)
+            normalizedPoint: CGPoint(x: 0.07, y: 0.07)
         )
         XCTAssertEqual(roundedCorner.redComponent, stageColor.redComponent, accuracy: 0.08)
         XCTAssertEqual(roundedCorner.greenComponent, stageColor.greenComponent, accuracy: 0.08)
@@ -483,9 +481,7 @@ final class ExportPipelineTests: XCTestCase {
         }
 
         let gapColor = try sampleColor(in: AVAsset(url: outputURL), at: 0.75)
-        XCTAssertEqual(gapColor.redComponent, 32 / 255, accuracy: 0.08)
-        XCTAssertEqual(gapColor.greenComponent, 64 / 255, accuracy: 0.08)
-        XCTAssertEqual(gapColor.blueComponent, 96 / 255, accuracy: 0.08)
+        assertEncodedColor(gapColor, equalsSRGB8: (red: 32, green: 64, blue: 96))
     }
 
     func testFramedTimelineTrimBeginningInsideGapKeepsCardHidden() async throws {
@@ -523,9 +519,7 @@ final class ExportPipelineTests: XCTestCase {
         )
 
         let gapColor = try sampleColor(in: AVAsset(url: outputURL), at: 0.1)
-        XCTAssertEqual(gapColor.redComponent, 32 / 255, accuracy: 0.08)
-        XCTAssertEqual(gapColor.greenComponent, 64 / 255, accuracy: 0.08)
-        XCTAssertEqual(gapColor.blueComponent, 96 / 255, accuracy: 0.08)
+        assertEncodedColor(gapColor, equalsSRGB8: (red: 32, green: 64, blue: 96))
     }
 
     func testTimelineCompositionRejectsInvalidValues() async throws {
@@ -791,6 +785,21 @@ final class ExportPipelineTests: XCTestCase {
                 return
             }
         }
+    }
+
+    private func assertEncodedColor(
+        _ color: NSColor,
+        equalsSRGB8 expected: (red: CGFloat, green: CGFloat, blue: CGFloat),
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        // Hardware encoders round-trip sRGB Core Animation content through Y'CbCr differently.
+        // Keep this raster assertion strict enough to catch a wrong stage while the pure color test
+        // verifies exact sRGB component parsing independently of codec conversion.
+        let codecTolerance: CGFloat = 0.16
+        XCTAssertEqual(color.redComponent, expected.red / 255, accuracy: codecTolerance, file: file, line: line)
+        XCTAssertEqual(color.greenComponent, expected.green / 255, accuracy: codecTolerance, file: file, line: line)
+        XCTAssertEqual(color.blueComponent, expected.blue / 255, accuracy: codecTolerance, file: file, line: line)
     }
 
     private func luminance(_ color: NSColor) -> CGFloat {

--- a/Tests/exportTests/ExportPipelineTests.swift
+++ b/Tests/exportTests/ExportPipelineTests.swift
@@ -3,6 +3,7 @@ import Automation
 import AVFoundation
 import Darwin
 @testable import Export
+import Project
 import XCTest
 
 // swiftlint:disable type_body_length
@@ -49,6 +50,7 @@ final class ExportPipelineTests: XCTestCase {
         let preset = Presets.h2641080p30
 
         let outputURL = baseURL.appendingPathComponent("output.mp4")
+        try Data("existing-export".utf8).write(to: outputURL)
         let pipeline = ExportPipeline()
         do {
             _ = try await pipeline.export(
@@ -65,6 +67,77 @@ final class ExportPipelineTests: XCTestCase {
         }
 
         XCTAssertTrue(fileManager.fileExists(atPath: outputURL.path))
+        XCTAssertNotEqual(try Data(contentsOf: outputURL), Data("existing-export".utf8))
+    }
+
+    func testDisabledFramingPreservesBlackLegacyLetterbox() async throws {
+        let fileManager = FileManager.default
+        let baseURL = try canonicalTemporaryDirectory().appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let sourceURL = baseURL.appendingPathComponent("square.mov")
+        try makeVideoFile(
+            at: sourceURL,
+            durationSeconds: 0.5,
+            color: (red: 0, green: 0, blue: 255)
+        )
+        let outputURL = baseURL.appendingPathComponent("legacy.mp4")
+        _ = try await ExportPipeline().export(
+            recordingURL: sourceURL,
+            preset: Presets.h2641080p30,
+            trimRange: nil,
+            outputURL: outputURL,
+            backgroundFraming: .defaults
+        )
+
+        let letterboxColor = try sampleColor(
+            in: AVAsset(url: outputURL),
+            at: 0.25,
+            normalizedPoint: CGPoint(x: 0.02, y: 0.5)
+        )
+        XCTAssertLessThan(letterboxColor.redComponent, 0.05)
+        XCTAssertLessThan(letterboxColor.greenComponent, 0.05)
+        XCTAssertLessThan(letterboxColor.blueComponent, 0.05)
+    }
+
+    func testCancelledExportDoesNotInstallDestination() async throws {
+        let fileManager = FileManager.default
+        let baseURL = try canonicalTemporaryDirectory().appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let sourceURL = baseURL.appendingPathComponent("source.mov")
+        try makeVideoFile(at: sourceURL, durationSeconds: 2)
+        let outputURL = baseURL.appendingPathComponent("cancelled.mp4")
+        try Data("existing-destination".utf8).write(to: outputURL)
+        let exportTask = Task {
+            try await ExportPipeline().export(
+                recordingURL: sourceURL,
+                preset: Presets.h2641080p30,
+                trimRange: nil,
+                outputURL: outputURL,
+                backgroundFraming: BackgroundFramingSettings(
+                    version: 1,
+                    enabled: true,
+                    backgroundColor: "#18181B",
+                    paddingFraction: 0.06,
+                    cornerRadiusFraction: 0.025,
+                    shadowStrength: 0.35
+                )
+            )
+        }
+        exportTask.cancel()
+
+        do {
+            _ = try await exportTask.value
+            XCTFail("Expected export cancellation.")
+        } catch is CancellationError {
+            // Expected: AVAssetExportSession.export(to:as:) cooperates with task cancellation.
+        } catch {
+            XCTAssertTrue(error is CancellationError, "Unexpected cancellation error: \(error)")
+        }
+        XCTAssertEqual(try String(contentsOf: outputURL, encoding: .utf8), "existing-destination")
     }
 
     func testExportRejectsAncestorSymlinkOutputPath() async throws {
@@ -256,6 +329,203 @@ final class ExportPipelineTests: XCTestCase {
         XCTAssertEqual(cameraRed, 0.25, accuracy: 0.1)
         XCTAssertLessThan(cameraColor.greenComponent, 0.08)
         XCTAssertLessThan(cameraColor.blueComponent, 0.08)
+    }
+
+    func testBackgroundFramingRendersStageAndRoundedSourceCard() async throws {
+        let fileManager = FileManager.default
+        let baseURL = try canonicalTemporaryDirectory().appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let sourceURL = baseURL.appendingPathComponent("source.mov")
+        try makeVideoFile(
+            at: sourceURL,
+            durationSeconds: 0.5,
+            color: (red: 0, green: 0, blue: 255)
+        )
+        let outputURL = baseURL.appendingPathComponent("framed.mp4")
+        let settings = try BackgroundFramingSettings(
+            version: 1,
+            enabled: true,
+            backgroundColor: "#204060",
+            paddingFraction: 0.06,
+            cornerRadiusFraction: 0.10,
+            shadowStrength: 0
+        )
+
+        do {
+            _ = try await ExportPipeline().export(
+                recordingURL: sourceURL,
+                preset: Presets.h2641080p30,
+                trimRange: nil,
+                outputURL: outputURL,
+                backgroundFraming: settings
+            )
+        } catch let error as ExportPipeline.ExportError {
+            if case .cannotCreateSession = error {
+                throw XCTSkip("Preset not supported.")
+            }
+            throw error
+        }
+
+        let exportedAsset = AVAsset(url: outputURL)
+        let stageColor = try sampleColor(
+            in: exportedAsset,
+            at: 0.25,
+            normalizedPoint: CGPoint(x: 0.02, y: 0.02)
+        )
+        XCTAssertEqual(stageColor.redComponent, 32 / 255, accuracy: 0.08)
+        XCTAssertEqual(stageColor.greenComponent, 64 / 255, accuracy: 0.08)
+        XCTAssertEqual(stageColor.blueComponent, 96 / 255, accuracy: 0.08)
+
+        let videoTracks = try await exportedAsset.loadTracks(withMediaType: .video)
+        let videoTrack = try XCTUnwrap(videoTracks.first)
+        let formatDescriptions = try await videoTrack.load(.formatDescriptions)
+        let formatDescription = try XCTUnwrap(formatDescriptions.first)
+        let extensions = try XCTUnwrap(
+            CMFormatDescriptionGetExtensions(formatDescription)
+        ) as NSDictionary
+        XCTAssertEqual(
+            extensions[kCMFormatDescriptionExtension_ColorPrimaries] as? String,
+            kCVImageBufferColorPrimaries_ITU_R_709_2 as String
+        )
+
+        let cardCenter = try sampleColor(in: exportedAsset, at: 0.25)
+        XCTAssertLessThan(cardCenter.redComponent, 0.08)
+        XCTAssertGreaterThan(cardCenter.blueComponent, 0.85)
+        XCTAssertGreaterThan(cardCenter.blueComponent, cardCenter.greenComponent * 3)
+
+        let roundedCorner = try sampleColor(
+            in: exportedAsset,
+            at: 0.25,
+            normalizedPoint: CGPoint(x: 0.061, y: 0.061)
+        )
+        XCTAssertEqual(roundedCorner.redComponent, stageColor.redComponent, accuracy: 0.08)
+        XCTAssertEqual(roundedCorner.greenComponent, stageColor.greenComponent, accuracy: 0.08)
+        XCTAssertEqual(roundedCorner.blueComponent, stageColor.blueComponent, accuracy: 0.08)
+    }
+
+    func testBackgroundFramingShadowFallsBelowCard() async throws {
+        let fileManager = FileManager.default
+        let baseURL = try canonicalTemporaryDirectory().appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let sourceURL = baseURL.appendingPathComponent("square.mov")
+        try makeVideoFile(at: sourceURL, durationSeconds: 0.5, color: (red: 0, green: 0, blue: 255))
+        let outputURL = baseURL.appendingPathComponent("shadow.mp4")
+        let settings = try BackgroundFramingSettings(
+            version: 1,
+            enabled: true,
+            backgroundColor: "#808080",
+            paddingFraction: 0.10,
+            cornerRadiusFraction: 0.025,
+            shadowStrength: 1
+        )
+        _ = try await ExportPipeline().export(
+            recordingURL: sourceURL,
+            preset: Presets.h2641080p30,
+            trimRange: nil,
+            outputURL: outputURL,
+            backgroundFraming: settings
+        )
+
+        let asset = AVAsset(url: outputURL)
+        let belowCard = try sampleColor(
+            in: asset,
+            at: 0.25,
+            normalizedPoint: CGPoint(x: 0.5, y: 0.925)
+        )
+        let aboveCard = try sampleColor(
+            in: asset,
+            at: 0.25,
+            normalizedPoint: CGPoint(x: 0.5, y: 0.075)
+        )
+        XCTAssertLessThan(luminance(belowCard), luminance(aboveCard) - 0.01)
+    }
+
+    func testEnabledTimelineGapRendersOnlyConfiguredStage() async throws {
+        let fileManager = FileManager.default
+        let baseURL = try canonicalTemporaryDirectory().appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let sourceURL = baseURL.appendingPathComponent("source.mov")
+        try makeVideoFile(at: sourceURL, durationSeconds: 2, color: (red: 0, green: 0, blue: 255))
+        let outputURL = baseURL.appendingPathComponent("framed-gap.mp4")
+        let settings = try BackgroundFramingSettings(
+            version: 1,
+            enabled: true,
+            backgroundColor: "#204060",
+            paddingFraction: 0.06,
+            cornerRadiusFraction: 0.025,
+            shadowStrength: 1
+        )
+
+        do {
+            _ = try await ExportPipeline().export(
+                recordingURL: sourceURL,
+                preset: Presets.h2641080p30,
+                trimRange: nil,
+                outputURL: outputURL,
+                timeline: ExportTimelineDocument(items: [
+                    .clip(ExportTimelineClip(id: "clip-1", sourceStartSeconds: 0, sourceEndSeconds: 0.5)),
+                    .gap(ExportTimelineGap(id: "gap-1", durationSeconds: 0.5)),
+                    .clip(ExportTimelineClip(id: "clip-2", sourceStartSeconds: 0.5, sourceEndSeconds: 1)),
+                ]),
+                backgroundFraming: settings
+            )
+        } catch let error as ExportPipeline.ExportError {
+            if case .cannotCreateSession = error {
+                throw XCTSkip("Preset not supported.")
+            }
+            throw error
+        }
+
+        let gapColor = try sampleColor(in: AVAsset(url: outputURL), at: 0.75)
+        XCTAssertEqual(gapColor.redComponent, 32 / 255, accuracy: 0.08)
+        XCTAssertEqual(gapColor.greenComponent, 64 / 255, accuracy: 0.08)
+        XCTAssertEqual(gapColor.blueComponent, 96 / 255, accuracy: 0.08)
+    }
+
+    func testFramedTimelineTrimBeginningInsideGapKeepsCardHidden() async throws {
+        let fileManager = FileManager.default
+        let baseURL = try canonicalTemporaryDirectory().appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let sourceURL = baseURL.appendingPathComponent("source.mov")
+        try makeVideoFile(at: sourceURL, durationSeconds: 2, color: (red: 0, green: 0, blue: 255))
+        let outputURL = baseURL.appendingPathComponent("trimmed-gap.mp4")
+        let settings = try BackgroundFramingSettings(
+            version: 1,
+            enabled: true,
+            backgroundColor: "#204060",
+            paddingFraction: 0.06,
+            cornerRadiusFraction: 0.025,
+            shadowStrength: 1
+        )
+
+        _ = try await ExportPipeline().export(
+            recordingURL: sourceURL,
+            preset: Presets.h2641080p30,
+            trimRange: CMTimeRange(
+                start: CMTime(seconds: 0.6, preferredTimescale: 600),
+                duration: CMTime(seconds: 0.2, preferredTimescale: 600)
+            ),
+            outputURL: outputURL,
+            timeline: ExportTimelineDocument(items: [
+                .clip(ExportTimelineClip(id: "clip-1", sourceStartSeconds: 0, sourceEndSeconds: 0.5)),
+                .gap(ExportTimelineGap(id: "gap-1", durationSeconds: 0.5)),
+                .clip(ExportTimelineClip(id: "clip-2", sourceStartSeconds: 0.5, sourceEndSeconds: 1)),
+            ]),
+            backgroundFraming: settings
+        )
+
+        let gapColor = try sampleColor(in: AVAsset(url: outputURL), at: 0.1)
+        XCTAssertEqual(gapColor.redComponent, 32 / 255, accuracy: 0.08)
+        XCTAssertEqual(gapColor.greenComponent, 64 / 255, accuracy: 0.08)
+        XCTAssertEqual(gapColor.blueComponent, 96 / 255, accuracy: 0.08)
     }
 
     func testTimelineCompositionRejectsInvalidValues() async throws {
@@ -523,7 +793,15 @@ final class ExportPipelineTests: XCTestCase {
         }
     }
 
-    private func sampleColor(in asset: AVAsset, at seconds: Double) throws -> NSColor {
+    private func luminance(_ color: NSColor) -> CGFloat {
+        0.2126 * color.redComponent + 0.7152 * color.greenComponent + 0.0722 * color.blueComponent
+    }
+
+    private func sampleColor(
+        in asset: AVAsset,
+        at seconds: Double,
+        normalizedPoint: CGPoint = CGPoint(x: 0.5, y: 0.5)
+    ) throws -> NSColor {
         let generator = AVAssetImageGenerator(asset: asset)
         generator.requestedTimeToleranceBefore = .zero
         generator.requestedTimeToleranceAfter = .zero
@@ -532,7 +810,15 @@ final class ExportPipelineTests: XCTestCase {
             actualTime: nil
         )
         let bitmap = NSBitmapImageRep(cgImage: image)
-        guard let color = bitmap.colorAt(x: image.width / 2, y: image.height / 2)?.usingColorSpace(.deviceRGB) else {
+        let xCoordinate = min(
+            image.width - 1,
+            max(0, Int(CGFloat(image.width) * normalizedPoint.x))
+        )
+        let yCoordinate = min(
+            image.height - 1,
+            max(0, Int(CGFloat(image.height) * normalizedPoint.y))
+        )
+        guard let color = bitmap.colorAt(x: xCoordinate, y: yCoordinate)?.usingColorSpace(.sRGB) else {
             throw TestError.cannotSampleColor
         }
         return color

--- a/Tests/renderingDeterminismTests/RenderingDeterminismTests.swift
+++ b/Tests/renderingDeterminismTests/RenderingDeterminismTests.swift
@@ -1,12 +1,142 @@
+import Automation
+import Project
 @testable import Rendering
 import XCTest
 
 final class RenderingDeterminismTests: XCTestCase {
-    func testRendererInitialization() {
-        let preview = PreviewRenderer()
-        let export = ExportRenderer()
+    func testDefaultLandscapeGeometryMatchesVersionOneFormula() throws {
+        let settings = try enabledSettings()
+        let geometry = try XCTUnwrap(BackgroundFramingGeometry(
+            renderSize: CGSize(width: 1920, height: 1080),
+            orientedSourceSize: CGSize(width: 1920, height: 1080),
+            settings: settings
+        ))
 
-        XCTAssertNotNil(preview)
-        XCTAssertNotNil(export)
+        assertRect(geometry.outputRect, equals: CGRect(x: 0, y: 0, width: 1920, height: 1080))
+        assertRect(geometry.cardRect, equals: CGRect(x: 115.2, y: 64.8, width: 1689.6, height: 950.4))
+        XCTAssertEqual(geometry.cornerRadius, 23.76, accuracy: 0.0001)
+        XCTAssertEqual(geometry.shadowOpacity, 0.105, accuracy: 0.0001)
+        XCTAssertEqual(geometry.shadowRadius, 13.23, accuracy: 0.0001)
+        XCTAssertEqual(geometry.shadowOffset.height, 4.536, accuracy: 0.0001)
+    }
+
+    func testVerticalOutputAspectFitsLandscapeSourceWithoutCropping() throws {
+        let geometry = try XCTUnwrap(BackgroundFramingGeometry(
+            renderSize: CGSize(width: 1080, height: 1920),
+            orientedSourceSize: CGSize(width: 1920, height: 1080),
+            settings: enabledSettings()
+        ))
+
+        assertRect(geometry.cardRect, equals: CGRect(x: 64.8, y: 692.7, width: 950.4, height: 534.6))
+        XCTAssertEqual(geometry.cardRect.width / geometry.cardRect.height, 16 / 9, accuracy: 0.0001)
+    }
+
+    func testDisabledGeometryPreservesLegacyFullFrameFit() {
+        let geometry = BackgroundFramingGeometry(
+            renderSize: CGSize(width: 1920, height: 1080),
+            orientedSourceSize: CGSize(width: 1920, height: 1080),
+            settings: .defaults
+        )
+
+        XCTAssertEqual(geometry?.cardRect, CGRect(x: 0, y: 0, width: 1920, height: 1080))
+        XCTAssertEqual(geometry?.cornerRadius, 0)
+        XCTAssertEqual(geometry?.shadowOpacity, 0)
+    }
+
+    func testGeometryRejectsNonFiniteOrEmptyDimensions() throws {
+        let settings = try enabledSettings()
+        XCTAssertNil(BackgroundFramingGeometry(
+            renderSize: CGSize(width: CGFloat.infinity, height: 1080),
+            orientedSourceSize: CGSize(width: 1920, height: 1080),
+            settings: settings
+        ))
+        XCTAssertNil(BackgroundFramingGeometry(
+            renderSize: CGSize(width: 1920, height: 1080),
+            orientedSourceSize: CGSize(width: 0, height: 1080),
+            settings: settings
+        ))
+    }
+
+    func testRotatedSourceBoundsAndCameraCompositionUseCanonicalOrder() {
+        let preferredTransform = CGAffineTransform(rotationAngle: .pi / 2)
+            .translatedBy(x: 0, y: -1080)
+        let bounds = VideoGeometryTransforms.orientedBounds(
+            naturalSize: CGSize(width: 1920, height: 1080),
+            preferredTransform: preferredTransform
+        )
+        XCTAssertEqual(bounds.width, 1080, accuracy: 0.0001)
+        XCTAssertEqual(bounds.height, 1920, accuracy: 0.0001)
+
+        let portraitCard = CGRect(x: 100, y: 50, width: 600, height: 800)
+        let rotatedBase = VideoGeometryTransforms.sourceToCardTransform(
+            naturalSize: CGSize(width: 1920, height: 1080),
+            preferredTransform: preferredTransform,
+            cardRect: portraitCard
+        )
+        let rotatedOutputBounds = VideoGeometryTransforms.orientedBounds(
+            naturalSize: CGSize(width: 1920, height: 1080),
+            preferredTransform: rotatedBase
+        )
+        assertRect(
+            rotatedOutputBounds,
+            equals: CGRect(x: 175, y: 50, width: 450, height: 800)
+        )
+
+        let card = CGRect(x: 100, y: 50, width: 800, height: 600)
+        let base = VideoGeometryTransforms.sourceToCardTransform(
+            naturalSize: CGSize(width: 1920, height: 1080),
+            preferredTransform: .identity,
+            cardRect: card
+        )
+        let topLeft = CGPoint.zero.applying(base)
+        let bottomRight = CGPoint(x: 1920, y: 1080).applying(base)
+        XCTAssertEqual(topLeft.x, card.minX, accuracy: 0.0001)
+        XCTAssertEqual(topLeft.y, card.minY + 75, accuracy: 0.0001)
+        XCTAssertEqual(bottomRight.x, card.maxX, accuracy: 0.0001)
+        XCTAssertEqual(bottomRight.y, card.maxY - 75, accuracy: 0.0001)
+
+        let keyframe = CameraKeyframe(time: 0, center: CGPoint(x: 480, y: 540), zoom: 2)
+        let combined = VideoGeometryTransforms.sourceTransform(
+            baseTransform: base,
+            keyframe: keyframe,
+            sourceSize: CGSize(width: 1920, height: 1080)
+        )
+
+        XCTAssertEqual(combined, VideoGeometryTransforms.cameraTransform(
+            for: keyframe,
+            sourceSize: CGSize(width: 1920, height: 1080)
+        ).concatenating(base))
+    }
+
+    func testBackgroundColorUsesExplicitSRGBComponents() throws {
+        let color = try XCTUnwrap(BackgroundFramingColor(hex: "#1A2B3C"))
+        XCTAssertEqual(color.red, 26 / 255, accuracy: 0.0001)
+        XCTAssertEqual(color.green, 43 / 255, accuracy: 0.0001)
+        XCTAssertEqual(color.blue, 60 / 255, accuracy: 0.0001)
+        XCTAssertNil(BackgroundFramingColor(hex: "#123"))
+    }
+
+    private func enabledSettings() throws -> BackgroundFramingSettings {
+        try BackgroundFramingSettings(
+            version: 1,
+            enabled: true,
+            backgroundColor: "#18181B",
+            paddingFraction: 0.06,
+            cornerRadiusFraction: 0.025,
+            shadowStrength: 0.35
+        )
+    }
+
+    private func assertRect(
+        _ actual: CGRect,
+        equals expected: CGRect,
+        accuracy: CGFloat = 0.0001,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertEqual(actual.minX, expected.minX, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(actual.minY, expected.minY, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(actual.width, expected.width, accuracy: accuracy, file: file, line: line)
+        XCTAssertEqual(actual.height, expected.height, accuracy: accuracy, file: file, line: line)
     }
 }

--- a/apps/desktop-electrobun/src/bun/bridge/HostBridgeService.ts
+++ b/apps/desktop-electrobun/src/bun/bridge/HostBridgeService.ts
@@ -124,6 +124,10 @@ export const layerHostBridgeService = Layer.succeed(
             const system = yield* SystemService;
             return yield* system.ping;
           }
+          case "ggEngineCapabilities": {
+            const system = yield* SystemService;
+            return yield* system.capabilities;
+          }
           case "ggEngineGetPermissions": {
             const permissions = yield* PermissionsService;
             return yield* permissions.get;

--- a/apps/desktop-electrobun/src/mainview/app/studio/domain/backgroundFramingGeometry.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/domain/backgroundFramingGeometry.ts
@@ -1,0 +1,62 @@
+import type { BackgroundFramingSettings } from "@guerillaglass/engine-contract/shared/valueObjects";
+
+export type RenderSize = Readonly<{ width: number; height: number }>;
+export type RenderRect = Readonly<{ x: number; y: number; width: number; height: number }>;
+
+export type BackgroundFramingGeometry = Readonly<{
+  outputRect: RenderRect;
+  cardRect: RenderRect;
+  cornerRadius: number;
+  shadowOpacity: number;
+  shadowBlurRadius: number;
+  shadowOffsetX: number;
+  shadowOffsetY: number;
+}>;
+
+export function computeBackgroundFramingGeometry(
+  outputSize: RenderSize,
+  sourceSize: RenderSize,
+  settings: BackgroundFramingSettings,
+): BackgroundFramingGeometry | null {
+  if (!isFinitePositiveSize(outputSize) || !isFinitePositiveSize(sourceSize)) {
+    return null;
+  }
+
+  const outputRect = { x: 0, y: 0, width: outputSize.width, height: outputSize.height };
+  const shorterOutputDimension = Math.min(outputSize.width, outputSize.height);
+  const padding = settings.enabled ? settings.paddingFraction * shorterOutputDimension : 0;
+  const availableWidth = outputSize.width - 2 * padding;
+  const availableHeight = outputSize.height - 2 * padding;
+  if (availableWidth <= 0 || availableHeight <= 0) {
+    return null;
+  }
+
+  const scale = Math.min(availableWidth / sourceSize.width, availableHeight / sourceSize.height);
+  const cardWidth = sourceSize.width * scale;
+  const cardHeight = sourceSize.height * scale;
+  const cardRect = {
+    x: (outputSize.width - cardWidth) / 2,
+    y: (outputSize.height - cardHeight) / 2,
+    width: cardWidth,
+    height: cardHeight,
+  };
+  const shadowStrength = settings.enabled ? settings.shadowStrength : 0;
+
+  return {
+    outputRect,
+    cardRect,
+    cornerRadius: settings.enabled
+      ? settings.cornerRadiusFraction * Math.min(cardWidth, cardHeight)
+      : 0,
+    shadowOpacity: 0.3 * shadowStrength,
+    shadowBlurRadius: 0.035 * shorterOutputDimension * shadowStrength,
+    shadowOffsetX: 0,
+    shadowOffsetY: 0.012 * shorterOutputDimension * shadowStrength,
+  };
+}
+
+function isFinitePositiveSize(size: RenderSize): boolean {
+  return (
+    Number.isFinite(size.width) && Number.isFinite(size.height) && size.width > 0 && size.height > 0
+  );
+}

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts
@@ -251,6 +251,7 @@ export function useStudioController() {
   });
 
   const {
+    capabilitiesQuery,
     captureStatusQuery,
     eventsQuery,
     exportInfoQuery,
@@ -286,26 +287,32 @@ export function useStudioController() {
     if (!projectAutoZoom) {
       return;
     }
-    const nextSignature = JSON.stringify(projectAutoZoom);
+    const nextSignature = JSON.stringify({
+      projectPath: projectQuery.data?.projectPath ?? null,
+      settings: projectAutoZoom,
+    });
     if (nextSignature === lastHydratedProjectAutoZoomSignatureRef.current) {
       return;
     }
     lastHydratedProjectAutoZoomSignatureRef.current = nextSignature;
     settingsForm.setFieldValue("autoZoom", projectAutoZoom);
-  }, [projectQuery.data?.autoZoom, settingsForm]);
+  }, [projectQuery.data?.autoZoom, projectQuery.data?.projectPath, settingsForm]);
 
   useEffect(() => {
     const projectBackgroundFraming = projectQuery.data?.backgroundFraming;
     if (!projectBackgroundFraming) {
       return;
     }
-    const nextSignature = JSON.stringify(projectBackgroundFraming);
+    const nextSignature = JSON.stringify({
+      projectPath: projectQuery.data?.projectPath ?? null,
+      settings: projectBackgroundFraming,
+    });
     if (nextSignature === lastHydratedBackgroundFramingSignatureRef.current) {
       return;
     }
     lastHydratedBackgroundFramingSignatureRef.current = nextSignature;
     settingsForm.setFieldValue("backgroundFraming", projectBackgroundFraming);
-  }, [projectQuery.data?.backgroundFraming, settingsForm]);
+  }, [projectQuery.data?.backgroundFraming, projectQuery.data?.projectPath, settingsForm]);
 
   const baselineTimelineDocument = useMemo<TimelineDocument>(() => {
     const projectTimeline = projectQuery.data?.timeline;
@@ -1073,6 +1080,8 @@ export function useStudioController() {
       : ui.labels.idle;
 
   return {
+    backgroundFramingSupported: capabilitiesQuery.data?.export.backgroundFraming === true,
+    capabilitiesQuery,
     captureStatusLabel,
     captureStatusQuery,
     exportForm,

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioDataQueries.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioDataQueries.ts
@@ -11,7 +11,7 @@ import type {
   ProjectState,
 } from "@guerillaglass/engine-contract/domains/project";
 import type { SourcesResult } from "@guerillaglass/engine-contract/domains/sources";
-import type { PingResult } from "@guerillaglass/engine-contract/domains/system";
+import type { CapabilitiesResult, PingResult } from "@guerillaglass/engine-contract/domains/system";
 import type { InputEvent } from "@guerillaglass/engine-contract/shared/valueObjects";
 import { hostBridgeEventNames } from "@shared/bridge/desktopBridgeContract";
 import { validateEncodedUnknownWithSchemaSync } from "@guerillaglass/engine-client/schemaContracts";
@@ -24,6 +24,7 @@ const emptySourceWindows: SourcesResult["windows"] = [];
 
 export const studioQueryKeys = {
   ping: () => ["studio", "ping"] as const,
+  capabilities: () => ["studio", "capabilities"] as const,
   permissions: () => ["studio", "permissions"] as const,
   sources: () => ["studio", "sources"] as const,
   captureStatus: () => ["studio", "captureStatus"] as const,
@@ -104,6 +105,13 @@ export function useStudioDataQueries({
     staleTime: 30_000,
   });
 
+  const capabilitiesQuery = useQuery<CapabilitiesResult>({
+    queryKey: studioQueryKeys.capabilities(),
+    queryFn: () => engineApi.capabilities(),
+    staleTime: Number.POSITIVE_INFINITY,
+    retry: false,
+  });
+
   const permissionsQuery = useQuery<PermissionsResult>({
     queryKey: studioQueryKeys.permissions(),
     queryFn: () => engineApi.getPermissions(),
@@ -177,6 +185,7 @@ export function useStudioDataQueries({
   const windowChoices = sourcesQuery.data?.windows ?? emptySourceWindows;
 
   return {
+    capabilitiesQuery,
     captureStatusQuery,
     eventsQuery,
     eventsURL,

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/useVideoPlaybackSync.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/useVideoPlaybackSync.ts
@@ -10,6 +10,7 @@ import type { PlaybackTransportStore } from "./timeline/usePlaybackTransport";
 
 type UseVideoPlaybackSyncOptions = {
   mediaRef: RefObject<HTMLVideoElement | null>;
+  sourceCardRef?: RefObject<HTMLDivElement | null>;
   playbackStore: PlaybackTransportStore;
   recordingMediaSource: string | null;
   timelineItems: CompiledTimelineItem[];
@@ -21,6 +22,7 @@ type UseVideoPlaybackSyncOptions = {
 
 export function useVideoPlaybackSync({
   mediaRef,
+  sourceCardRef,
   playbackStore,
   recordingMediaSource,
   timelineItems,
@@ -128,7 +130,7 @@ export function useVideoPlaybackSync({
       const boundedPlayhead = Math.max(0, Math.min(playheadSecondsRef.current, timelineDuration));
       const resolution = resolveTimelinePlaybackAtProgramTime(timelineItems, boundedPlayhead);
       const isGap = resolution.kind === "gap";
-      media.style.visibility = isGap ? "hidden" : "";
+      setSourceVisibility(media, sourceCardRef, !isGap);
       if (resolution.kind !== "clip") {
         return;
       }
@@ -147,7 +149,14 @@ export function useVideoPlaybackSync({
 
     syncPausedSeek();
     return playbackStore.subscribe(syncPausedSeek);
-  }, [mediaRef, playbackStore, recordingMediaSource, timelineDuration, timelineItems]);
+  }, [
+    mediaRef,
+    playbackStore,
+    recordingMediaSource,
+    sourceCardRef,
+    timelineDuration,
+    timelineItems,
+  ]);
 
   useEffect(() => {
     const media = mediaRef.current;
@@ -167,7 +176,7 @@ export function useVideoPlaybackSync({
         playheadSecondsRef.current,
       );
       const isGap = resolution.kind === "gap";
-      media.style.visibility = isGap ? "hidden" : "";
+      setSourceVisibility(media, sourceCardRef, !isGap);
 
       if (isGap) {
         media.pause();
@@ -207,7 +216,7 @@ export function useVideoPlaybackSync({
         );
         if (boundaryResolution.kind === "gap") {
           media.pause();
-          media.style.visibility = "hidden";
+          setSourceVisibility(media, sourceCardRef, false);
           setPlayheadSecondsFromMedia(boundarySeconds);
           return true;
         }
@@ -294,6 +303,7 @@ export function useVideoPlaybackSync({
     setDisplayPlayheadSecondsFromMedia,
     setPlayheadSecondsFromMedia,
     setTimelinePlaybackActive,
+    sourceCardRef,
     timelineItems,
   ]);
 
@@ -309,7 +319,7 @@ export function useVideoPlaybackSync({
         playheadSecondsRef.current,
       );
       const isGap = resolution.kind === "gap";
-      media.style.visibility = isGap ? "hidden" : "";
+      setSourceVisibility(media, sourceCardRef, !isGap);
       if (resolution.kind !== "clip") {
         return;
       }
@@ -331,7 +341,7 @@ export function useVideoPlaybackSync({
       );
       if (resolution.kind === "gap") {
         media.pause();
-        media.style.visibility = "hidden";
+        setSourceVisibility(media, sourceCardRef, false);
         return;
       }
       if (resolution.kind === "clip") {
@@ -349,7 +359,7 @@ export function useVideoPlaybackSync({
         );
         if (boundaryResolution.kind === "gap") {
           media.pause();
-          media.style.visibility = "hidden";
+          setSourceVisibility(media, sourceCardRef, false);
           setPlayheadSecondsFromMedia(boundarySeconds);
           return;
         }
@@ -358,7 +368,7 @@ export function useVideoPlaybackSync({
         if (nextClip) {
           try {
             media.currentTime = nextClip.sourceStartSeconds;
-            media.style.visibility = "";
+            setSourceVisibility(media, sourceCardRef, true);
             setPlayheadSecondsFromMedia(nextClip.programStartSeconds);
             void media.play().catch(() => setTimelinePlaybackActive(false));
             return;
@@ -391,5 +401,23 @@ export function useVideoPlaybackSync({
       media.removeEventListener("ended", handleEnded);
       media.removeEventListener("loadedmetadata", handleLoadedMetadata);
     };
-  }, [mediaRef, setPlayheadSecondsFromMedia, setTimelinePlaybackActive, timelineItems]);
+  }, [
+    mediaRef,
+    setPlayheadSecondsFromMedia,
+    setTimelinePlaybackActive,
+    sourceCardRef,
+    timelineItems,
+  ]);
+}
+
+function setSourceVisibility(
+  media: HTMLVideoElement,
+  sourceCardRef: RefObject<HTMLDivElement | null> | undefined,
+  isVisible: boolean,
+): void {
+  const visibility = isVisible ? "" : "hidden";
+  media.style.visibility = visibility;
+  if (sourceCardRef?.current) {
+    sourceCardRef.current.style.visibility = visibility;
+  }
 }

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/BackgroundFramingPreview.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/BackgroundFramingPreview.tsx
@@ -1,0 +1,114 @@
+import type { BackgroundFramingSettings } from "@guerillaglass/engine-contract/shared/valueObjects";
+import { useCallback, useMemo, useSyncExternalStore, type ReactNode, type Ref } from "react";
+import {
+  computeBackgroundFramingGeometry,
+  type RenderSize,
+} from "../domain/backgroundFramingGeometry";
+
+const emptySize: RenderSize = Object.freeze({ width: 0, height: 0 });
+
+class ElementSizeStore {
+  private element: HTMLElement | null = null;
+  private observer: ResizeObserver | null = null;
+  private snapshot: RenderSize = emptySize;
+  private readonly listeners = new Set<() => void>();
+
+  readonly subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  };
+
+  readonly getSnapshot = (): RenderSize => this.snapshot;
+
+  readonly setElement = (element: HTMLElement | null): void => {
+    if (this.element === element) {
+      return;
+    }
+    this.observer?.disconnect();
+    this.element = element;
+    this.observer = null;
+    if (!element) {
+      this.update(emptySize);
+      return;
+    }
+
+    this.measure(element);
+    this.observer = new ResizeObserver(() => this.measure(element));
+    this.observer.observe(element);
+  };
+
+  private measure(element: HTMLElement): void {
+    const bounds = element.getBoundingClientRect();
+    this.update({ width: bounds.width, height: bounds.height });
+  }
+
+  private update(size: RenderSize): void {
+    if (size.width === this.snapshot.width && size.height === this.snapshot.height) {
+      return;
+    }
+    this.snapshot = Object.freeze(size);
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+}
+
+type BackgroundFramingPreviewProps = {
+  settings: BackgroundFramingSettings;
+  outputSize: RenderSize;
+  sourceSize: RenderSize;
+  cardRef?: Ref<HTMLDivElement>;
+  children: ReactNode;
+};
+
+export function BackgroundFramingPreview({
+  settings,
+  outputSize,
+  sourceSize,
+  cardRef,
+  children,
+}: BackgroundFramingPreviewProps) {
+  const sizeStore = useMemo(() => new ElementSizeStore(), []);
+  const measuredSize = useSyncExternalStore(
+    sizeStore.subscribe,
+    sizeStore.getSnapshot,
+    () => emptySize,
+  );
+  const setStageElement = useCallback(
+    (element: HTMLDivElement | null) => sizeStore.setElement(element),
+    [sizeStore],
+  );
+  const geometry = computeBackgroundFramingGeometry(outputSize, sourceSize, settings);
+  const scale = measuredSize.width > 0 ? measuredSize.width / outputSize.width : 0;
+  const card = geometry?.cardRect;
+
+  return (
+    <div
+      ref={setStageElement}
+      className="relative h-full w-full overflow-hidden rounded-md"
+      data-testid="background-framing-stage"
+      data-framing-enabled={settings.enabled}
+      style={{ backgroundColor: settings.enabled ? settings.backgroundColor : undefined }}
+    >
+      {card ? (
+        <div
+          ref={cardRef}
+          className="absolute overflow-hidden"
+          data-testid="background-framing-card"
+          style={{
+            left: card.x * scale,
+            top: card.y * scale,
+            width: card.width * scale,
+            height: card.height * scale,
+            borderRadius: (geometry?.cornerRadius ?? 0) * scale,
+            boxShadow: settings.enabled
+              ? `${(geometry?.shadowOffsetX ?? 0) * scale}px ${(geometry?.shadowOffsetY ?? 0) * scale}px ${(geometry?.shadowBlurRadius ?? 0) * scale}px rgba(0, 0, 0, ${geometry?.shadowOpacity ?? 0})`
+              : undefined,
+          }}
+        >
+          {children}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorModeContent.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorModeContent.tsx
@@ -4,6 +4,7 @@ import { buildCaptureTelemetryPresentation } from "../../view-model/captureTelem
 import type { StudioController } from "../../hooks/core/useStudioController";
 import {
   AudioMixerChannel,
+  InspectorColorField,
   InspectorDetailRows,
   InspectorNumericField,
   InspectorOptionCard,
@@ -19,6 +20,7 @@ import { ShortcutOverridesSection } from "./ShortcutOverridesSection";
 type InspectorModeStudio = Pick<
   StudioController,
   | "audioMixer"
+  | "backgroundFramingSupported"
   | "captureStatusQuery"
   | "exportForm"
   | "formatAspectRatio"
@@ -137,6 +139,63 @@ function AutoZoomSection({
   );
 }
 
+function BackgroundFramingSection({ studio }: { studio: InspectorModeStudio }) {
+  return (
+    <studio.settingsForm.Field name="backgroundFraming">
+      {(field) => (
+        <div className="space-y-2 px-0.5">
+          <p className="gg-utility-label">{studio.ui.labels.backgroundFraming}</p>
+          <InspectorToggleField
+            label={studio.ui.labels.backgroundFraming}
+            checked={field.state.value.enabled}
+            onCheckedChange={(enabled) => field.handleChange({ ...field.state.value, enabled })}
+          />
+          <InspectorColorField
+            label={studio.ui.labels.backgroundColor}
+            value={field.state.value.backgroundColor}
+            onValueChange={(backgroundColor) =>
+              field.handleChange({ ...field.state.value, backgroundColor })
+            }
+          />
+          <InspectorSliderField
+            label={studio.ui.labels.backgroundPadding}
+            value={field.state.value.paddingFraction}
+            displayValue={`${Math.round(field.state.value.paddingFraction * 100)}%`}
+            min={0}
+            max={0.25}
+            step={0.01}
+            onValueChange={(paddingFraction) =>
+              field.handleChange({ ...field.state.value, paddingFraction })
+            }
+          />
+          <InspectorSliderField
+            label={studio.ui.labels.cornerRoundness}
+            value={field.state.value.cornerRadiusFraction}
+            displayValue={`${Math.round(field.state.value.cornerRadiusFraction * 1000) / 10}%`}
+            min={0}
+            max={0.1}
+            step={0.005}
+            onValueChange={(cornerRadiusFraction) =>
+              field.handleChange({ ...field.state.value, cornerRadiusFraction })
+            }
+          />
+          <InspectorSliderField
+            label={studio.ui.labels.shadowStrength}
+            value={field.state.value.shadowStrength}
+            displayValue={`${Math.round(field.state.value.shadowStrength * 100)}%`}
+            min={0}
+            max={1}
+            step={0.05}
+            onValueChange={(shadowStrength) =>
+              field.handleChange({ ...field.state.value, shadowStrength })
+            }
+          />
+        </div>
+      )}
+    </studio.settingsForm.Field>
+  );
+}
+
 export function CaptureInspectorContent({ studio }: { studio: InspectorModeStudio }) {
   const captureSource = studio.settingsForm.state.values.captureSource;
   const telemetry = studio.captureStatusQuery.data?.telemetry;
@@ -248,6 +307,7 @@ export function CaptureInspectorContent({ studio }: { studio: InspectorModeStudi
           showAudioMixer
           sliderClassName="gg-inspector-slider"
         />
+        {studio.backgroundFramingSupported ? <BackgroundFramingSection studio={studio} /> : null}
       </InspectorSection>
 
       <InspectorSection title={studio.ui.inspectorTabs.advanced.toUpperCase()}>
@@ -284,6 +344,7 @@ export function EditInspectorContent({ studio }: { studio: InspectorModeStudio }
 
       <InspectorSection title={studio.ui.inspectorTabs.effects.toUpperCase()}>
         <AutoZoomSection studio={studio} headingIcon={<Sparkles className="h-3.5 w-3.5" />} />
+        {studio.backgroundFramingSupported ? <BackgroundFramingSection studio={studio} /> : null}
       </InspectorSection>
     </>
   );

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorPrimitives.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/inspector/InspectorPrimitives.tsx
@@ -105,6 +105,7 @@ export function InspectorSliderField({
         </FieldLabel>
         <FieldContent>
           <Slider
+            aria-label={label}
             className={className}
             min={min}
             max={max}
@@ -152,6 +153,36 @@ export function InspectorSelectField({
             </SelectContent>
           </Select>
         </FieldContent>
+      </Field>
+    </InspectorOptionCard>
+  );
+}
+
+export function InspectorColorField({
+  label,
+  value,
+  onValueChange,
+}: {
+  label: string;
+  value: string;
+  onValueChange: (value: string) => void;
+}) {
+  return (
+    <InspectorOptionCard>
+      <Field>
+        <FieldLabel className="flex w-full items-center justify-between gap-3 border-0 px-0 py-0">
+          <span className="gg-copy-strong">{label}</span>
+          <span className="flex items-center gap-2">
+            <span className="gg-copy-meta font-mono">{value}</span>
+            <Input
+              type="color"
+              aria-label={label}
+              value={value}
+              className="h-8 w-10 cursor-pointer p-1"
+              onChange={(event) => onValueChange(event.target.value.toUpperCase())}
+            />
+          </span>
+        </FieldLabel>
       </Field>
     </InspectorOptionCard>
   );
@@ -252,6 +283,7 @@ export function AudioMixerChannel({
       />
       <Progress value={Math.round(level * 100)} />
       <Slider
+        aria-label={label}
         className="gg-inspector-slider"
         min={0}
         max={1}

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { ScreenShare, ShieldCheck } from "lucide-react";
 import { AspectRatio } from "@guerillaglass/ui/components/aspect-ratio";
 import { Button } from "@guerillaglass/ui/components/button";
@@ -18,6 +19,7 @@ import { cn } from "@guerillaglass/ui";
 import { useStudio } from "../state/StudioProvider";
 import { EditorWorkspace } from "../layout/EditorWorkspace";
 import { InspectorPanel } from "../panels/InspectorPanel";
+import { BackgroundFramingPreview } from "../panels/BackgroundFramingPreview";
 import { useLiveCapturePreview } from "../hooks/useLiveCapturePreview";
 import {
   useRecordingMediaSourceErrorRecovery,
@@ -48,6 +50,10 @@ export function CaptureRoute() {
     recordingMediaSource,
     refreshRecordingMediaSource,
   );
+  const [sourceSize, setSourceSize] = useState({ width: 1920, height: 1080 });
+  const outputSize = studio.selectedPreset
+    ? { width: studio.selectedPreset.width, height: studio.selectedPreset.height }
+    : { width: 1920, height: 1080 };
   const isCaptureRunning = Boolean(studio.captureStatusQuery.data?.isRunning);
   const captureSessionId = isCaptureRunning
     ? (studio.captureStatusQuery.data?.captureSessionId ?? null)
@@ -258,53 +264,98 @@ export function CaptureRoute() {
           <StudioPaneBody className="gg-preview-pane-body">
             <div className="gg-preview-workspace">
               <div className="gg-preview-stage-wrap">
-                <AspectRatio ratio={16 / 9} className="h-auto w-auto">
+                <AspectRatio
+                  ratio={outputSize.width / outputSize.height}
+                  className={cn(
+                    "max-h-full max-w-[1000px]",
+                    outputSize.width >= outputSize.height ? "w-full" : "h-full w-auto",
+                  )}
+                >
                   <div className="gg-preview-stage">
-                    {isCaptureRunning ? (
-                      <div className="relative h-full w-full overflow-hidden rounded-md">
-                        <img
-                          ref={liveCapturePreviewImageRef}
-                          alt={studio.ui.helper.activePreviewTitle}
-                          className={cn(
-                            "h-full w-full object-contain",
-                            liveCapturePreviewHasFrame ? "block" : "hidden",
-                          )}
-                        />
-                        {!liveCapturePreviewHasFrame ? (
-                          <div className="flex h-full w-full items-center justify-center text-center">
-                            <p className="text-sm font-medium">
-                              {studio.ui.helper.activePreviewTitle}
-                            </p>
-                          </div>
-                        ) : null}
+                    <studio.settingsForm.Field name="backgroundFraming">
+                      {(field) => (
+                        <BackgroundFramingPreview
+                          settings={
+                            studio.backgroundFramingSupported
+                              ? field.state.value
+                              : { ...field.state.value, enabled: false }
+                          }
+                          outputSize={outputSize}
+                          sourceSize={sourceSize}
+                        >
+                          {isCaptureRunning ? (
+                            <div className="relative h-full w-full overflow-hidden">
+                              <img
+                                ref={liveCapturePreviewImageRef}
+                                alt={studio.ui.helper.activePreviewTitle}
+                                className={cn(
+                                  "h-full w-full object-contain",
+                                  liveCapturePreviewHasFrame ? "block" : "hidden",
+                                )}
+                                onLoad={(event) => {
+                                  const image = event.currentTarget;
+                                  if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+                                    setSourceSize((current) =>
+                                      current.width === image.naturalWidth &&
+                                      current.height === image.naturalHeight
+                                        ? current
+                                        : {
+                                            width: image.naturalWidth,
+                                            height: image.naturalHeight,
+                                          },
+                                    );
+                                  }
+                                }}
+                              />
+                              {!liveCapturePreviewHasFrame ? (
+                                <div className="flex h-full w-full items-center justify-center text-center">
+                                  <p className="text-sm font-medium">
+                                    {studio.ui.helper.activePreviewTitle}
+                                  </p>
+                                </div>
+                              ) : null}
 
-                        {studio.captureStatusQuery.data?.isRecording ? (
-                          <div className="pointer-events-none absolute top-4 left-4 flex items-center gap-2 rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-white shadow-lg ring-1 ring-white/15 backdrop-blur-sm">
-                            <span className="h-2 w-2 rounded-full bg-red-500" />
-                            {studio.ui.labels.recording}
-                          </div>
-                        ) : null}
-                      </div>
-                    ) : recordingMediaSource ? (
-                      <video
-                        key={recordingMediaSource}
-                        src={recordingMediaSource}
-                        className="h-full w-full rounded-md object-contain"
-                        preload="metadata"
-                        controls
-                        playsInline
-                        onError={handleMediaError}
-                      />
-                    ) : (
-                      <Empty className="max-w-lg border-0 bg-transparent p-6">
-                        <EmptyHeader>
-                          <EmptyTitle className="text-sm">
-                            {studio.ui.helper.emptyPreviewTitle}
-                          </EmptyTitle>
-                          <EmptyDescription>{studio.ui.helper.emptyPreviewBody}</EmptyDescription>
-                        </EmptyHeader>
-                      </Empty>
-                    )}
+                              {studio.captureStatusQuery.data?.isRecording ? (
+                                <div className="pointer-events-none absolute top-4 left-4 flex items-center gap-2 rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-white shadow-lg ring-1 ring-white/15 backdrop-blur-sm">
+                                  <span className="h-2 w-2 rounded-full bg-red-500" />
+                                  {studio.ui.labels.recording}
+                                </div>
+                              ) : null}
+                            </div>
+                          ) : recordingMediaSource ? (
+                            <video
+                              key={recordingMediaSource}
+                              src={recordingMediaSource}
+                              className="h-full w-full object-contain"
+                              preload="metadata"
+                              controls
+                              playsInline
+                              onLoadedMetadata={(event) => {
+                                const video = event.currentTarget;
+                                if (video.videoWidth > 0 && video.videoHeight > 0) {
+                                  setSourceSize({
+                                    width: video.videoWidth,
+                                    height: video.videoHeight,
+                                  });
+                                }
+                              }}
+                              onError={handleMediaError}
+                            />
+                          ) : (
+                            <Empty className="h-full border-0 bg-transparent p-6">
+                              <EmptyHeader>
+                                <EmptyTitle className="text-sm">
+                                  {studio.ui.helper.emptyPreviewTitle}
+                                </EmptyTitle>
+                                <EmptyDescription>
+                                  {studio.ui.helper.emptyPreviewBody}
+                                </EmptyDescription>
+                              </EmptyHeader>
+                            </Empty>
+                          )}
+                        </BackgroundFramingPreview>
+                      )}
+                    </studio.settingsForm.Field>
                   </div>
                 </AspectRatio>
               </div>

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/EditRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/EditRoute.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import { useRef, useState } from "react";
 import { AspectRatio } from "@guerillaglass/ui/components/aspect-ratio";
 import {
   Empty,
@@ -11,6 +11,7 @@ import { EditorWorkspace } from "../layout/EditorWorkspace";
 import { InspectorPanel } from "../panels/InspectorPanel";
 import { TimelineDock } from "../panels/TimelineDock";
 import { ProjectUtilityPanel } from "../panels/ProjectUtilityPanel";
+import { BackgroundFramingPreview } from "../panels/BackgroundFramingPreview";
 import { formatCaptureTargetLabelFromMetadata } from "../view-model/captureTargetLabelFormatter";
 import {
   useRecordingMediaSourceErrorRecovery,
@@ -35,6 +36,7 @@ export function EditRoute() {
     setDisplayPlayheadSecondsFromMedia,
     projectQuery,
     recordingURL,
+    selectedPreset,
     setPlayheadSecondsFromMedia,
     setTimelinePlaybackActive,
     timelineDuration,
@@ -42,6 +44,11 @@ export function EditRoute() {
     ui,
   } = studio;
   const mediaRef = useRef<HTMLVideoElement | null>(null);
+  const sourceCardRef = useRef<HTMLDivElement | null>(null);
+  const [sourceSize, setSourceSize] = useState({ width: 1920, height: 1080 });
+  const outputSize = selectedPreset
+    ? { width: selectedPreset.width, height: selectedPreset.height }
+    : { width: 1920, height: 1080 };
   const { source: recordingMediaSource, refresh: refreshRecordingMediaSource } =
     useRecordingMediaSourceLease(recordingURL);
   const handleMediaError = useRecordingMediaSourceErrorRecovery(
@@ -60,6 +67,7 @@ export function EditRoute() {
 
   useVideoPlaybackSync({
     mediaRef,
+    sourceCardRef,
     playbackStore,
     recordingMediaSource,
     timelineItems,
@@ -84,38 +92,69 @@ export function EditRoute() {
           </StudioPaneHeader>
           <StudioPaneBody className="flex min-h-0 flex-col gap-4">
             <div className="flex min-h-0 flex-1 items-center justify-center overflow-hidden">
-              <AspectRatio ratio={16 / 9} className="h-full w-auto max-h-full max-w-[1000px]">
+              <AspectRatio
+                ratio={outputSize.width / outputSize.height}
+                className="h-full w-auto max-h-full max-w-[1000px]"
+              >
                 <div className="gg-preview-stage">
-                  {recordingMediaSource ? (
-                    <video
-                      ref={mediaRef}
-                      key={recordingMediaSource}
-                      src={recordingMediaSource}
-                      className="h-full w-full rounded-md object-contain"
-                      preload="metadata"
-                      controls
-                      playsInline
-                      onPlay={() => {
-                        setTimelinePlaybackActive(true);
-                      }}
-                      onPause={() => {
-                        setTimelinePlaybackActive(false);
-                      }}
-                      onError={handleMediaError}
-                    />
-                  ) : captureStatusQuery.data?.isRunning ? (
-                    <div className="space-y-2">
-                      <p className="text-sm font-medium">{ui.helper.activePreviewTitle}</p>
-                      <p className="text-xs text-muted-foreground">{ui.helper.activePreviewBody}</p>
-                    </div>
-                  ) : (
-                    <Empty className="max-w-md border-border/70 bg-background/70 p-6">
-                      <EmptyHeader>
-                        <EmptyTitle className="text-sm">{ui.helper.emptyPreviewTitle}</EmptyTitle>
-                        <EmptyDescription>{ui.helper.emptyPreviewBody}</EmptyDescription>
-                      </EmptyHeader>
-                    </Empty>
-                  )}
+                  <studio.settingsForm.Field name="backgroundFraming">
+                    {(field) => (
+                      <BackgroundFramingPreview
+                        settings={
+                          studio.backgroundFramingSupported
+                            ? field.state.value
+                            : { ...field.state.value, enabled: false }
+                        }
+                        outputSize={outputSize}
+                        sourceSize={sourceSize}
+                        cardRef={sourceCardRef}
+                      >
+                        {recordingMediaSource ? (
+                          <video
+                            ref={mediaRef}
+                            key={recordingMediaSource}
+                            src={recordingMediaSource}
+                            className="h-full w-full object-contain"
+                            preload="metadata"
+                            controls
+                            playsInline
+                            onLoadedMetadata={(event) => {
+                              const video = event.currentTarget;
+                              if (video.videoWidth > 0 && video.videoHeight > 0) {
+                                setSourceSize({
+                                  width: video.videoWidth,
+                                  height: video.videoHeight,
+                                });
+                              }
+                            }}
+                            onPlay={() => {
+                              setTimelinePlaybackActive(true);
+                            }}
+                            onPause={() => {
+                              setTimelinePlaybackActive(false);
+                            }}
+                            onError={handleMediaError}
+                          />
+                        ) : captureStatusQuery.data?.isRunning ? (
+                          <div className="flex h-full flex-col items-center justify-center space-y-2 text-center">
+                            <p className="text-sm font-medium">{ui.helper.activePreviewTitle}</p>
+                            <p className="text-xs text-muted-foreground">
+                              {ui.helper.activePreviewBody}
+                            </p>
+                          </div>
+                        ) : (
+                          <Empty className="h-full border-border/70 bg-background/70 p-6">
+                            <EmptyHeader>
+                              <EmptyTitle className="text-sm">
+                                {ui.helper.emptyPreviewTitle}
+                              </EmptyTitle>
+                              <EmptyDescription>{ui.helper.emptyPreviewBody}</EmptyDescription>
+                            </EmptyHeader>
+                          </Empty>
+                        )}
+                      </BackgroundFramingPreview>
+                    )}
+                  </studio.settingsForm.Field>
                 </div>
               </AspectRatio>
             </div>

--- a/apps/desktop-electrobun/src/mainview/lib/engine.ts
+++ b/apps/desktop-electrobun/src/mainview/lib/engine.ts
@@ -12,7 +12,7 @@ import {
   type CaptureFrameRate,
   type SourcesResult,
 } from "@guerillaglass/engine-contract/domains/sources";
-import type { PingResult } from "@guerillaglass/engine-contract/domains/system";
+import type { CapabilitiesResult, PingResult } from "@guerillaglass/engine-contract/domains/system";
 import {
   inputEventLogSchema,
   type AutoZoomSettings,
@@ -116,6 +116,10 @@ function isMacOS13WindowPickerUnsupported(error: unknown): boolean {
 export const engineApi = {
   async ping(): Promise<PingResult> {
     return await invokeBridgeContract("ggEnginePing", "engine ping result");
+  },
+
+  async capabilities(): Promise<CapabilitiesResult> {
+    return await invokeBridgeContract("ggEngineCapabilities", "engine capabilities result");
   },
 
   async getPermissions(): Promise<PermissionsResult> {

--- a/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
+++ b/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
@@ -37,7 +37,12 @@ import {
   type CaptureFrameRate,
   type SourcesResult,
 } from "@guerillaglass/engine-contract/domains/sources";
-import { pingResultSchema, type PingResult } from "@guerillaglass/engine-contract/domains/system";
+import {
+  capabilitiesResultSchema,
+  pingResultSchema,
+  type CapabilitiesResult,
+  type PingResult,
+} from "@guerillaglass/engine-contract/domains/system";
 import type {
   AutoZoomSettings,
   TimelineDocument,
@@ -243,6 +248,7 @@ const engineProjectRecentsBridgeParamsSchema = Schema.Struct({
 });
 const engineSuccessSchemas = {
   "system.ping": pingResultSchema,
+  "system.capabilities": capabilitiesResultSchema,
   "permissions.get": permissionsResultSchema,
   "agent.preflight": agentPreflightResultSchema,
   "agent.run": agentRunResultSchema,
@@ -422,6 +428,11 @@ export const bridgeRequestDefinitions = {
     () => undefined,
     undefinedBridgeParamsSchema,
     engineSuccessSchema("system.ping"),
+  ),
+  ggEngineCapabilities: defineValidatedBridgeRequest<undefined, CapabilitiesResult, []>(
+    () => undefined,
+    undefinedBridgeParamsSchema,
+    engineSuccessSchema("system.capabilities"),
   ),
   ggEngineGetPermissions: defineValidatedBridgeRequest<undefined, PermissionsResult, []>(
     () => undefined,

--- a/apps/desktop-electrobun/src/shared/localization.ts
+++ b/apps/desktop-electrobun/src/shared/localization.ts
@@ -194,6 +194,7 @@ export function getStudioMessages(locale: string | null | undefined) {
       autoZoomIntensity: (value: number) => m.studio_labels_autoZoomIntensity({ value }, options),
       minimumKeyframeInterval: m.studio_labels_minimumKeyframeInterval(undefined, options),
       backgroundFraming: m.studio_labels_backgroundFraming(undefined, options),
+      backgroundColor: m.studio_labels_backgroundColor(undefined, options),
       backgroundPadding: m.studio_labels_backgroundPadding(undefined, options),
       cornerRoundness: m.studio_labels_cornerRoundness(undefined, options),
       shadowStrength: m.studio_labels_shadowStrength(undefined, options),

--- a/apps/desktop-electrobun/tests/background-framing-geometry.test.ts
+++ b/apps/desktop-electrobun/tests/background-framing-geometry.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import {
+  computeBackgroundFramingGeometry,
+  type RenderSize,
+} from "../src/mainview/app/studio/domain/backgroundFramingGeometry";
+import {
+  defaultBackgroundFramingSettings,
+  type BackgroundFramingSettings,
+} from "@guerillaglass/engine-contract/shared/valueObjects";
+
+const enabledSettings: BackgroundFramingSettings = {
+  ...defaultBackgroundFramingSettings,
+  enabled: true,
+};
+
+function geometry(outputSize: RenderSize, sourceSize: RenderSize = { width: 1920, height: 1080 }) {
+  const result = computeBackgroundFramingGeometry(outputSize, sourceSize, enabledSettings);
+  expect(result).not.toBeNull();
+  return result!;
+}
+
+describe("background framing geometry", () => {
+  it("matches the v1 landscape geometry vector", () => {
+    const result = geometry({ width: 1920, height: 1080 });
+
+    expect(result.cardRect.x).toBeCloseTo(115.2, 8);
+    expect(result.cardRect.y).toBeCloseTo(64.8, 8);
+    expect(result.cardRect.width).toBeCloseTo(1689.6, 8);
+    expect(result.cardRect.height).toBeCloseTo(950.4, 8);
+    expect(result.cornerRadius).toBeCloseTo(23.76, 8);
+    expect(result.shadowOpacity).toBeCloseTo(0.105, 8);
+    expect(result.shadowBlurRadius).toBeCloseTo(13.23, 8);
+    expect(result.shadowOffsetY).toBeCloseTo(4.536, 8);
+  });
+
+  it("aspect fits landscape content into a vertical output without cropping", () => {
+    const result = geometry({ width: 1080, height: 1920 });
+
+    expect(result.cardRect.x).toBeCloseTo(64.8, 8);
+    expect(result.cardRect.y).toBeCloseTo(692.7, 8);
+    expect(result.cardRect.width).toBeCloseTo(950.4, 8);
+    expect(result.cardRect.height).toBeCloseTo(534.6, 8);
+    expect(result.cardRect.width / result.cardRect.height).toBeCloseTo(16 / 9, 8);
+  });
+
+  it("keeps the legacy full-frame fit while disabled", () => {
+    const result = computeBackgroundFramingGeometry(
+      { width: 1920, height: 1080 },
+      { width: 1920, height: 1080 },
+      defaultBackgroundFramingSettings,
+    );
+
+    expect(result?.cardRect).toEqual({ x: 0, y: 0, width: 1920, height: 1080 });
+    expect(result?.cornerRadius).toBe(0);
+    expect(result?.shadowOpacity).toBe(0);
+  });
+
+  it("rejects empty and non-finite render dimensions", () => {
+    expect(
+      computeBackgroundFramingGeometry(
+        { width: 0, height: 1080 },
+        { width: 1920, height: 1080 },
+        enabledSettings,
+      ),
+    ).toBeNull();
+    expect(
+      computeBackgroundFramingGeometry(
+        { width: 1920, height: 1080 },
+        { width: Number.POSITIVE_INFINITY, height: 1080 },
+        enabledSettings,
+      ),
+    ).toBeNull();
+  });
+});

--- a/apps/desktop-electrobun/tests/engine-api.test.ts
+++ b/apps/desktop-electrobun/tests/engine-api.test.ts
@@ -125,6 +125,15 @@ describe("renderer engine bridge", () => {
         protocolVersion: "2",
         platform: "macOS",
       }),
+      ggEngineCapabilities: async () => ({
+        protocolVersion: "2",
+        platform: "macos",
+        phase: "native",
+        capture: { display: true, window: true, systemAudio: true, microphone: true },
+        recording: { inputTracking: true },
+        export: { presets: true, cutPlan: true, backgroundFraming: true },
+        project: { openSave: true },
+      }),
       ggEngineGetPermissions: async () => ({
         screenRecordingGranted: true,
         microphoneGranted: false,
@@ -285,6 +294,7 @@ describe("renderer engine bridge", () => {
     };
 
     const ping = await engineApi.ping();
+    const capabilities = await engineApi.capabilities();
     const permissions = await engineApi.getPermissions();
     const requestedScreenPermission = await engineApi.requestScreenRecordingPermission();
     const requestedMicPermission = await engineApi.requestMicrophonePermission();
@@ -335,6 +345,7 @@ describe("renderer engine bridge", () => {
     const events = parseInputEventLog(eventsRaw);
 
     expect(ping.protocolVersion).toBe("2");
+    expect(capabilities.export.backgroundFraming).toBe(true);
     expect(permissions.inputMonitoring).toBe("granted");
     expect(requestedScreenPermission.success).toBe(true);
     expect(requestedMicPermission.success).toBe(true);

--- a/apps/desktop-electrobun/tests/parity-e2e.test.ts
+++ b/apps/desktop-electrobun/tests/parity-e2e.test.ts
@@ -93,6 +93,7 @@ describe("engine HTTP parity e2e", () => {
 
             const capabilities = yield* engine.engineCapabilities;
             expect(capabilities.platform).toBe(fixture.expectedPlatform);
+            expect(capabilities.export.backgroundFraming).toBe(false);
 
             const sources = yield* engine.sourcesList;
             expect(sources.displays.length).toBeGreaterThan(0);

--- a/apps/desktop-electrobun/tests/playback-clock-source.test.ts
+++ b/apps/desktop-electrobun/tests/playback-clock-source.test.ts
@@ -27,7 +27,7 @@ describe("video playback clock source", () => {
     const source = await readFile(playbackSyncPath, "utf8");
 
     expect(source).toContain(
-      'if (boundaryResolution.kind === "gap") {\n          media.pause();\n          media.style.visibility = "hidden";\n          setPlayheadSecondsFromMedia(boundarySeconds);',
+      'if (boundaryResolution.kind === "gap") {\n          media.pause();\n          setSourceVisibility(media, sourceCardRef, false);\n          setPlayheadSecondsFromMedia(boundarySeconds);',
     );
   });
 });

--- a/apps/desktop-electrobun/tests/ui/editor-export-timeline.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/editor-export-timeline.browser.test.tsx
@@ -12,6 +12,7 @@ import {
   useStudioController,
   type StudioController,
 } from "../../src/mainview/app/studio/hooks/core/useStudioController";
+import { studioQueryKeys } from "../../src/mainview/app/studio/hooks/core/useStudioDataQueries";
 
 const initialTimeline: TimelineDocument = {
   version: 2,
@@ -39,6 +40,15 @@ function installMockBridge() {
     engineVersion: "0.1.0",
     protocolVersion: "1.0.0",
     platform: "darwin",
+  });
+  bridgeWindow.ggEngineCapabilities = async () => ({
+    protocolVersion: "1.0.0",
+    phase: "native",
+    platform: "macos",
+    capture: { display: true, window: true, systemAudio: true, microphone: true },
+    recording: { inputTracking: true },
+    export: { presets: true, cutPlan: true, backgroundFraming: true },
+    project: { openSave: true },
   });
   bridgeWindow.ggEngineGetPermissions = async () => ({
     screenRecordingGranted: true,
@@ -222,6 +232,54 @@ describe("editor timeline export integration", () => {
     expect(capturedExportParams).toMatchObject({
       backgroundFraming: defaultBackgroundFramingSettings,
     });
+  });
+
+  test("exports complete unsaved background framing settings", async () => {
+    await waitFor(() => expect(latestStudio?.selectedPreset?.id).toBe("h264-1080p-30"));
+    const backgroundFraming = {
+      version: 1 as const,
+      enabled: true,
+      backgroundColor: "#204060",
+      paddingFraction: 0.12,
+      cornerRadiusFraction: 0.05,
+      shadowStrength: 0.7,
+    };
+    await applyStudioAction((studio) => {
+      studio.settingsForm.setFieldValue("backgroundFraming", backgroundFraming);
+    });
+    await applyStudioAction(async (studio) => studio.exportMutation.mutateAsync());
+
+    expect(capturedExportParams).toMatchObject({ backgroundFraming });
+  });
+
+  test("project switches replace unsaved framing even when persisted values match", async () => {
+    await waitFor(() =>
+      expect(latestStudio?.settingsForm.state.values.backgroundFraming).toEqual(
+        defaultBackgroundFramingSettings,
+      ),
+    );
+    await applyStudioAction((studio) => {
+      studio.settingsForm.setFieldValue("backgroundFraming", {
+        ...defaultBackgroundFramingSettings,
+        enabled: true,
+      });
+    });
+
+    await act(async () => {
+      queryClient?.setQueryData(studioQueryKeys.projectCurrent(), {
+        projectPath: "/tmp/project-b.gglassproj",
+        recordingURL: "/tmp/recording.mov",
+        autoZoom: { isEnabled: true, intensity: 1, minimumKeyframeInterval: 1 / 30 },
+        backgroundFraming: defaultBackgroundFramingSettings,
+        timeline: initialTimeline,
+      });
+    });
+
+    await waitFor(() =>
+      expect(latestStudio?.settingsForm.state.values.backgroundFraming).toEqual(
+        defaultBackgroundFramingSettings,
+      ),
+    );
   });
 
   test("drag-drop non-ripple move splits gaps and synchronizes selection and playhead", async () => {

--- a/apps/desktop-electrobun/tests/ui/studio-shell.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/studio-shell.browser.test.tsx
@@ -2,7 +2,10 @@ import React from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, test } from "vitest";
 import { page } from "vitest/browser";
+import { defaultBackgroundFramingSettings } from "@guerillaglass/engine-contract/shared/valueObjects";
 import App from "../../src/mainview/App";
+
+let backgroundFramingSupported = true;
 
 const captureStatus = {
   isRunning: false,
@@ -20,6 +23,15 @@ function installMockBridge() {
     engineVersion: "0.1.0",
     protocolVersion: "1.0.0",
     platform: "darwin",
+  });
+  windowWithBridge.ggEngineCapabilities = async () => ({
+    protocolVersion: "1.0.0",
+    phase: "native",
+    platform: "macos",
+    capture: { display: true, window: true, systemAudio: true, microphone: true },
+    recording: { inputTracking: true },
+    export: { presets: true, cutPlan: true, backgroundFraming: backgroundFramingSupported },
+    project: { openSave: true },
   });
   windowWithBridge.ggEngineGetPermissions = async () => ({
     screenRecordingGranted: true,
@@ -102,18 +114,24 @@ function installMockBridge() {
   windowWithBridge.ggEngineProjectCurrent = async () => ({
     projectPath: null,
     autoZoom: { isEnabled: true, intensity: 1, minimumKeyframeInterval: 1 / 30 },
+    backgroundFraming: {
+      ...defaultBackgroundFramingSettings,
+      enabled: !backgroundFramingSupported,
+    },
   });
   windowWithBridge.ggEngineProjectOpen = async ({
     projectPath,
   }: { projectPath?: string } = {}) => ({
     projectPath: projectPath ?? "/tmp/mock.gglassproj",
     autoZoom: { isEnabled: true, intensity: 1, minimumKeyframeInterval: 1 / 30 },
+    backgroundFraming: defaultBackgroundFramingSettings,
   });
   windowWithBridge.ggEngineProjectSave = async ({
     projectPath,
   }: { projectPath?: string } = {}) => ({
     projectPath: projectPath ?? "/tmp/mock.gglassproj",
     autoZoom: { isEnabled: true, intensity: 1, minimumKeyframeInterval: 1 / 30 },
+    backgroundFraming: defaultBackgroundFramingSettings,
   });
   windowWithBridge.ggEngineProjectRecents = async () => ({ items: [] });
   windowWithBridge.ggResolveCapturePreviewURL = async () => null;
@@ -129,6 +147,7 @@ function installMockBridge() {
 let root: Root | undefined;
 
 beforeEach(() => {
+  backgroundFramingSupported = true;
   localStorage.clear();
   installMockBridge();
   document.body.innerHTML = '<div id="root"></div>';
@@ -143,6 +162,44 @@ afterEach(() => {
 });
 
 describe("studio shell browser smoke", () => {
+  test("background framing controls update the real preview stage", async () => {
+    await expect.element(page.getByTestId("background-framing-stage")).toBeVisible();
+    await page.getByRole("button", { name: "EFFECTS" }).click();
+    const framingToggle = page.getByRole("checkbox", { name: "Background framing" });
+    await expect.element(framingToggle).toBeVisible();
+    await framingToggle.click();
+
+    await expect
+      .element(page.getByTestId("background-framing-stage"))
+      .toHaveAttribute("data-framing-enabled", "true");
+    await expect.element(page.getByTestId("background-framing-card")).toBeVisible();
+    await expect
+      .element(page.getByRole("slider", { name: "Background padding" }))
+      .toBeInTheDocument();
+    await expect
+      .element(page.getByRole("slider", { name: "Corner roundness" }))
+      .toBeInTheDocument();
+    await expect.element(page.getByRole("slider", { name: "Shadow strength" })).toBeInTheDocument();
+    await page.screenshot({ path: "../../test-results/screenshots/background-framing.png" });
+  });
+
+  test("unsupported native renderers hide framing controls and keep preview disabled", async () => {
+    root?.unmount();
+    backgroundFramingSupported = false;
+    installMockBridge();
+    root = createRoot(document.getElementById("root")!);
+    root.render(<App />);
+
+    await expect.element(page.getByTestId("background-framing-stage")).toBeVisible();
+    await page.getByRole("button", { name: "EFFECTS" }).click();
+    await expect
+      .element(page.getByTestId("background-framing-stage"))
+      .toHaveAttribute("data-framing-enabled", "false");
+    await expect
+      .element(page.getByRole("checkbox", { name: "Background framing" }))
+      .not.toBeInTheDocument();
+  });
+
   test("renders shell and navigates capture/edit modes", async () => {
     await expect
       .element(page.getByRole("heading", { level: 1, name: "Guerillaglass" }))

--- a/apps/desktop-electrobun/tests/ui/video-playback-gaps.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/video-playback-gaps.browser.test.tsx
@@ -48,8 +48,10 @@ function Harness({
   duration?: number;
 }) {
   const mediaRef = useRef<HTMLVideoElement>(null);
+  const sourceCardRef = useRef<HTMLDivElement>(null);
   useVideoPlaybackSync({
     mediaRef,
+    sourceCardRef,
     playbackStore,
     recordingMediaSource: "recording",
     timelineItems: items,
@@ -58,7 +60,11 @@ function Harness({
     setDisplayPlayheadSecondsFromMedia: playbackStore.setDisplayTimeSeconds,
     setPlayheadSecondsFromMedia: playbackStore.seek,
   });
-  return <video ref={mediaRef} />;
+  return (
+    <div ref={sourceCardRef} data-testid="source-card">
+      <video ref={mediaRef} />
+    </div>
+  );
 }
 
 function runFrame(atMs: number) {
@@ -110,6 +116,9 @@ describe("timeline preview across gaps", () => {
     act(() => playbackStore.seek(2));
 
     expect(media.style.visibility).toBe("hidden");
+    expect(
+      document.querySelector<HTMLElement>("[data-testid='source-card']")?.style.visibility,
+    ).toBe("hidden");
     expect(media.currentTime).toBe(0.25);
   });
 
@@ -123,6 +132,9 @@ describe("timeline preview across gaps", () => {
     expect(playbackStore.getSnapshot().playheadSeconds).toBeCloseTo(0.6);
     expect(media.currentTime).toBeCloseTo(0.1);
     expect(media.style.visibility).toBe("");
+    expect(
+      document.querySelector<HTMLElement>("[data-testid='source-card']")?.style.visibility,
+    ).toBe("");
     expect(media.play).toHaveBeenCalled();
   });
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -190,7 +190,7 @@ Groundwork already present:
 
 - [x] Editor-first shell baseline exists (`Capture` / `Edit` / `Deliver`).
 - [x] Timeline toolbar and lane surface exist.
-- [x] Auto-zoom settings exist in the inspector; background-framing localization/scaffold labels exist for the pending contract and renderer slices.
+- [x] Auto-zoom and background-framing settings exist in the inspector with deterministic preview/export wiring.
 - [x] Deliver/export route exists as a local surface.
 - [x] Imported-transcript protocol groundwork exists for later caption/transcript editing.
 
@@ -288,7 +288,11 @@ Progress (current repo)
 
 - [x] Input Monitoring permission flow + event tracking
 - [x] Auto-zoom planning + constraints (planner + renderer wiring + UI tuning)
-- [ ] Background framing (contract/persistence complete; renderer pending)
+- [x] Background framing
+  - Versioned project-global settings drive the live Capture/Edit preview and macOS native export.
+  - Preview and export share golden geometry vectors for stage padding, aspect-fit card bounds, corner radius, and shadow formulas.
+  - Native export uses explicit sRGB stage color, rounded source masking, gap-aware shadow visibility, and cancellation-aware async export.
+  - Capability reporting enables framing only on the production macOS renderer; Rust foundation shells explicitly report it unsupported.
 - [ ] Vertical export with re-planned camera
 - [x] Live preview remains useful during recording
 - [x] Timeline v2 clip/gap data model implemented in contract, renderer, and Swift project state
@@ -308,7 +312,7 @@ Suggested Phase 2 PR slices:
 1. `phase2/timeline-v2-export-macos` — make macOS export honor timeline v2 edits, gaps, and program-time Deliver trims.
 2. `phase2/timeline-drag-move-gaps` — add drag-to-move, finish gap interaction/readability, and verify preview behavior across gaps.
 3. `phase2/background-framing-contract` — define persisted background framing/effects settings in the project/export contract per `docs/BACKGROUND_FRAMING_DESIGN.md` (implemented).
-4. `phase2/background-framing-renderer` — implement native export rendering for background stage, padding, rounded screen card, and shadow.
+4. `phase2/background-framing-renderer` — implement native export rendering for background stage, padding, rounded screen card, and shadow (implemented).
 5. `phase2/vertical-camera-replan` — make camera planning/export aspect-ratio-aware for 9:16 vertical output.
 6. `phase2/segment-camera-overrides` — add clip-level camera/keyframe override model and inspector controls.
 7. `phase2/crop-reframe-tool` — add deterministic crop/reframe controls with preview/export wiring.

--- a/engines/macos-swift/EngineService+Export.swift
+++ b/engines/macos-swift/EngineService+Export.swift
@@ -42,7 +42,8 @@ extension EngineService {
                 preset: preset,
                 trimRange: trimRange(start: payload.trimStartSeconds?.value1, end: payload.trimEndSeconds?.value1),
                 outputURL: URL(fileURLWithPath: payload.outputURL.value1),
-                timeline: exportTimeline(from: payload.timeline)
+                timeline: exportTimeline(from: payload.timeline),
+                backgroundFraming: resolvedBackgroundFraming
             )
             let jobId = "macos-export-\(UUID().uuidString)"
             latestExportJobId = jobId
@@ -53,6 +54,8 @@ extension EngineService {
                 status: .succeeded,
                 outputURL: .init(value1: exportedURL.path)
             ))))
+        } catch is CancellationError {
+            throw CancellationError()
         } catch let error as BackgroundFramingSettings.ValidationError {
             return .badRequest(.init(body: .json(badRequest(.invalid_params, error.localizedDescription))))
         } catch let error as ExportPipeline.ExportError {
@@ -81,17 +84,21 @@ extension EngineService {
                 recordingURL: recordingURL,
                 preset: preset,
                 trimRange: nil,
-                outputURL: URL(fileURLWithPath: payload.outputURL.value1)
+                outputURL: URL(fileURLWithPath: payload.outputURL.value1),
+                backgroundFraming: currentProjectDocument.project.backgroundFraming
             )
             let jobId = "macos-export-cut-plan-\(UUID().uuidString)"
             latestExportJobId = jobId
             latestExportOutputURL = exportedURL
+            latestExportBackgroundFraming = currentProjectDocument.project.backgroundFraming
             return .ok(.init(body: .json(.init(
                 jobId: .init(value1: jobId),
                 status: .succeeded,
                 outputURL: .init(value1: exportedURL.path),
                 appliedSegments: .init(value1: Double(currentProjectDocument.project.timeline.items.count))
             ))))
+        } catch is CancellationError {
+            throw CancellationError()
         } catch {
             return .badRequest(.init(body: .json(badRequest(.invalid_request, error.localizedDescription))))
         }

--- a/engines/macos-swift/EngineService+System.swift
+++ b/engines/macos-swift/EngineService+System.swift
@@ -22,7 +22,7 @@ extension EngineService {
             phase: .native,
             capture: .init(display: true, window: true, systemAudio: true, microphone: true),
             recording: .init(inputTracking: true),
-            export: .init(presets: true, cutPlan: true),
+            export: .init(presets: true, cutPlan: true, backgroundFraming: true),
             project: .init(openSave: true),
             agent: .init(
                 preflight: true,

--- a/engines/macos-swift/modules/export/ExportPipeline.swift
+++ b/engines/macos-swift/modules/export/ExportPipeline.swift
@@ -2,18 +2,11 @@ import Automation
 import AVFoundation
 import Darwin
 import Foundation
+import Project
 import Rendering
 
 /// Public class exposed by the macOS engine module.
 public final class ExportPipeline {
-    private final class ExportSessionBox: @unchecked Sendable {
-        let session: AVAssetExportSession
-
-        init(_ session: AVAssetExportSession) {
-            self.session = session
-        }
-    }
-
     private let renderer = ExportRenderer()
 
     public enum ExportError: LocalizedError {
@@ -44,7 +37,8 @@ public final class ExportPipeline {
         trimRange: CMTimeRange?,
         outputURL: URL,
         cameraPlan: CameraPlan? = nil,
-        timeline: ExportTimelineDocument? = nil
+        timeline: ExportTimelineDocument? = nil,
+        backgroundFraming: BackgroundFramingSettings = .defaults
     ) async throws -> URL {
         let asset = AVAsset(url: recordingURL)
         return try await export(
@@ -53,7 +47,8 @@ public final class ExportPipeline {
             trimRange: trimRange,
             outputURL: outputURL,
             cameraPlan: cameraPlan,
-            timeline: timeline
+            timeline: timeline,
+            backgroundFraming: backgroundFraming
         )
     }
 
@@ -63,7 +58,8 @@ public final class ExportPipeline {
         trimRange: CMTimeRange?,
         outputURL: URL,
         cameraPlan: CameraPlan? = nil,
-        timeline: ExportTimelineDocument? = nil
+        timeline: ExportTimelineDocument? = nil,
+        backgroundFraming: BackgroundFramingSettings = .defaults
     ) async throws -> URL {
         let videoTracks = try await asset.loadTracks(withMediaType: .video)
         guard videoTracks.first != nil else {
@@ -88,8 +84,6 @@ public final class ExportPipeline {
         ) else {
             throw ExportError.cannotCreateSession
         }
-        let sessionBox = ExportSessionBox(session)
-
         let replacementDirectoryURL = try makeExportReplacementDirectory(appropriateFor: outputURL)
         defer { try? FileManager.default.removeItem(at: replacementDirectoryURL) }
         let temporaryOutputURL = replacementDirectoryURL
@@ -98,8 +92,6 @@ public final class ExportPipeline {
 
         try rejectSymlinkComponents(in: outputURL)
 
-        session.outputURL = temporaryOutputURL
-        session.outputFileType = preset.fileType
         if let trimRange {
             session.timeRange = trimRange
         }
@@ -110,30 +102,28 @@ public final class ExportPipeline {
                 timelineComposition: timelineComposition,
                 renderSize: renderSize,
                 frameRate: Double(preset.fps),
-                plan: cameraPlan
+                plan: cameraPlan,
+                backgroundFraming: backgroundFraming
             )
         } else if let composition = try await renderer.makeVideoComposition(
             asset: asset,
             renderSize: renderSize,
             frameRate: Double(preset.fps),
-            plan: cameraPlan
+            plan: cameraPlan,
+            backgroundFraming: backgroundFraming
         ) {
             session.videoComposition = composition
         }
 
-        try await withCheckedThrowingContinuation { continuation in
-            sessionBox.session.exportAsynchronously {
-                switch sessionBox.session.status {
-                case .completed:
-                    continuation.resume()
-                case .failed, .cancelled:
-                    continuation.resume(throwing: ExportError.failed(sessionBox.session.error))
-                default:
-                    continuation.resume(throwing: ExportError.failed(sessionBox.session.error))
-                }
-            }
+        do {
+            try await session.export(to: temporaryOutputURL, as: preset.fileType)
+        } catch is CancellationError {
+            throw CancellationError()
+        } catch {
+            throw ExportError.failed(error)
         }
 
+        try Task.checkCancellation()
         try installExportFileNoSymlink(from: temporaryOutputURL, to: outputURL)
         try rejectSymlinkComponents(in: outputURL)
         return outputURL
@@ -150,13 +140,20 @@ private func makeExportReplacementDirectory(appropriateFor outputURL: URL) throw
 }
 
 private func installExportFileNoSymlink(from sourceURL: URL, to destinationURL: URL) throws {
-    try rejectSymlinkComponents(in: destinationURL)
-    try removeExistingRegularFileNoSymlink(at: destinationURL)
-    try rejectSymlinkComponents(in: destinationURL.deletingLastPathComponent())
-    try copyRegularFileNoFollow(from: sourceURL, to: destinationURL)
+    let parentURL = destinationURL.deletingLastPathComponent()
+    try rejectSymlinkComponents(in: parentURL)
+    try validateReplaceableDestinationNoSymlink(at: destinationURL)
+
+    let installCandidateURL = parentURL.appendingPathComponent(".gg-export-install-\(UUID().uuidString)")
+    defer { try? FileManager.default.removeItem(at: installCandidateURL) }
+    try copyRegularFileNoFollow(from: sourceURL, to: installCandidateURL)
+    try Task.checkCancellation()
+    try rejectSymlinkComponents(in: parentURL)
+    try validateReplaceableDestinationNoSymlink(at: destinationURL)
+    try atomicRename(from: installCandidateURL, to: destinationURL)
 }
 
-private func removeExistingRegularFileNoSymlink(at destinationURL: URL) throws {
+private func validateReplaceableDestinationNoSymlink(at destinationURL: URL) throws {
     var metadata = stat()
     let status = destinationURL.withUnsafeFileSystemRepresentation { fileSystemPath in
         guard let fileSystemPath else {
@@ -178,8 +175,18 @@ private func removeExistingRegularFileNoSymlink(at destinationURL: URL) throws {
             NSError(domain: "GuerillaglassExport", code: Int(EFTYPE), userInfo: [NSLocalizedDescriptionKey: "Export destination already exists and is not a regular file"])
         )
     }
+}
 
-    try FileManager.default.removeItem(at: destinationURL)
+private func atomicRename(from sourceURL: URL, to destinationURL: URL) throws {
+    let status = sourceURL.withUnsafeFileSystemRepresentation { sourcePath in
+        destinationURL.withUnsafeFileSystemRepresentation { destinationPath in
+            guard let sourcePath, let destinationPath else { return Int32(-1) }
+            return Darwin.rename(sourcePath, destinationPath)
+        }
+    }
+    guard status == 0 else {
+        throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
 }
 
 private func copyRegularFileNoFollow(from sourceURL: URL, to destinationURL: URL) throws {
@@ -198,6 +205,7 @@ private func copyRegularFileNoFollow(from sourceURL: URL, to destinationURL: URL
 
     var buffer = [UInt8](repeating: 0, count: 1024 * 1024)
     while true {
+        try Task.checkCancellation()
         let bytesRead = buffer.withUnsafeMutableBytes { rawBuffer in
             Darwin.read(sourceFd, rawBuffer.baseAddress, rawBuffer.count)
         }
@@ -213,6 +221,7 @@ private func copyRegularFileNoFollow(from sourceURL: URL, to destinationURL: URL
 
         var written = 0
         while written < bytesRead {
+            try Task.checkCancellation()
             let bytesWritten = buffer.withUnsafeBytes { rawBuffer in
                 Darwin.write(
                     destinationFd,

--- a/engines/macos-swift/modules/export/TimelineComposition.swift
+++ b/engines/macos-swift/modules/export/TimelineComposition.swift
@@ -52,6 +52,14 @@ public enum CompiledExportTimelineItem: Equatable, Sendable {
         case let .gap(_, programRange): programRange
         }
     }
+
+    /// Whether the compiled interval contains source media rather than a gap.
+    public var isClip: Bool {
+        if case .clip = self {
+            return true
+        }
+        return false
+    }
 }
 
 public struct ExportTimelineComposition {

--- a/engines/macos-swift/modules/export/TimelineVideoCompositionBuilder.swift
+++ b/engines/macos-swift/modules/export/TimelineVideoCompositionBuilder.swift
@@ -1,23 +1,35 @@
 import Automation
 import AVFoundation
 import CoreGraphics
+import Project
+import Rendering
 
 public enum TimelineVideoCompositionBuilder {
     public static func makeComposition(
         timelineComposition: ExportTimelineComposition,
         renderSize: CGSize,
         frameRate: Double,
-        plan: CameraPlan? = nil
+        plan: CameraPlan? = nil,
+        backgroundFraming: BackgroundFramingSettings = .defaults
     ) -> AVVideoComposition? {
         guard renderSize.width > 0, renderSize.height > 0 else { return nil }
         guard let videoTrack = timelineComposition.videoTrack else { return nil }
         guard let sourceNaturalSize = timelineComposition.sourceNaturalSize else { return nil }
 
         let sourcePreferredTransform = timelineComposition.sourcePreferredTransform ?? .identity
-        let baseTransform = makeBaseTransform(
-            preferredTransform: sourcePreferredTransform,
+        let sourceBounds = VideoGeometryTransforms.orientedBounds(
             naturalSize: sourceNaturalSize,
-            renderSize: renderSize
+            preferredTransform: sourcePreferredTransform
+        )
+        guard let geometry = BackgroundFramingGeometry(
+            renderSize: renderSize,
+            orientedSourceSize: sourceBounds.size,
+            settings: backgroundFraming
+        ) else { return nil }
+        let baseTransform = VideoGeometryTransforms.sourceToCardTransform(
+            naturalSize: sourceNaturalSize,
+            preferredTransform: sourcePreferredTransform,
+            cardRect: geometry.cardRect
         )
         let sortedKeyframes = plan?.keyframes.sorted(by: { $0.time < $1.time }) ?? []
 
@@ -26,7 +38,10 @@ public enum TimelineVideoCompositionBuilder {
             guard range.duration > .zero else { return nil }
             let instruction = AVMutableVideoCompositionInstruction()
             instruction.timeRange = range
-            instruction.backgroundColor = CGColor(gray: 0, alpha: 1)
+            instruction.enablePostProcessing = backgroundFraming.enabled
+            instruction.backgroundColor = BackgroundFramingColor(
+                hex: backgroundFraming.enabled ? backgroundFraming.backgroundColor : "#000000"
+            )?.cgColor
             switch item {
             case let .clip(_, sourceRange, programRange):
                 let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: videoTrack)
@@ -50,7 +65,25 @@ public enum TimelineVideoCompositionBuilder {
         composition.renderSize = renderSize
         let timescale = max(1, Int32(frameRate.rounded()))
         composition.frameDuration = CMTime(value: 1, timescale: timescale)
+        if backgroundFraming.enabled {
+            composition.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+            composition.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+            composition.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+        }
         composition.instructions = instructions
+        let visibilitySegments = timelineComposition.items.map { item in
+            BackgroundFramingVisibilitySegment(
+                startSeconds: item.programRange.start.seconds,
+                durationSeconds: item.programRange.duration.seconds,
+                isVisible: item.isClip
+            )
+        }
+        BackgroundFramingVideoComposition.apply(
+            to: composition,
+            geometry: geometry,
+            settings: backgroundFraming,
+            visibilitySegments: visibilitySegments
+        )
         return composition
     }
 }
@@ -193,48 +226,9 @@ private func timelineClipTransform(
     keyframe: CameraKeyframe,
     sourceSize: CGSize
 ) -> CGAffineTransform {
-    cameraTransform(for: keyframe, sourceSize: sourceSize).concatenating(baseTransform)
-}
-
-private func cameraTransform(for keyframe: CameraKeyframe, sourceSize: CGSize) -> CGAffineTransform {
-    let zoom = max(1, keyframe.zoom)
-    let sourceCenter = CGPoint(x: sourceSize.width / 2, y: sourceSize.height / 2)
-    var transform = CGAffineTransform(translationX: sourceCenter.x, y: sourceCenter.y)
-    transform = transform.scaledBy(x: zoom, y: zoom)
-    transform = transform.translatedBy(x: -keyframe.center.x, y: -keyframe.center.y)
-    return transform
-}
-
-private func makeBaseTransform(
-    preferredTransform: CGAffineTransform,
-    naturalSize: CGSize,
-    renderSize: CGSize
-) -> CGAffineTransform {
-    let orientedBounds = transformedBounds(size: naturalSize, transform: preferredTransform)
-    guard orientedBounds.width > 0, orientedBounds.height > 0 else { return preferredTransform }
-
-    let scale = min(renderSize.width / orientedBounds.width, renderSize.height / orientedBounds.height)
-    let scaledSize = CGSize(width: orientedBounds.width * scale, height: orientedBounds.height * scale)
-    let translateX = (renderSize.width - scaledSize.width) / 2
-    let translateY = (renderSize.height - scaledSize.height) / 2
-
-    var transform = preferredTransform
-    transform = transform.translatedBy(x: -orientedBounds.minX, y: -orientedBounds.minY)
-    transform = transform.scaledBy(x: scale, y: scale)
-    transform = transform.translatedBy(x: translateX, y: translateY)
-    return transform
-}
-
-private func transformedBounds(size: CGSize, transform: CGAffineTransform) -> CGRect {
-    let points = [
-        CGPoint(x: 0, y: 0),
-        CGPoint(x: size.width, y: 0),
-        CGPoint(x: 0, y: size.height),
-        CGPoint(x: size.width, y: size.height)
-    ].map { $0.applying(transform) }
-    let minX = points.map(\.x).min() ?? 0
-    let maxX = points.map(\.x).max() ?? 0
-    let minY = points.map(\.y).min() ?? 0
-    let maxY = points.map(\.y).max() ?? 0
-    return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    VideoGeometryTransforms.sourceTransform(
+        baseTransform: baseTransform,
+        keyframe: keyframe,
+        sourceSize: sourceSize
+    )
 }

--- a/engines/macos-swift/modules/project/BackgroundFramingSettings.swift
+++ b/engines/macos-swift/modules/project/BackgroundFramingSettings.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Versioned project-global background stage and source-card framing settings.
-public struct BackgroundFramingSettings: Codable, Equatable {
+public struct BackgroundFramingSettings: Codable, Equatable, Sendable {
     public enum ValidationError: Error, LocalizedError {
         case unsupportedVersion(Double)
         case invalidBackgroundColor(String)

--- a/engines/macos-swift/modules/rendering/BackgroundFramingGeometry.swift
+++ b/engines/macos-swift/modules/rendering/BackgroundFramingGeometry.swift
@@ -1,0 +1,82 @@
+import CoreGraphics
+import Foundation
+import Project
+
+/// Resolution-independent background-stage geometry shared by preview and export rendering.
+public struct BackgroundFramingGeometry: Equatable, Sendable {
+    public let outputRect: CGRect
+    public let cardRect: CGRect
+    public let cornerRadius: CGFloat
+    public let shadowOpacity: Float
+    public let shadowRadius: CGFloat
+    public let shadowOffset: CGSize
+
+    public init?(
+        renderSize: CGSize,
+        orientedSourceSize: CGSize,
+        settings: BackgroundFramingSettings
+    ) {
+        guard renderSize.isFiniteAndPositive, orientedSourceSize.isFiniteAndPositive else {
+            return nil
+        }
+
+        let outputRect = CGRect(origin: .zero, size: renderSize)
+        let shorterOutputDimension = min(renderSize.width, renderSize.height)
+        let padding = settings.enabled ? CGFloat(settings.paddingFraction) * shorterOutputDimension : 0
+        let availableRect = outputRect.insetBy(dx: padding, dy: padding)
+        guard availableRect.width > 0, availableRect.height > 0 else { return nil }
+
+        let scale = min(
+            availableRect.width / orientedSourceSize.width,
+            availableRect.height / orientedSourceSize.height
+        )
+        let cardSize = CGSize(
+            width: orientedSourceSize.width * scale,
+            height: orientedSourceSize.height * scale
+        )
+        let cardRect = CGRect(
+            x: availableRect.midX - cardSize.width / 2,
+            y: availableRect.midY - cardSize.height / 2,
+            width: cardSize.width,
+            height: cardSize.height
+        )
+        let shorterCardDimension = min(cardSize.width, cardSize.height)
+        let shadowStrength = settings.enabled ? CGFloat(settings.shadowStrength) : 0
+
+        self.outputRect = outputRect
+        self.cardRect = cardRect
+        cornerRadius = settings.enabled
+            ? CGFloat(settings.cornerRadiusFraction) * shorterCardDimension
+            : 0
+        shadowOpacity = Float(0.30 * shadowStrength)
+        shadowRadius = 0.035 * shorterOutputDimension * shadowStrength
+        shadowOffset = CGSize(width: 0, height: 0.012 * shorterOutputDimension * shadowStrength)
+    }
+}
+
+/// Explicit opaque sRGB color used by the deterministic background stage.
+public struct BackgroundFramingColor: Equatable, Sendable {
+    public let red: CGFloat
+    public let green: CGFloat
+    public let blue: CGFloat
+
+    public init?(hex: String) {
+        guard hex.count == 7, hex.first == "#", let value = UInt32(hex.dropFirst(), radix: 16) else {
+            return nil
+        }
+        red = CGFloat((value >> 16) & 0xFF) / 255
+        green = CGFloat((value >> 8) & 0xFF) / 255
+        blue = CGFloat(value & 0xFF) / 255
+    }
+
+    public var cgColor: CGColor {
+        let colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+        return CGColor(colorSpace: colorSpace, components: [red, green, blue, 1])!
+    }
+}
+
+private extension CGSize {
+    var isFiniteAndPositive: Bool {
+        width.isFinite && height.isFinite && width > 0 && height > 0
+    }
+}

--- a/engines/macos-swift/modules/rendering/BackgroundFramingVideoComposition.swift
+++ b/engines/macos-swift/modules/rendering/BackgroundFramingVideoComposition.swift
@@ -1,0 +1,96 @@
+import AVFoundation
+import Project
+import QuartzCore
+
+/// Clip/gap visibility used to suppress the source-card shadow during timeline gaps.
+public struct BackgroundFramingVisibilitySegment: Equatable, Sendable {
+    public let startSeconds: Double
+    public let durationSeconds: Double
+    public let isVisible: Bool
+
+    public init(startSeconds: Double, durationSeconds: Double, isVisible: Bool) {
+        self.startSeconds = startSeconds
+        self.durationSeconds = durationSeconds
+        self.isVisible = isVisible
+    }
+}
+
+/// Applies the static background stage, rounded source-card mask, and shadow to a composition.
+public enum BackgroundFramingVideoComposition {
+    public static func apply(
+        to composition: AVMutableVideoComposition,
+        geometry: BackgroundFramingGeometry,
+        settings: BackgroundFramingSettings,
+        visibilitySegments: [BackgroundFramingVisibilitySegment] = []
+    ) {
+        guard settings.enabled, let stageColor = BackgroundFramingColor(hex: settings.backgroundColor) else {
+            return
+        }
+
+        let parentLayer = CALayer()
+        parentLayer.frame = geometry.outputRect
+        parentLayer.backgroundColor = stageColor.cgColor
+
+        let cardPath = CGPath(
+            roundedRect: geometry.cardRect,
+            cornerWidth: geometry.cornerRadius,
+            cornerHeight: geometry.cornerRadius,
+            transform: nil
+        )
+
+        let shadowLayer = CAShapeLayer()
+        shadowLayer.frame = geometry.outputRect
+        shadowLayer.path = cardPath
+        shadowLayer.fillColor = CGColor(gray: 0, alpha: 1)
+        shadowLayer.shadowPath = cardPath
+        shadowLayer.shadowColor = CGColor(gray: 0, alpha: 1)
+        shadowLayer.shadowOpacity = geometry.shadowOpacity
+        shadowLayer.shadowRadius = geometry.shadowRadius
+        shadowLayer.shadowOffset = CGSize(
+            width: geometry.shadowOffset.width,
+            height: -geometry.shadowOffset.height
+        )
+        applyVisibility(visibilitySegments, to: shadowLayer)
+
+        let videoLayer = CALayer()
+        videoLayer.frame = geometry.outputRect
+        let maskLayer = CAShapeLayer()
+        maskLayer.frame = geometry.outputRect
+        maskLayer.path = cardPath
+        maskLayer.fillColor = CGColor(gray: 1, alpha: 1)
+        videoLayer.mask = maskLayer
+
+        parentLayer.addSublayer(shadowLayer)
+        parentLayer.addSublayer(videoLayer)
+        // The Configuration initializer requires the macOS 26 SDK. Keep the deployment-compatible
+        // initializer until the repository's minimum supported Xcode SDK provides that symbol.
+        composition.animationTool = AVVideoCompositionCoreAnimationTool(
+            postProcessingAsVideoLayer: videoLayer,
+            in: parentLayer
+        )
+    }
+}
+
+private func applyVisibility(
+    _ segments: [BackgroundFramingVisibilitySegment],
+    to layer: CALayer
+) {
+    let validSegments = segments.filter {
+        $0.startSeconds.isFinite && $0.durationSeconds.isFinite &&
+            $0.startSeconds >= 0 && $0.durationSeconds > 0
+    }
+    guard let finalSegment = validSegments.last else { return }
+    let duration = finalSegment.startSeconds + finalSegment.durationSeconds
+    guard duration > 0 else { return }
+
+    layer.opacity = validSegments.first?.isVisible == true ? 1 : 0
+    let animation = CAKeyframeAnimation(keyPath: "opacity")
+    animation.values = validSegments.map { $0.isVisible ? 1 : 0 } + [finalSegment.isVisible ? 1 : 0]
+    animation.keyTimes = validSegments.map { NSNumber(value: $0.startSeconds / duration) } + [1]
+    animation.calculationMode = .discrete
+    animation.beginTime = AVCoreAnimationBeginTimeAtZero
+    animation.duration = duration
+    animation.isRemovedOnCompletion = false
+    animation.fillMode = .both
+    layer.add(animation, forKey: "background-framing-visibility")
+}

--- a/engines/macos-swift/modules/rendering/CameraPlanVideoCompositionBuilder.swift
+++ b/engines/macos-swift/modules/rendering/CameraPlanVideoCompositionBuilder.swift
@@ -1,6 +1,7 @@
 import Automation
 import AVFoundation
 import CoreGraphics
+import Project
 
 enum CameraPlanVideoCompositionBuilder {
     static func makeComposition(
@@ -8,7 +9,8 @@ enum CameraPlanVideoCompositionBuilder {
         track: AVAssetTrack,
         renderSize: CGSize,
         frameRate: Double,
-        plan: CameraPlan?
+        plan: CameraPlan?,
+        backgroundFraming: BackgroundFramingSettings = .defaults
     ) async throws -> AVVideoComposition? {
         guard renderSize.width > 0, renderSize.height > 0 else { return nil }
 
@@ -20,14 +22,23 @@ enum CameraPlanVideoCompositionBuilder {
         let requiresTransform = !preferredTransform.isIdentity
         let hasPlan = !(plan?.keyframes.isEmpty ?? true)
 
-        if !hasPlan, !requiresScaling, !requiresTransform {
+        if !hasPlan, !requiresScaling, !requiresTransform, !backgroundFraming.enabled {
             return nil
         }
 
-        let baseTransform = makeBaseTransform(
-            preferredTransform: preferredTransform,
+        let sourceBounds = VideoGeometryTransforms.orientedBounds(
             naturalSize: naturalSize,
-            renderSize: renderSize
+            preferredTransform: preferredTransform
+        )
+        guard let geometry = BackgroundFramingGeometry(
+            renderSize: renderSize,
+            orientedSourceSize: sourceBounds.size,
+            settings: backgroundFraming
+        ) else { return nil }
+        let baseTransform = VideoGeometryTransforms.sourceToCardTransform(
+            naturalSize: naturalSize,
+            preferredTransform: preferredTransform,
+            cardRect: geometry.cardRect
         )
 
         let layerInstruction = makeLayerInstruction(
@@ -41,12 +52,26 @@ enum CameraPlanVideoCompositionBuilder {
         let instruction = AVMutableVideoCompositionInstruction()
         instruction.timeRange = CMTimeRange(start: .zero, duration: duration)
         instruction.layerInstructions = [layerInstruction]
+        instruction.enablePostProcessing = backgroundFraming.enabled
+        instruction.backgroundColor = BackgroundFramingColor(
+            hex: backgroundFraming.enabled ? backgroundFraming.backgroundColor : "#000000"
+        )?.cgColor
 
         let composition = AVMutableVideoComposition()
         composition.renderSize = renderSize
         let timescale = max(1, Int32(frameRate.rounded()))
         composition.frameDuration = CMTime(value: 1, timescale: timescale)
+        if backgroundFraming.enabled {
+            composition.colorPrimaries = AVVideoColorPrimaries_ITU_R_709_2
+            composition.colorTransferFunction = AVVideoTransferFunction_ITU_R_709_2
+            composition.colorYCbCrMatrix = AVVideoYCbCrMatrix_ITU_R_709_2
+        }
         composition.instructions = [instruction]
+        BackgroundFramingVideoComposition.apply(
+            to: composition,
+            geometry: geometry,
+            settings: backgroundFraming
+        )
         return composition
     }
 }
@@ -65,8 +90,10 @@ private func makeLayerInstruction(
     }
 
     let keyframes = plan.keyframes.sorted(by: { $0.time < $1.time })
-    let firstTransform = baseTransform.concatenating(
-        cameraTransform(for: keyframes[0], sourceSize: sourceSize)
+    let firstTransform = VideoGeometryTransforms.sourceTransform(
+        baseTransform: baseTransform,
+        keyframe: keyframes[0],
+        sourceSize: sourceSize
     )
     layerInstruction.setTransform(firstTransform, at: .zero)
 
@@ -79,11 +106,15 @@ private func makeLayerInstruction(
             continue
         }
 
-        let startTransform = baseTransform.concatenating(
-            cameraTransform(for: previous, sourceSize: sourceSize)
+        let startTransform = VideoGeometryTransforms.sourceTransform(
+            baseTransform: baseTransform,
+            keyframe: previous,
+            sourceSize: sourceSize
         )
-        let endTransform = baseTransform.concatenating(
-            cameraTransform(for: keyframe, sourceSize: sourceSize)
+        let endTransform = VideoGeometryTransforms.sourceTransform(
+            baseTransform: baseTransform,
+            keyframe: keyframe,
+            sourceSize: sourceSize
         )
         let timeRange = CMTimeRange(start: startTime, end: endTime)
         layerInstruction.setTransformRamp(
@@ -95,31 +126,6 @@ private func makeLayerInstruction(
     }
 
     return layerInstruction
-}
-
-private func makeBaseTransform(
-    preferredTransform: CGAffineTransform,
-    naturalSize: CGSize,
-    renderSize: CGSize
-) -> CGAffineTransform {
-    let scale = min(renderSize.width / naturalSize.width, renderSize.height / naturalSize.height)
-    let scaledSize = CGSize(width: naturalSize.width * scale, height: naturalSize.height * scale)
-    let translateX = (renderSize.width - scaledSize.width) / 2
-    let translateY = (renderSize.height - scaledSize.height) / 2
-
-    var transform = preferredTransform
-    transform = transform.scaledBy(x: scale, y: scale)
-    transform = transform.translatedBy(x: translateX, y: translateY)
-    return transform
-}
-
-private func cameraTransform(for keyframe: CameraKeyframe, sourceSize: CGSize) -> CGAffineTransform {
-    let zoom = max(1, keyframe.zoom)
-    let sourceCenter = CGPoint(x: sourceSize.width / 2, y: sourceSize.height / 2)
-    var transform = CGAffineTransform(translationX: sourceCenter.x, y: sourceCenter.y)
-    transform = transform.scaledBy(x: zoom, y: zoom)
-    transform = transform.translatedBy(x: -keyframe.center.x, y: -keyframe.center.y)
-    return transform
 }
 
 private func clampTime(_ time: TimeInterval, duration: CMTime) -> CMTime {

--- a/engines/macos-swift/modules/rendering/ExportRenderer.swift
+++ b/engines/macos-swift/modules/rendering/ExportRenderer.swift
@@ -1,6 +1,7 @@
 import Automation
 import AVFoundation
 import Foundation
+import Project
 
 /// Public class exposed by the macOS engine module.
 public final class ExportRenderer {
@@ -10,7 +11,8 @@ public final class ExportRenderer {
         asset: AVAsset,
         renderSize: CGSize,
         frameRate: Double,
-        plan: CameraPlan?
+        plan: CameraPlan?,
+        backgroundFraming: BackgroundFramingSettings = .defaults
     ) async throws -> AVVideoComposition? {
         let tracks = try await asset.loadTracks(withMediaType: .video)
         guard let track = tracks.first else { return nil }
@@ -20,7 +22,8 @@ public final class ExportRenderer {
             track: track,
             renderSize: renderSize,
             frameRate: frameRate,
-            plan: plan
+            plan: plan,
+            backgroundFraming: backgroundFraming
         )
     }
 }

--- a/engines/macos-swift/modules/rendering/PreviewRenderer.swift
+++ b/engines/macos-swift/modules/rendering/PreviewRenderer.swift
@@ -1,6 +1,7 @@
 import Automation
 import AVFoundation
 import Foundation
+import Project
 
 /// Public class exposed by the macOS engine module.
 public final class PreviewRenderer {
@@ -8,20 +9,27 @@ public final class PreviewRenderer {
 
     public func makeVideoComposition(
         asset: AVAsset,
-        plan: CameraPlan?
+        plan: CameraPlan?,
+        backgroundFraming: BackgroundFramingSettings = .defaults
     ) async throws -> AVVideoComposition? {
         let tracks = try await asset.loadTracks(withMediaType: .video)
         guard let track = tracks.first else { return nil }
         let naturalSize = try await track.load(.naturalSize)
+        let preferredTransform = try await track.load(.preferredTransform)
+        let orientedSize = VideoGeometryTransforms.orientedBounds(
+            naturalSize: naturalSize,
+            preferredTransform: preferredTransform
+        ).size
         let nominalFrameRate = try await track.load(.nominalFrameRate)
         let frameRate = nominalFrameRate > 0 ? Double(nominalFrameRate) : 30
 
         return try await CameraPlanVideoCompositionBuilder.makeComposition(
             asset: asset,
             track: track,
-            renderSize: naturalSize,
+            renderSize: orientedSize,
             frameRate: frameRate,
-            plan: plan
+            plan: plan,
+            backgroundFraming: backgroundFraming
         )
     }
 }

--- a/engines/macos-swift/modules/rendering/VideoGeometryTransforms.swift
+++ b/engines/macos-swift/modules/rendering/VideoGeometryTransforms.swift
@@ -1,0 +1,69 @@
+import Automation
+import CoreGraphics
+
+/// Canonical source-orientation, aspect-fit, and camera transforms shared by render paths.
+public enum VideoGeometryTransforms {
+    public static func orientedBounds(
+        naturalSize: CGSize,
+        preferredTransform: CGAffineTransform
+    ) -> CGRect {
+        let points = [
+            CGPoint(x: 0, y: 0),
+            CGPoint(x: naturalSize.width, y: 0),
+            CGPoint(x: 0, y: naturalSize.height),
+            CGPoint(x: naturalSize.width, y: naturalSize.height)
+        ].map { $0.applying(preferredTransform) }
+        let minX = points.map(\.x).min() ?? 0
+        let maxX = points.map(\.x).max() ?? 0
+        let minY = points.map(\.y).min() ?? 0
+        let maxY = points.map(\.y).max() ?? 0
+        return CGRect(x: minX, y: minY, width: maxX - minX, height: maxY - minY)
+    }
+
+    public static func sourceToCardTransform(
+        naturalSize: CGSize,
+        preferredTransform: CGAffineTransform,
+        cardRect: CGRect
+    ) -> CGAffineTransform {
+        let bounds = orientedBounds(naturalSize: naturalSize, preferredTransform: preferredTransform)
+        guard bounds.width > 0, bounds.height > 0 else { return preferredTransform }
+
+        let scale = min(cardRect.width / bounds.width, cardRect.height / bounds.height)
+        let scaledSize = CGSize(width: bounds.width * scale, height: bounds.height * scale)
+        let destinationOrigin = CGPoint(
+            x: cardRect.midX - scaledSize.width / 2,
+            y: cardRect.midY - scaledSize.height / 2
+        )
+
+        var destinationTransform = CGAffineTransform(
+            translationX: destinationOrigin.x,
+            y: destinationOrigin.y
+        )
+        destinationTransform = destinationTransform.scaledBy(x: scale, y: scale)
+        destinationTransform = destinationTransform.translatedBy(
+            x: -bounds.minX,
+            y: -bounds.minY
+        )
+        return preferredTransform.concatenating(destinationTransform)
+    }
+
+    public static func cameraTransform(
+        for keyframe: CameraKeyframe,
+        sourceSize: CGSize
+    ) -> CGAffineTransform {
+        let zoom = max(1, keyframe.zoom)
+        let sourceCenter = CGPoint(x: sourceSize.width / 2, y: sourceSize.height / 2)
+        var transform = CGAffineTransform(translationX: sourceCenter.x, y: sourceCenter.y)
+        transform = transform.scaledBy(x: zoom, y: zoom)
+        transform = transform.translatedBy(x: -keyframe.center.x, y: -keyframe.center.y)
+        return transform
+    }
+
+    public static func sourceTransform(
+        baseTransform: CGAffineTransform,
+        keyframe: CameraKeyframe,
+        sourceSize: CGSize
+    ) -> CGAffineTransform {
+        cameraTransform(for: keyframe, sourceSize: sourceSize).concatenating(baseTransform)
+    }
+}

--- a/engines/native-foundation/src/system.rs
+++ b/engines/native-foundation/src/system.rs
@@ -33,6 +33,7 @@ pub(crate) fn capabilities(id: &EngineCallId, platform: &str) -> EngineResponse 
             "export": {
                 "presets": true,
                 "cutPlan": true,
+                "backgroundFraming": false,
             },
             "project": {
                 "openSave": true,

--- a/engines/native-foundation/src/transport.rs
+++ b/engines/native-foundation/src/transport.rs
@@ -717,6 +717,7 @@ mod tests {
         assert_eq!(capabilities["platform"], "linux");
         assert_eq!(capabilities["phase"], "foundation");
         assert_eq!(capabilities["capture"]["display"], true);
+        assert_eq!(capabilities["export"]["backgroundFraming"], false);
         assert_eq!(capabilities["agent"]["localOnly"], true);
     }
 

--- a/engines/protocol-rust/src/models.rs
+++ b/engines/protocol-rust/src/models.rs
@@ -2759,6 +2759,10 @@ pub struct CapabilitiesResultExport {
     #[serde(rename = "cutPlan")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cut_plan: Option<bool>,
+
+    #[serde(rename = "backgroundFraming")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub background_framing: Option<bool>,
 }
 
 impl CapabilitiesResultExport {
@@ -2767,6 +2771,7 @@ impl CapabilitiesResultExport {
         CapabilitiesResultExport {
             presets,
             cut_plan: None,
+            background_framing: None,
         }
     }
 }
@@ -2782,6 +2787,13 @@ impl std::fmt::Display for CapabilitiesResultExport {
             self.cut_plan
                 .as_ref()
                 .map(|cut_plan| ["cutPlan".to_string(), cut_plan.to_string()].join(",")),
+            self.background_framing.as_ref().map(|background_framing| {
+                [
+                    "backgroundFraming".to_string(),
+                    background_framing.to_string(),
+                ]
+                .join(",")
+            }),
         ];
 
         write!(
@@ -2805,6 +2817,7 @@ impl std::str::FromStr for CapabilitiesResultExport {
         struct IntermediateRep {
             pub presets: Vec<bool>,
             pub cut_plan: Vec<bool>,
+            pub background_framing: Vec<bool>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -2834,6 +2847,10 @@ impl std::str::FromStr for CapabilitiesResultExport {
                     "cutPlan" => intermediate_rep.cut_plan.push(
                         <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
+                    #[allow(clippy::redundant_clone)]
+                    "backgroundFraming" => intermediate_rep.background_framing.push(
+                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
                     _ => {
                         return std::result::Result::Err(
                             "Unexpected key while parsing CapabilitiesResultExport".to_string(),
@@ -2854,6 +2871,7 @@ impl std::str::FromStr for CapabilitiesResultExport {
                 .next()
                 .ok_or_else(|| "presets missing in CapabilitiesResultExport".to_string())?,
             cut_plan: intermediate_rep.cut_plan.into_iter().next(),
+            background_framing: intermediate_rep.background_framing.into_iter().next(),
         })
     }
 }

--- a/engines/protocol-swift/Sources/EngineProtocol/openapi.json
+++ b/engines/protocol-swift/Sources/EngineProtocol/openapi.json
@@ -2742,6 +2742,9 @@
               },
               "cutPlan": {
                 "type": "boolean"
+              },
+              "backgroundFraming": {
+                "type": "boolean"
               }
             },
             "required": [

--- a/messages/de-DE.json
+++ b/messages/de-DE.json
@@ -156,6 +156,7 @@
   "studio_labels_autoZoomIntensity": "Auto-Zoom-Intensität ({value}%)",
   "studio_labels_minimumKeyframeInterval": "Min. Keyframe-Intervall (s)",
   "studio_labels_backgroundFraming": "Hintergrundrahmen",
+  "studio_labels_backgroundColor": "Hintergrundfarbe",
   "studio_labels_backgroundPadding": "Hintergrundabstand",
   "studio_labels_cornerRoundness": "Eckenrundung",
   "studio_labels_shadowStrength": "Schattenstärke",

--- a/messages/en-US.json
+++ b/messages/en-US.json
@@ -156,6 +156,7 @@
   "studio_labels_autoZoomIntensity": "Auto-zoom intensity ({value}%)",
   "studio_labels_minimumKeyframeInterval": "Min keyframe interval (s)",
   "studio_labels_backgroundFraming": "Background framing",
+  "studio_labels_backgroundColor": "Background color",
   "studio_labels_backgroundPadding": "Background padding",
   "studio_labels_cornerRoundness": "Corner roundness",
   "studio_labels_shadowStrength": "Shadow strength",

--- a/packages/engine-contract/generated/engine.openapi.json
+++ b/packages/engine-contract/generated/engine.openapi.json
@@ -2742,6 +2742,9 @@
               },
               "cutPlan": {
                 "type": "boolean"
+              },
+              "backgroundFraming": {
+                "type": "boolean"
               }
             },
             "required": [

--- a/packages/engine-contract/src/domains/system.ts
+++ b/packages/engine-contract/src/domains/system.ts
@@ -39,6 +39,7 @@ export const capabilitiesResultSchema = Schema.Struct({
   export: Schema.Struct({
     presets: Schema.Boolean,
     cutPlan: Schema.optionalKey(Schema.Boolean),
+    backgroundFraming: Schema.optionalKey(Schema.Boolean),
   }),
   project: Schema.Struct({
     openSave: Schema.Boolean,

--- a/packages/ui/src/components/slider.tsx
+++ b/packages/ui/src/components/slider.tsx
@@ -41,6 +41,11 @@ function Slider({
           <SliderPrimitive.Thumb
             data-slot="slider-thumb"
             key={index}
+            aria-label={
+              _values.length === 1
+                ? props["aria-label"]
+                : `${props["aria-label"] ?? "Value"} ${index + 1}`
+            }
             className="border-primary ring-ring/50 size-4 rounded-full border bg-white shadow-sm transition-[color,box-shadow] hover:ring-4 focus-visible:ring-4 focus-visible:outline-hidden block shrink-0 select-none disabled:pointer-events-none disabled:opacity-50"
           />
         ))}


### PR DESCRIPTION
# Summary

- render versioned project-global background framing in macOS preview/export with deterministic sRGB stage color, aspect-fit card geometry, rounded masking, shadow, rotation/camera composition, and timeline-gap visibility
- add matching pure React geometry, Capture/Edit previews, localized accessible inspector controls, project-switch-safe hydration, and renderer capability gating
- advertise framing only on the production macOS renderer, keep Rust foundation shells truthful, and add native raster, geometry, browser, parity, cancellation, overwrite-safety, and compatibility coverage
- mark the ordered `phase2/background-framing-renderer` roadmap slice implemented

# Checklist

- [x] Read and applied `AGENTS.md`, the nearest nested agent guide, and `REVIEW.md`
- [x] Kept the change scoped to one roadmap slice or maintenance purpose
- [x] Ran `bun run repo:check`
- [x] Ran `bun run gate` or documented unsupported/deferred platform checks
- [x] Regenerated derived artifacts and verified determinism when changing contracts, or N/A
- [x] Updated roadmap/docs when architecture, workflow, or tracked status changed, or N/A
- [x] Added both `en-US` and `de-DE` messages for user-visible UI, or N/A
- [x] Ran `bun run desktop:acceptance` for desktop/runtime changes, or N/A
- [x] Used Peekaboo against the packaged app to navigate the affected workflow and retained native-window screenshots, or N/A
- [x] Included screenshots for material UI changes, or N/A
- [x] Addressed every review comment and ran `bun run pr:check-review-threads -- <PR number>` with zero unresolved threads

# Validation evidence

- `bun run repo:check`
- `bun run gate` (TypeScript, Rust, SwiftFormat, SwiftLint, and all 97 Swift tests passed)
- `bun run desktop:acceptance`
- `bun run protocol:generate-bindings` plus deterministic regeneration check
- `bun run docs:check`
- `bun run --cwd apps/desktop-electrobun test:ui`
- `bun run --cwd apps/desktop-electrobun test -- tests/background-framing-geometry.test.ts tests/parity-e2e.test.ts`
- focused native raster exports cover stage/card pixels, rounded corners, shadows, 90°/270° rotation, vertical output, clip-gap-clip and trims beginning in gaps, camera transforms, Rec.709 metadata, disabled legacy letterboxing, cancellation, and destination preservation
- latest native timings: framed stage/card `0.501s`, shadow `0.328s`, gap trim `0.287s`, disabled legacy `0.195s` for focused short fixture exports; no unexpected regression observed
- packaged app launched with the native Swift engine; Peekaboo navigated Capture → Edit → Deliver, expanded framing controls, enabled framing, and retained screenshots in `.tmp/peekaboo-background-renderer/`; runtime acceptance reported zero fatal matches
- packaged live recording was not exercised because macOS TCC has not granted Screen Recording to the unsigned `Guerillaglass-dev.app`; real media output was validated by the native raster export suite instead

# Cross-boundary review

- [x] Preview, persistence, and export remain aligned for editor-model changes, or N/A
- [x] Hosted services remain optional for local capture/edit/export, or N/A
- [x] New native capabilities are advertised only on implemented targets, or N/A

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds deterministic, capability-gated background framing across the editor and macOS export pipeline.
- Introduces shared React and Swift geometry for stage color, aspect-fit card layout, rounded masking, shadows, and rotation/camera composition.
- Adds project-safe settings hydration, accessible localized inspector controls, Capture/Edit previews, and timeline-gap visibility.
- Extends renderer capability contracts while leaving non-macOS foundation engines explicitly unsupported.
- Makes export installation cancellation-aware and preserves existing destinations until replacement succeeds.
- Adds native raster, geometry, browser, parity, cancellation, overwrite-safety, and compatibility coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no blocking failure eligible for this follow-up review remains.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| engines/macos-swift/modules/rendering/BackgroundFramingVideoComposition.swift | Adds the Core Animation stage, rounded mask, shadow, and timeline-driven visibility used by native framed exports. |
| engines/macos-swift/modules/rendering/VideoGeometryTransforms.swift | Centralizes source orientation, aspect-fit placement, and camera-transform composition. |
| engines/macos-swift/modules/export/ExportPipeline.swift | Integrates framing into export and installs completed output through a cancellation-aware atomic replacement path. |
| apps/desktop-electrobun/src/mainview/app/studio/panels/BackgroundFramingPreview.tsx | Adds the responsive React preview stage and card rendering driven by shared framing settings. |
| apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioController.ts | Gates framing by native capability and makes project settings hydration sensitive to project identity. |
| packages/engine-contract/src/domains/system.ts | Extends renderer capability reporting with explicit background-framing support. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Capture/Edit UI
    participant Project as Project Settings
    participant Bridge as Engine Bridge
    participant Renderer as macOS Renderer
    participant Export as Export Pipeline

    Project->>UI: Hydrate background framing
    Bridge-->>UI: Report framing capability
    UI->>UI: Render deterministic preview geometry
    UI->>Bridge: Submit export settings
    Bridge->>Export: Start export with framing
    Export->>Renderer: Build stage, card, mask, shadow
    Renderer-->>Export: Framed video composition
    Export-->>Bridge: Atomically install output
    Bridge-->>UI: Return completed export
```

<sub>Reviews (3): Last reviewed commit: ["test(swift): allow hardware codec color ..."](https://github.com/okikesolutions/guerillaglass/commit/221314da63fa0553284c35c5bfa6ff001a6c33df) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47107142)</sub>

<!-- /greptile_comment -->
