### PR TITLE
feat(editor): replan camera for vertical export

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -76,7 +76,7 @@ let package = Package(
         ),
         .target(
             name: "Export",
-            dependencies: ["Automation", "Project", "Rendering"],
+            dependencies: ["Automation", "InputTracking", "Project", "Rendering"],
             path: "engines/macos-swift/modules/export"
         ),
         .testTarget(
@@ -101,7 +101,7 @@ let package = Package(
         ),
         .testTarget(
             name: "ExportTests",
-            dependencies: ["Export", "Project"],
+            dependencies: ["Export", "InputTracking", "Project"],
             path: "Tests/exportTests"
         )
     ]

--- a/Tests/automationTests/AutomationTests.swift
+++ b/Tests/automationTests/AutomationTests.swift
@@ -48,6 +48,49 @@ final class AutomationTests: XCTestCase {
         XCTAssertEqual(clickSample.intensity, constraints.clickIntensity, accuracy: 0.0001)
     }
 
+    func testPlannerReplansCameraViewportForOutputAspectRatio() throws {
+        let sourceSize = CGSize(width: 1920, height: 1080)
+        let event = InputEvent(
+            type: .mouseDown,
+            timestamp: 0,
+            position: CGPoint(x: 1800, y: 540)
+        )
+        let constraints = ZoomConstraints(
+            maxPanSpeed: .greatestFiniteMagnitude,
+            maxPanAcceleration: .greatestFiniteMagnitude,
+            minimumKeyframeInterval: 0
+        )
+        let planner = VirtualCameraPlanner()
+
+        let landscape = planner.plan(
+            events: [event],
+            sourceSize: sourceSize,
+            duration: 1,
+            outputSize: CGSize(width: 1920, height: 1080),
+            constraints: constraints
+        )
+        let portrait = planner.plan(
+            events: [event],
+            sourceSize: sourceSize,
+            duration: 1,
+            outputSize: CGSize(width: 1080, height: 1920),
+            constraints: constraints
+        )
+
+        XCTAssertEqual(try XCTUnwrap(landscape.outputAspectRatio), 16 / 9, accuracy: 0.0001)
+        XCTAssertEqual(try XCTUnwrap(portrait.outputAspectRatio), 9 / 16, accuracy: 0.0001)
+        XCTAssertGreaterThan(
+            try XCTUnwrap(portrait.keyframes.first).center.x,
+            try XCTUnwrap(landscape.keyframes.first).center.x + 150
+        )
+        let portraitView = try constraints.cameraViewSize(
+            in: sourceSize,
+            zoom: XCTUnwrap(portrait.keyframes.first).zoom,
+            outputAspectRatio: XCTUnwrap(portrait.outputAspectRatio)
+        )
+        XCTAssertEqual(portraitView.width / portraitView.height, 9 / 16, accuracy: 0.0001)
+    }
+
     func testPlannerClampsZoomAndDuration() {
         let planner = VirtualCameraPlanner()
         let constraints = ZoomConstraints(

--- a/Tests/exportTests/ExportPipelineTests.swift
+++ b/Tests/exportTests/ExportPipelineTests.swift
@@ -3,6 +3,7 @@ import Automation
 import AVFoundation
 import Darwin
 @testable import Export
+import InputTracking
 import Project
 import XCTest
 
@@ -329,6 +330,83 @@ final class ExportPipelineTests: XCTestCase {
         XCTAssertEqual(cameraRed, 0.25, accuracy: 0.1)
         XCTAssertLessThan(cameraColor.greenComponent, 0.08)
         XCTAssertLessThan(cameraColor.blueComponent, 0.08)
+    }
+
+    func testVerticalExportReplansCameraFromCaptureEvents() async throws {
+        let fileManager = FileManager.default
+        let baseURL = try canonicalTemporaryDirectory().appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        defer { try? fileManager.removeItem(at: baseURL) }
+
+        let sourceURL = baseURL.appendingPathComponent("gradient.mov")
+        try makeGradientVideoFile(at: sourceURL, durationSeconds: 1)
+        let leftURL = baseURL.appendingPathComponent("vertical-left.mp4")
+        let rightURL = baseURL.appendingPathComponent("vertical-right.mp4")
+        let preset = ExportPreset(
+            id: "test-vertical",
+            name: "Test vertical",
+            width: 180,
+            height: 320,
+            fps: 30,
+            codec: .h264,
+            fileType: .mp4,
+            exportPresetName: AVAssetExportPresetHighestQuality
+        )
+        let metadata = CaptureMetadata(
+            source: .display,
+            contentRect: CaptureRect(originX: 0, originY: 0, width: 320, height: 180),
+            pixelScale: 1
+        )
+        let settings = AutoZoomSettings(isEnabled: true, intensity: 1, minimumKeyframeInterval: 1 / 30)
+        let framing = try BackgroundFramingSettings(
+            version: 1,
+            enabled: true,
+            backgroundColor: "#204060",
+            paddingFraction: 0.06,
+            cornerRadiusFraction: 0.025,
+            shadowStrength: 0.35
+        )
+
+        _ = try await ExportPipeline().export(
+            recordingURL: sourceURL,
+            preset: preset,
+            trimRange: nil,
+            outputURL: leftURL,
+            cameraEvents: [
+                InputEvent(type: .mouseDown, timestamp: 0, position: CGPoint(x: 40, y: 90))
+            ],
+            autoZoomSettings: settings,
+            captureMetadata: metadata,
+            backgroundFraming: framing
+        )
+        _ = try await ExportPipeline().export(
+            recordingURL: sourceURL,
+            preset: preset,
+            trimRange: nil,
+            outputURL: rightURL,
+            cameraEvents: [
+                InputEvent(type: .mouseDown, timestamp: 0, position: CGPoint(x: 280, y: 90))
+            ],
+            autoZoomSettings: settings,
+            captureMetadata: metadata,
+            backgroundFraming: framing
+        )
+
+        let leftColor = try sampleColor(in: AVAsset(url: leftURL), at: 0.5)
+        let rightColor = try sampleColor(in: AVAsset(url: rightURL), at: 0.5)
+        XCTAssertGreaterThan(rightColor.redComponent - leftColor.redComponent, 0.5)
+        let stageColor = try sampleColor(
+            in: AVAsset(url: rightURL),
+            at: 0.5,
+            normalizedPoint: CGPoint(x: 0.01, y: 0.01)
+        )
+        assertEncodedColor(stageColor, equalsSRGB8: (red: 32, green: 64, blue: 96))
+
+        let outputTracks = try await AVAsset(url: rightURL).loadTracks(withMediaType: .video)
+        let outputTrack = try XCTUnwrap(outputTracks.first)
+        let outputSize = try await outputTrack.load(.naturalSize)
+        XCTAssertEqual(outputSize.width, 180, accuracy: 1)
+        XCTAssertEqual(outputSize.height, 320, accuracy: 1)
     }
 
     func testBackgroundFramingRendersStageAndRoundedSourceCard() async throws {

--- a/Tests/projectMigrationTests/ProjectMigrationTests.swift
+++ b/Tests/projectMigrationTests/ProjectMigrationTests.swift
@@ -2,6 +2,12 @@
 import XCTest
 
 final class ProjectMigrationTests: XCTestCase {
+    func testAutoZoomRequiresEventsOnlyWhenEnabledWithPositiveIntensity() {
+        XCTAssertFalse(AutoZoomSettings(isEnabled: false, intensity: 1).requiresInputEvents)
+        XCTAssertFalse(AutoZoomSettings(isEnabled: true, intensity: 0).requiresInputEvents)
+        XCTAssertTrue(AutoZoomSettings(isEnabled: true, intensity: 0.5).requiresInputEvents)
+    }
+
     func testMigrationPassesThroughCurrentVersion() throws {
         let encoder = ProjectStore.makeDefaultEncoder()
         let document = ProjectDocument()

--- a/Tests/renderingDeterminismTests/RenderingDeterminismTests.swift
+++ b/Tests/renderingDeterminismTests/RenderingDeterminismTests.swift
@@ -108,6 +108,62 @@ final class RenderingDeterminismTests: XCTestCase {
         ).concatenating(base))
     }
 
+    func testPortraitCameraViewportCropsAndFillsPortraitCard() {
+        let sourceSize = CGSize(width: 1920, height: 1080)
+        let keyframe = CameraKeyframe(
+            time: 0,
+            center: CGPoint(x: 960, y: 540),
+            zoom: 1
+        )
+        let viewport = VideoGeometryTransforms.cameraViewportRect(
+            sourceSize: sourceSize,
+            keyframe: keyframe,
+            outputAspectRatio: 9 / 16
+        )
+        assertRect(
+            viewport,
+            equals: CGRect(x: 656.25, y: 0, width: 607.5, height: 1080)
+        )
+
+        let card = CGRect(x: 50, y: 100, width: 540, height: 960)
+        let transform = VideoGeometryTransforms.sourceToCameraViewportTransform(
+            naturalSize: sourceSize,
+            preferredTransform: .identity,
+            cardRect: card,
+            keyframe: keyframe,
+            outputAspectRatio: 9 / 16
+        )
+        let topLeft = viewport.origin.applying(transform)
+        let bottomRight = CGPoint(x: viewport.maxX, y: viewport.maxY).applying(transform)
+        XCTAssertEqual(topLeft.x, card.minX, accuracy: 0.0001)
+        XCTAssertEqual(topLeft.y, card.minY, accuracy: 0.0001)
+        XCTAssertEqual(bottomRight.x, card.maxX, accuracy: 0.0001)
+        XCTAssertEqual(bottomRight.y, card.maxY, accuracy: 0.0001)
+    }
+
+    func testPortraitCameraViewportPreservesPreferredSourceOrientation() {
+        let naturalSize = CGSize(width: 1920, height: 1080)
+        let preferredTransform = CGAffineTransform(rotationAngle: .pi / 2)
+            .translatedBy(x: 0, y: -1080)
+        let card = CGRect(x: 50, y: 100, width: 540, height: 960)
+        let transform = VideoGeometryTransforms.sourceToCameraViewportTransform(
+            naturalSize: naturalSize,
+            preferredTransform: preferredTransform,
+            cardRect: card,
+            keyframe: CameraKeyframe(
+                time: 0,
+                center: CGPoint(x: 540, y: 960),
+                zoom: 1
+            ),
+            outputAspectRatio: 9 / 16
+        )
+        let outputBounds = VideoGeometryTransforms.orientedBounds(
+            naturalSize: naturalSize,
+            preferredTransform: transform
+        )
+        assertRect(outputBounds, equals: card)
+    }
+
     func testBackgroundColorUsesExplicitSRGBComponents() throws {
         let color = try XCTUnwrap(BackgroundFramingColor(hex: "#1A2B3C"))
         XCTAssertEqual(color.red, 26 / 255, accuracy: 0.0001)

--- a/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioMutations.ts
+++ b/apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioMutations.ts
@@ -661,6 +661,7 @@ export function useStudioMutations({
         trimStartSeconds: trimStart,
         trimEndSeconds: trimEnd,
         timeline: timelineDocument,
+        autoZoom: settingsForm.state.values.autoZoom,
         backgroundFraming: settingsForm.state.values.backgroundFraming,
       });
       return { ...result, outputURL: result.outputURL ?? outputURL };

--- a/apps/desktop-electrobun/src/mainview/app/studio/panels/BackgroundFramingPreview.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/panels/BackgroundFramingPreview.tsx
@@ -57,6 +57,7 @@ type BackgroundFramingPreviewProps = {
   settings: BackgroundFramingSettings;
   outputSize: RenderSize;
   sourceSize: RenderSize;
+  cameraReframeEnabled?: boolean;
   cardRef?: Ref<HTMLDivElement>;
   children: ReactNode;
 };
@@ -65,6 +66,7 @@ export function BackgroundFramingPreview({
   settings,
   outputSize,
   sourceSize,
+  cameraReframeEnabled = false,
   cardRef,
   children,
 }: BackgroundFramingPreviewProps) {
@@ -78,7 +80,8 @@ export function BackgroundFramingPreview({
     (element: HTMLDivElement | null) => sizeStore.setElement(element),
     [sizeStore],
   );
-  const geometry = computeBackgroundFramingGeometry(outputSize, sourceSize, settings);
+  const compositionSourceSize = cameraReframeEnabled ? outputSize : sourceSize;
+  const geometry = computeBackgroundFramingGeometry(outputSize, compositionSourceSize, settings);
   const scale = measuredSize.width > 0 ? measuredSize.width / outputSize.width : 0;
   const card = geometry?.cardRect;
 
@@ -93,8 +96,13 @@ export function BackgroundFramingPreview({
       {card ? (
         <div
           ref={cardRef}
-          className="absolute overflow-hidden"
+          className={
+            cameraReframeEnabled
+              ? "gg-camera-reframe-card absolute overflow-hidden"
+              : "absolute overflow-hidden"
+          }
           data-testid="background-framing-card"
+          data-camera-reframe={cameraReframeEnabled}
           style={{
             left: card.x * scale,
             top: card.y * scale,

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/CaptureRoute.tsx
@@ -274,86 +274,91 @@ export function CaptureRoute() {
                   <div className="gg-preview-stage">
                     <studio.settingsForm.Field name="backgroundFraming">
                       {(field) => (
-                        <BackgroundFramingPreview
-                          settings={
-                            studio.backgroundFramingSupported
-                              ? field.state.value
-                              : { ...field.state.value, enabled: false }
-                          }
-                          outputSize={outputSize}
-                          sourceSize={sourceSize}
-                        >
-                          {isCaptureRunning ? (
-                            <div className="relative h-full w-full overflow-hidden">
-                              <img
-                                ref={liveCapturePreviewImageRef}
-                                alt={studio.ui.helper.activePreviewTitle}
-                                className={cn(
-                                  "h-full w-full object-contain",
-                                  liveCapturePreviewHasFrame ? "block" : "hidden",
-                                )}
-                                onLoad={(event) => {
-                                  const image = event.currentTarget;
-                                  if (image.naturalWidth > 0 && image.naturalHeight > 0) {
-                                    setSourceSize((current) =>
-                                      current.width === image.naturalWidth &&
-                                      current.height === image.naturalHeight
-                                        ? current
-                                        : {
-                                            width: image.naturalWidth,
-                                            height: image.naturalHeight,
-                                          },
-                                    );
-                                  }
-                                }}
-                              />
-                              {!liveCapturePreviewHasFrame ? (
-                                <div className="flex h-full w-full items-center justify-center text-center">
-                                  <p className="text-sm font-medium">
-                                    {studio.ui.helper.activePreviewTitle}
-                                  </p>
-                                </div>
-                              ) : null}
+                        <studio.settingsForm.Field name="autoZoom">
+                          {(autoZoomField) => (
+                            <BackgroundFramingPreview
+                              settings={
+                                studio.backgroundFramingSupported
+                                  ? field.state.value
+                                  : { ...field.state.value, enabled: false }
+                              }
+                              outputSize={outputSize}
+                              sourceSize={sourceSize}
+                              cameraReframeEnabled={autoZoomField.state.value.isEnabled}
+                            >
+                              {isCaptureRunning ? (
+                                <div className="relative h-full w-full overflow-hidden">
+                                  <img
+                                    ref={liveCapturePreviewImageRef}
+                                    alt={studio.ui.helper.activePreviewTitle}
+                                    className={cn(
+                                      "h-full w-full object-contain",
+                                      liveCapturePreviewHasFrame ? "block" : "hidden",
+                                    )}
+                                    onLoad={(event) => {
+                                      const image = event.currentTarget;
+                                      if (image.naturalWidth > 0 && image.naturalHeight > 0) {
+                                        setSourceSize((current) =>
+                                          current.width === image.naturalWidth &&
+                                          current.height === image.naturalHeight
+                                            ? current
+                                            : {
+                                                width: image.naturalWidth,
+                                                height: image.naturalHeight,
+                                              },
+                                        );
+                                      }
+                                    }}
+                                  />
+                                  {!liveCapturePreviewHasFrame ? (
+                                    <div className="flex h-full w-full items-center justify-center text-center">
+                                      <p className="text-sm font-medium">
+                                        {studio.ui.helper.activePreviewTitle}
+                                      </p>
+                                    </div>
+                                  ) : null}
 
-                              {studio.captureStatusQuery.data?.isRecording ? (
-                                <div className="pointer-events-none absolute top-4 left-4 flex items-center gap-2 rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-white shadow-lg ring-1 ring-white/15 backdrop-blur-sm">
-                                  <span className="h-2 w-2 rounded-full bg-red-500" />
-                                  {studio.ui.labels.recording}
+                                  {studio.captureStatusQuery.data?.isRecording ? (
+                                    <div className="pointer-events-none absolute top-4 left-4 flex items-center gap-2 rounded-full bg-black/70 px-3 py-1 text-xs font-medium text-white shadow-lg ring-1 ring-white/15 backdrop-blur-sm">
+                                      <span className="h-2 w-2 rounded-full bg-red-500" />
+                                      {studio.ui.labels.recording}
+                                    </div>
+                                  ) : null}
                                 </div>
-                              ) : null}
-                            </div>
-                          ) : recordingMediaSource ? (
-                            <video
-                              key={recordingMediaSource}
-                              src={recordingMediaSource}
-                              className="h-full w-full object-contain"
-                              preload="metadata"
-                              controls
-                              playsInline
-                              onLoadedMetadata={(event) => {
-                                const video = event.currentTarget;
-                                if (video.videoWidth > 0 && video.videoHeight > 0) {
-                                  setSourceSize({
-                                    width: video.videoWidth,
-                                    height: video.videoHeight,
-                                  });
-                                }
-                              }}
-                              onError={handleMediaError}
-                            />
-                          ) : (
-                            <Empty className="h-full border-0 bg-transparent p-6">
-                              <EmptyHeader>
-                                <EmptyTitle className="text-sm">
-                                  {studio.ui.helper.emptyPreviewTitle}
-                                </EmptyTitle>
-                                <EmptyDescription>
-                                  {studio.ui.helper.emptyPreviewBody}
-                                </EmptyDescription>
-                              </EmptyHeader>
-                            </Empty>
+                              ) : recordingMediaSource ? (
+                                <video
+                                  key={recordingMediaSource}
+                                  src={recordingMediaSource}
+                                  className="h-full w-full object-contain"
+                                  preload="metadata"
+                                  controls
+                                  playsInline
+                                  onLoadedMetadata={(event) => {
+                                    const video = event.currentTarget;
+                                    if (video.videoWidth > 0 && video.videoHeight > 0) {
+                                      setSourceSize({
+                                        width: video.videoWidth,
+                                        height: video.videoHeight,
+                                      });
+                                    }
+                                  }}
+                                  onError={handleMediaError}
+                                />
+                              ) : (
+                                <Empty className="h-full border-0 bg-transparent p-6">
+                                  <EmptyHeader>
+                                    <EmptyTitle className="text-sm">
+                                      {studio.ui.helper.emptyPreviewTitle}
+                                    </EmptyTitle>
+                                    <EmptyDescription>
+                                      {studio.ui.helper.emptyPreviewBody}
+                                    </EmptyDescription>
+                                  </EmptyHeader>
+                                </Empty>
+                              )}
+                            </BackgroundFramingPreview>
                           )}
-                        </BackgroundFramingPreview>
+                        </studio.settingsForm.Field>
                       )}
                     </studio.settingsForm.Field>
                   </div>

--- a/apps/desktop-electrobun/src/mainview/app/studio/routes/EditRoute.tsx
+++ b/apps/desktop-electrobun/src/mainview/app/studio/routes/EditRoute.tsx
@@ -99,60 +99,67 @@ export function EditRoute() {
                 <div className="gg-preview-stage">
                   <studio.settingsForm.Field name="backgroundFraming">
                     {(field) => (
-                      <BackgroundFramingPreview
-                        settings={
-                          studio.backgroundFramingSupported
-                            ? field.state.value
-                            : { ...field.state.value, enabled: false }
-                        }
-                        outputSize={outputSize}
-                        sourceSize={sourceSize}
-                        cardRef={sourceCardRef}
-                      >
-                        {recordingMediaSource ? (
-                          <video
-                            ref={mediaRef}
-                            key={recordingMediaSource}
-                            src={recordingMediaSource}
-                            className="h-full w-full object-contain"
-                            preload="metadata"
-                            controls
-                            playsInline
-                            onLoadedMetadata={(event) => {
-                              const video = event.currentTarget;
-                              if (video.videoWidth > 0 && video.videoHeight > 0) {
-                                setSourceSize({
-                                  width: video.videoWidth,
-                                  height: video.videoHeight,
-                                });
-                              }
-                            }}
-                            onPlay={() => {
-                              setTimelinePlaybackActive(true);
-                            }}
-                            onPause={() => {
-                              setTimelinePlaybackActive(false);
-                            }}
-                            onError={handleMediaError}
-                          />
-                        ) : captureStatusQuery.data?.isRunning ? (
-                          <div className="flex h-full flex-col items-center justify-center space-y-2 text-center">
-                            <p className="text-sm font-medium">{ui.helper.activePreviewTitle}</p>
-                            <p className="text-xs text-muted-foreground">
-                              {ui.helper.activePreviewBody}
-                            </p>
-                          </div>
-                        ) : (
-                          <Empty className="h-full border-border/70 bg-background/70 p-6">
-                            <EmptyHeader>
-                              <EmptyTitle className="text-sm">
-                                {ui.helper.emptyPreviewTitle}
-                              </EmptyTitle>
-                              <EmptyDescription>{ui.helper.emptyPreviewBody}</EmptyDescription>
-                            </EmptyHeader>
-                          </Empty>
+                      <studio.settingsForm.Field name="autoZoom">
+                        {(autoZoomField) => (
+                          <BackgroundFramingPreview
+                            settings={
+                              studio.backgroundFramingSupported
+                                ? field.state.value
+                                : { ...field.state.value, enabled: false }
+                            }
+                            outputSize={outputSize}
+                            sourceSize={sourceSize}
+                            cameraReframeEnabled={autoZoomField.state.value.isEnabled}
+                            cardRef={sourceCardRef}
+                          >
+                            {recordingMediaSource ? (
+                              <video
+                                ref={mediaRef}
+                                key={recordingMediaSource}
+                                src={recordingMediaSource}
+                                className="h-full w-full object-contain"
+                                preload="metadata"
+                                controls
+                                playsInline
+                                onLoadedMetadata={(event) => {
+                                  const video = event.currentTarget;
+                                  if (video.videoWidth > 0 && video.videoHeight > 0) {
+                                    setSourceSize({
+                                      width: video.videoWidth,
+                                      height: video.videoHeight,
+                                    });
+                                  }
+                                }}
+                                onPlay={() => {
+                                  setTimelinePlaybackActive(true);
+                                }}
+                                onPause={() => {
+                                  setTimelinePlaybackActive(false);
+                                }}
+                                onError={handleMediaError}
+                              />
+                            ) : captureStatusQuery.data?.isRunning ? (
+                              <div className="flex h-full flex-col items-center justify-center space-y-2 text-center">
+                                <p className="text-sm font-medium">
+                                  {ui.helper.activePreviewTitle}
+                                </p>
+                                <p className="text-xs text-muted-foreground">
+                                  {ui.helper.activePreviewBody}
+                                </p>
+                              </div>
+                            ) : (
+                              <Empty className="h-full border-border/70 bg-background/70 p-6">
+                                <EmptyHeader>
+                                  <EmptyTitle className="text-sm">
+                                    {ui.helper.emptyPreviewTitle}
+                                  </EmptyTitle>
+                                  <EmptyDescription>{ui.helper.emptyPreviewBody}</EmptyDescription>
+                                </EmptyHeader>
+                              </Empty>
+                            )}
+                          </BackgroundFramingPreview>
                         )}
-                      </BackgroundFramingPreview>
+                      </studio.settingsForm.Field>
                     )}
                   </studio.settingsForm.Field>
                 </div>

--- a/apps/desktop-electrobun/src/mainview/index.css
+++ b/apps/desktop-electrobun/src/mainview/index.css
@@ -455,6 +455,11 @@
     );
   }
 
+  .gg-camera-reframe-card video,
+  .gg-camera-reframe-card img {
+    object-fit: cover;
+  }
+
   .gg-preview-footer {
     @apply shrink-0;
   }

--- a/apps/desktop-electrobun/src/mainview/lib/engine.ts
+++ b/apps/desktop-electrobun/src/mainview/lib/engine.ts
@@ -274,6 +274,7 @@ export const engineApi = {
     trimStartSeconds?: number;
     trimEndSeconds?: number;
     timeline?: TimelineDocument;
+    autoZoom?: AutoZoomSettings;
     backgroundFraming?: BackgroundFramingSettings;
   }) {
     return await invokeBridgeContract("ggEngineRunExport", "export run result", params);

--- a/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
+++ b/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
@@ -45,6 +45,7 @@ import {
 } from "@guerillaglass/engine-contract/domains/system";
 import type {
   AutoZoomSettings,
+  BackgroundFramingSettings,
   TimelineDocument,
 } from "@guerillaglass/engine-contract/shared/valueObjects";
 import {
@@ -627,6 +628,8 @@ export const bridgeRequestDefinitions = {
       trimStartSeconds?: number;
       trimEndSeconds?: number;
       timeline?: TimelineDocument;
+      autoZoom?: AutoZoomSettings;
+      backgroundFraming?: BackgroundFramingSettings;
     },
     ExportRunResult,
     [
@@ -636,6 +639,8 @@ export const bridgeRequestDefinitions = {
         trimStartSeconds?: number;
         trimEndSeconds?: number;
         timeline?: TimelineDocument;
+        autoZoom?: AutoZoomSettings;
+        backgroundFraming?: BackgroundFramingSettings;
       },
     ]
   >(
@@ -680,9 +685,21 @@ export const bridgeRequestDefinitions = {
     engineSuccessSchema("project.open"),
   ),
   ggEngineProjectSave: defineValidatedBridgeRequest<
-    { projectPath?: ProjectPath; autoZoom?: AutoZoomSettings; timeline?: TimelineDocument },
+    {
+      projectPath?: ProjectPath;
+      autoZoom?: AutoZoomSettings;
+      backgroundFraming?: BackgroundFramingSettings;
+      timeline?: TimelineDocument;
+    },
     ProjectState,
-    [params: { projectPath?: string; autoZoom?: AutoZoomSettings; timeline?: TimelineDocument }]
+    [
+      params: {
+        projectPath?: string;
+        autoZoom?: AutoZoomSettings;
+        backgroundFraming?: BackgroundFramingSettings;
+        timeline?: TimelineDocument;
+      },
+    ]
   >(
     (params) => ({
       ...params,

--- a/apps/desktop-electrobun/tests/engine-api.test.ts
+++ b/apps/desktop-electrobun/tests/engine-api.test.ts
@@ -518,11 +518,13 @@ describe("renderer engine bridge", () => {
       outputURL: "/tmp/out.mp4",
       presetId: "h264-1080p-30",
       timeline,
+      autoZoom: { isEnabled: true, intensity: 0.75, minimumKeyframeInterval: 1 / 30 },
       backgroundFraming: defaultBackgroundFramingSettings,
     });
 
     expect(capturedParams).toMatchObject({
       timeline,
+      autoZoom: { isEnabled: true, intensity: 0.75, minimumKeyframeInterval: 1 / 30 },
       backgroundFraming: defaultBackgroundFramingSettings,
     });
   });

--- a/apps/desktop-electrobun/tests/ui/studio-shell.browser.test.tsx
+++ b/apps/desktop-electrobun/tests/ui/studio-shell.browser.test.tsx
@@ -96,9 +96,15 @@ function installMockBridge() {
         name: "1080p",
         width: 1920,
         height: 1080,
-        frameRate: 60,
-        videoBitRate: 8_000_000,
-        audioBitRate: 192_000,
+        fps: 60,
+        fileType: "mp4",
+      },
+      {
+        id: "preset-vertical",
+        name: "Vertical 1080p",
+        width: 1080,
+        height: 1920,
+        fps: 30,
         fileType: "mp4",
       },
     ],
@@ -149,6 +155,7 @@ let root: Root | undefined;
 beforeEach(() => {
   backgroundFramingSupported = true;
   localStorage.clear();
+  window.history.replaceState({}, "", "/capture");
   installMockBridge();
   document.body.innerHTML = '<div id="root"></div>';
   root = createRoot(document.getElementById("root")!);
@@ -174,6 +181,9 @@ describe("studio shell browser smoke", () => {
       .toHaveAttribute("data-framing-enabled", "true");
     await expect.element(page.getByTestId("background-framing-card")).toBeVisible();
     await expect
+      .element(page.getByTestId("background-framing-card"))
+      .toHaveAttribute("data-camera-reframe", "true");
+    await expect
       .element(page.getByRole("slider", { name: "Background padding" }))
       .toBeInTheDocument();
     await expect
@@ -181,6 +191,26 @@ describe("studio shell browser smoke", () => {
       .toBeInTheDocument();
     await expect.element(page.getByRole("slider", { name: "Shadow strength" })).toBeInTheDocument();
     await page.screenshot({ path: "../../test-results/screenshots/background-framing.png" });
+  });
+
+  test("vertical presets switch the auto-zoom preview to a portrait viewport", async () => {
+    await page.getByRole("link", { name: "Deliver" }).click();
+    await page
+      .getByTestId("editor-center-pane")
+      .getByRole("combobox")
+      .selectOptions("preset-vertical");
+    await page.getByRole("link", { name: "Edit" }).click();
+    await expect.element(page.getByTestId("background-framing-card")).toBeVisible();
+
+    const card = document.querySelector<HTMLElement>("[data-testid='background-framing-card']");
+    expect(card).not.toBeNull();
+    const bounds = card!.getBoundingClientRect();
+    expect(bounds.height).toBeGreaterThan(bounds.width);
+    await expect
+      .element(page.getByTestId("background-framing-card"))
+      .toHaveAttribute("data-camera-reframe", "true");
+    await page.screenshot({ path: "../../test-results/screenshots/vertical-camera-preview.png" });
+    await page.getByRole("link", { name: "Capture" }).click();
   });
 
   test("unsupported native renderers hide framing controls and keep preview disabled", async () => {

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -293,7 +293,13 @@ Progress (current repo)
   - Preview and export share golden geometry vectors for stage padding, aspect-fit card bounds, corner radius, and shadow formulas.
   - Native export uses explicit sRGB stage color, rounded source masking, gap-aware shadow visibility, and cancellation-aware async export.
   - Capability reporting enables framing only on the production macOS renderer; Rust foundation shells explicitly report it unsupported.
-- [ ] Vertical export with re-planned camera
+- [x] Vertical export with re-planned camera
+  - macOS export derives a fresh camera plan for each selected output preset from persisted input events and the explicit export auto-zoom override (falling back to project settings for older clients).
+  - Capture-space event coordinates are normalized through persisted capture metadata before planning against the oriented source dimensions.
+  - Camera viewports use the output aspect ratio, so 9:16 exports crop and pan within a portrait viewport instead of reusing landscape transforms.
+  - Direct and timeline exports share the same aspect-aware viewport transform while preserving clip/gap and program-time trim semantics.
+  - Capture/Edit previews switch between legacy aspect-fit and aspect-aware cover composition with the auto-zoom toggle.
+  - Swift coverage verifies landscape-versus-portrait replanning, deterministic viewport geometry, event-directed raster output, and encoded portrait dimensions.
 - [x] Live preview remains useful during recording
 - [x] Timeline v2 clip/gap data model implemented in contract, renderer, and Swift project state
 - [x] Pure split/delete/lift/move command layer implemented with unit coverage
@@ -313,7 +319,7 @@ Suggested Phase 2 PR slices:
 2. `phase2/timeline-drag-move-gaps` — add drag-to-move, finish gap interaction/readability, and verify preview behavior across gaps.
 3. `phase2/background-framing-contract` — define persisted background framing/effects settings in the project/export contract per `docs/BACKGROUND_FRAMING_DESIGN.md` (implemented).
 4. `phase2/background-framing-renderer` — implement native export rendering for background stage, padding, rounded screen card, and shadow (implemented).
-5. `phase2/vertical-camera-replan` — make camera planning/export aspect-ratio-aware for 9:16 vertical output.
+5. `phase2/vertical-camera-replan` — make camera planning/export aspect-ratio-aware for 9:16 vertical output (implemented).
 6. `phase2/segment-camera-overrides` — add clip-level camera/keyframe override model and inspector controls.
 7. `phase2/crop-reframe-tool` — add deterministic crop/reframe controls with preview/export wiring.
 8. `phase2/redaction-highlight-tools` — add redaction/highlight overlay models and render hooks.

--- a/engines/macos-swift/EngineService+Export.swift
+++ b/engines/macos-swift/EngineService+Export.swift
@@ -45,7 +45,7 @@ extension EngineService {
                 preset: preset,
                 trimRange: trimRange(start: payload.trimStartSeconds?.value1, end: payload.trimEndSeconds?.value1),
                 outputURL: URL(fileURLWithPath: payload.outputURL.value1),
-                cameraEvents: availableCameraEvents(),
+                cameraEvents: availableCameraEvents(for: resolvedAutoZoom),
                 autoZoomSettings: resolvedAutoZoom,
                 captureMetadata: currentProjectDocument.project.captureMetadata,
                 timeline: exportTimeline(from: payload.timeline),
@@ -91,7 +91,7 @@ extension EngineService {
                 preset: preset,
                 trimRange: nil,
                 outputURL: URL(fileURLWithPath: payload.outputURL.value1),
-                cameraEvents: availableCameraEvents(),
+                cameraEvents: availableCameraEvents(for: currentProjectDocument.project.autoZoom),
                 autoZoomSettings: currentProjectDocument.project.autoZoom,
                 captureMetadata: currentProjectDocument.project.captureMetadata,
                 backgroundFraming: currentProjectDocument.project.backgroundFraming
@@ -131,7 +131,8 @@ extension EngineService {
         return captureEngine.recordingURL
     }
 
-    private func availableCameraEvents() throws -> [InputEvent] {
+    private func availableCameraEvents(for autoZoom: AutoZoomSettings) throws -> [InputEvent] {
+        guard autoZoom.requiresInputEvents else { return [] }
         guard let eventsURL = projectEventsURL() ?? currentEventsURL,
               FileManager.default.fileExists(atPath: eventsURL.path)
         else { return [] }

--- a/engines/macos-swift/EngineService+Export.swift
+++ b/engines/macos-swift/EngineService+Export.swift
@@ -2,6 +2,7 @@ import AVFoundation
 import EngineProtocol
 import Export
 import Foundation
+import InputTracking
 import Project
 
 extension EngineService {
@@ -37,11 +38,16 @@ extension EngineService {
                 exportOverride: backgroundFramingOverride,
                 persisted: currentProjectDocument.project.backgroundFraming
             )
+            let resolvedAutoZoom = payload.autoZoom.map(projectAutoZoom)
+                ?? currentProjectDocument.project.autoZoom
             let exportedURL = try await exportPipeline.export(
                 recordingURL: recordingURL,
                 preset: preset,
                 trimRange: trimRange(start: payload.trimStartSeconds?.value1, end: payload.trimEndSeconds?.value1),
                 outputURL: URL(fileURLWithPath: payload.outputURL.value1),
+                cameraEvents: availableCameraEvents(),
+                autoZoomSettings: resolvedAutoZoom,
+                captureMetadata: currentProjectDocument.project.captureMetadata,
                 timeline: exportTimeline(from: payload.timeline),
                 backgroundFraming: resolvedBackgroundFraming
             )
@@ -85,6 +91,9 @@ extension EngineService {
                 preset: preset,
                 trimRange: nil,
                 outputURL: URL(fileURLWithPath: payload.outputURL.value1),
+                cameraEvents: availableCameraEvents(),
+                autoZoomSettings: currentProjectDocument.project.autoZoom,
+                captureMetadata: currentProjectDocument.project.captureMetadata,
                 backgroundFraming: currentProjectDocument.project.backgroundFraming
             )
             let jobId = "macos-export-cut-plan-\(UUID().uuidString)"
@@ -120,6 +129,13 @@ extension EngineService {
             return projectURL
         }
         return captureEngine.recordingURL
+    }
+
+    private func availableCameraEvents() throws -> [InputEvent] {
+        guard let eventsURL = projectEventsURL() ?? currentEventsURL,
+              FileManager.default.fileExists(atPath: eventsURL.path)
+        else { return [] }
+        return try InputEventLog.load(from: eventsURL).events
     }
 
     private func trimRange(start: Double?, end: Double?) -> CMTimeRange? {

--- a/engines/macos-swift/EngineService+GeneratedHelpers.swift
+++ b/engines/macos-swift/EngineService+GeneratedHelpers.swift
@@ -91,7 +91,17 @@ extension EngineService {
         )
     }
 
-    func autoZoomState() -> Components.Schemas.ProjectState.autoZoomPayload {
+    func projectAutoZoom(
+        from payload: Components.Schemas.AutoZoomSettings
+    ) -> AutoZoomSettings {
+        AutoZoomSettings(
+            isEnabled: payload.isEnabled,
+            intensity: payload.intensity.value1,
+            minimumKeyframeInterval: payload.minimumKeyframeInterval.value1
+        ).clamped()
+    }
+
+    func autoZoomState() -> Components.Schemas.AutoZoomSettings {
         let autoZoom = currentProjectDocument.project.autoZoom
         return .init(
             isEnabled: autoZoom.isEnabled,

--- a/engines/macos-swift/EngineService+Project.swift
+++ b/engines/macos-swift/EngineService+Project.swift
@@ -52,11 +52,7 @@ extension EngineService {
 
         var document = currentProjectDocument
         if let autoZoom = payload.autoZoom {
-            document.project.autoZoom = AutoZoomSettings(
-                isEnabled: autoZoom.isEnabled,
-                intensity: autoZoom.intensity.value1,
-                minimumKeyframeInterval: autoZoom.minimumKeyframeInterval.value1
-            ).clamped()
+            document.project.autoZoom = projectAutoZoom(from: autoZoom)
         }
         if let backgroundFraming = payload.backgroundFraming {
             do {

--- a/engines/macos-swift/modules/automation/VirtualCameraPlanner.swift
+++ b/engines/macos-swift/modules/automation/VirtualCameraPlanner.swift
@@ -18,11 +18,19 @@ public struct CameraKeyframe: Equatable {
 /// Public value type exposed by the macOS engine module.
 public struct CameraPlan: Equatable {
     public let sourceSize: CGSize
+    /// Aspect ratio used to derive the camera viewport; `nil` preserves legacy full-source framing.
+    public let outputAspectRatio: CGFloat?
     public let keyframes: [CameraKeyframe]
     public let duration: TimeInterval
 
-    public init(sourceSize: CGSize, keyframes: [CameraKeyframe], duration: TimeInterval) {
+    public init(
+        sourceSize: CGSize,
+        outputAspectRatio: CGFloat? = nil,
+        keyframes: [CameraKeyframe],
+        duration: TimeInterval
+    ) {
         self.sourceSize = sourceSize
+        self.outputAspectRatio = outputAspectRatio
         self.keyframes = keyframes
         self.duration = duration
     }
@@ -40,16 +48,23 @@ public final class VirtualCameraPlanner {
         events: [InputEvent],
         sourceSize: CGSize,
         duration: TimeInterval,
+        outputSize: CGSize? = nil,
         constraints: ZoomConstraints = ZoomConstraints()
     ) -> CameraPlan {
         let sanitizedDuration = max(duration, events.map(\.timestamp).max() ?? 0)
+        let outputAspectRatio = validAspectRatio(for: outputSize)
         let samples = attentionModel.samples(from: events, constraints: constraints)
 
         if samples.isEmpty {
             let center = CGPoint(x: sourceSize.width / 2, y: sourceSize.height / 2)
             let zoom = constraints.clampedZoom(constraints.idleZoom)
             let keyframes = makeIdleKeyframes(center: center, zoom: zoom, duration: sanitizedDuration)
-            return CameraPlan(sourceSize: sourceSize, keyframes: keyframes, duration: sanitizedDuration)
+            return CameraPlan(
+                sourceSize: sourceSize,
+                outputAspectRatio: outputAspectRatio,
+                keyframes: keyframes,
+                duration: sanitizedDuration
+            )
         }
 
         let targets = makeAnchoredTargets(
@@ -64,16 +79,27 @@ public final class VirtualCameraPlanner {
         )
 
         let rawKeyframes = reducedTargets.map { target in
-            makeKeyframe(for: target, sourceSize: sourceSize, constraints: constraints)
+            makeKeyframe(
+                for: target,
+                sourceSize: sourceSize,
+                outputAspectRatio: outputAspectRatio,
+                constraints: constraints
+            )
         }
 
         let constrainedKeyframes = applyPanConstraints(
             to: rawKeyframes,
             sourceSize: sourceSize,
+            outputAspectRatio: outputAspectRatio,
             constraints: constraints
         )
 
-        return CameraPlan(sourceSize: sourceSize, keyframes: constrainedKeyframes, duration: sanitizedDuration)
+        return CameraPlan(
+            sourceSize: sourceSize,
+            outputAspectRatio: outputAspectRatio,
+            keyframes: constrainedKeyframes,
+            duration: sanitizedDuration
+        )
     }
 }
 
@@ -163,9 +189,20 @@ private func makeIdleKeyframes(center: CGPoint, zoom: CGFloat, duration: TimeInt
     return [start, end]
 }
 
+private func validAspectRatio(for outputSize: CGSize?) -> CGFloat? {
+    guard let outputSize,
+          outputSize.width.isFinite,
+          outputSize.height.isFinite,
+          outputSize.width > 0,
+          outputSize.height > 0
+    else { return nil }
+    return outputSize.width / outputSize.height
+}
+
 private func makeKeyframe(
     for target: FocusTarget,
     sourceSize: CGSize,
+    outputAspectRatio: CGFloat?,
     constraints: ZoomConstraints
 ) -> CameraKeyframe {
     let baseZoom = max(1.0, constraints.baseZoom)
@@ -173,13 +210,19 @@ private func makeKeyframe(
     let intensity = CGFloat(min(max(target.intensity, 0), 1))
     let zoom = constraints.clampedZoom(baseZoom + (maxZoom - baseZoom) * intensity)
     let clampedTarget = constraints.clampedTarget(target.position, in: sourceSize)
-    let center = constraints.clampedCenter(for: clampedTarget, in: sourceSize, zoom: zoom)
+    let center = constraints.clampedCenter(
+        for: clampedTarget,
+        in: sourceSize,
+        zoom: zoom,
+        outputAspectRatio: outputAspectRatio
+    )
     return CameraKeyframe(time: target.time, center: center, zoom: zoom)
 }
 
 private func applyPanConstraints(
     to keyframes: [CameraKeyframe],
     sourceSize: CGSize,
+    outputAspectRatio: CGFloat?,
     constraints: ZoomConstraints
 ) -> [CameraKeyframe] {
     guard keyframes.count > 1 else { return keyframes }
@@ -190,7 +233,12 @@ private func applyPanConstraints(
 
     for frame in keyframes {
         guard let last = adjusted.last else {
-            let center = constraints.clampedCenter(frame.center, in: sourceSize, zoom: frame.zoom)
+            let center = constraints.clampedCenter(
+                frame.center,
+                in: sourceSize,
+                zoom: frame.zoom,
+                outputAspectRatio: outputAspectRatio
+            )
             adjusted.append(CameraKeyframe(time: frame.time, center: center, zoom: frame.zoom))
             previousVelocity = .zero
             continue
@@ -215,7 +263,12 @@ private func applyPanConstraints(
             desiredCenter = last.center + velocity * deltaTimeValue
         }
 
-        desiredCenter = constraints.clampedCenter(desiredCenter, in: sourceSize, zoom: frame.zoom)
+        desiredCenter = constraints.clampedCenter(
+            desiredCenter,
+            in: sourceSize,
+            zoom: frame.zoom,
+            outputAspectRatio: outputAspectRatio
+        )
         adjusted.append(CameraKeyframe(time: frame.time, center: desiredCenter, zoom: frame.zoom))
         previousVelocity = velocity
     }

--- a/engines/macos-swift/modules/automation/ZoomConstraints.swift
+++ b/engines/macos-swift/modules/automation/ZoomConstraints.swift
@@ -72,13 +72,20 @@ public struct ZoomConstraints: Equatable {
         return CGPoint(x: clampedX, y: clampedY)
     }
 
-    public func clampedCenter(_ center: CGPoint, in sourceSize: CGSize, zoom: CGFloat) -> CGPoint {
+    public func clampedCenter(
+        _ center: CGPoint,
+        in sourceSize: CGSize,
+        zoom: CGFloat,
+        outputAspectRatio: CGFloat? = nil
+    ) -> CGPoint {
         guard sourceSize.width > 0, sourceSize.height > 0 else { return center }
-        let zoomed = clampedZoom(zoom)
-        let viewWidth = sourceSize.width / zoomed
-        let viewHeight = sourceSize.height / zoomed
-        let halfWidth = viewWidth / 2
-        let halfHeight = viewHeight / 2
+        let viewSize = cameraViewSize(
+            in: sourceSize,
+            zoom: zoom,
+            outputAspectRatio: outputAspectRatio
+        )
+        let halfWidth = viewSize.width / 2
+        let halfHeight = viewSize.height / 2
         let minX = halfWidth
         let maxX = sourceSize.width - halfWidth
         let minY = halfHeight
@@ -88,13 +95,20 @@ public struct ZoomConstraints: Equatable {
         return CGPoint(x: clampedX, y: clampedY)
     }
 
-    public func clampedCenter(for target: CGPoint, in sourceSize: CGSize, zoom: CGFloat) -> CGPoint {
+    public func clampedCenter(
+        for target: CGPoint,
+        in sourceSize: CGSize,
+        zoom: CGFloat,
+        outputAspectRatio: CGFloat? = nil
+    ) -> CGPoint {
         guard sourceSize.width > 0, sourceSize.height > 0 else { return target }
-        let zoomed = clampedZoom(zoom)
-        let viewWidth = sourceSize.width / zoomed
-        let viewHeight = sourceSize.height / zoomed
-        let halfWidth = viewWidth / 2
-        let halfHeight = viewHeight / 2
+        let viewSize = cameraViewSize(
+            in: sourceSize,
+            zoom: zoom,
+            outputAspectRatio: outputAspectRatio
+        )
+        let halfWidth = viewSize.width / 2
+        let halfHeight = viewSize.height / 2
 
         let minCenterX = halfWidth
         let maxCenterX = sourceSize.width - halfWidth
@@ -102,8 +116,8 @@ public struct ZoomConstraints: Equatable {
         let maxCenterY = sourceSize.height - halfHeight
 
         let margin = max(0, min(safeMarginFraction, 0.25))
-        let marginX = viewWidth * margin
-        let marginY = viewHeight * margin
+        let marginX = viewSize.width * margin
+        let marginY = viewSize.height * margin
         let innerHalfWidth = max(0, halfWidth - marginX)
         let innerHalfHeight = max(0, halfHeight - marginY)
 
@@ -119,5 +133,24 @@ public struct ZoomConstraints: Equatable {
         let clampedX = min(max(target.x, minAllowedX), maxAllowedX)
         let clampedY = min(max(target.y, minAllowedY), maxAllowedY)
         return CGPoint(x: clampedX, y: clampedY)
+    }
+
+    public func cameraViewSize(
+        in sourceSize: CGSize,
+        zoom: CGFloat,
+        outputAspectRatio: CGFloat? = nil
+    ) -> CGSize {
+        let sourceAspectRatio = sourceSize.width / sourceSize.height
+        let aspectRatio = outputAspectRatio.flatMap { ratio in
+            ratio.isFinite && ratio > 0 ? ratio : nil
+        } ?? sourceAspectRatio
+
+        let baseSize = if sourceAspectRatio > aspectRatio {
+            CGSize(width: sourceSize.height * aspectRatio, height: sourceSize.height)
+        } else {
+            CGSize(width: sourceSize.width, height: sourceSize.width / aspectRatio)
+        }
+        let zoomed = clampedZoom(zoom)
+        return CGSize(width: baseSize.width / zoomed, height: baseSize.height / zoomed)
     }
 }

--- a/engines/macos-swift/modules/export/ExportPipeline.swift
+++ b/engines/macos-swift/modules/export/ExportPipeline.swift
@@ -2,6 +2,7 @@ import Automation
 import AVFoundation
 import Darwin
 import Foundation
+import InputTracking
 import Project
 import Rendering
 
@@ -37,6 +38,9 @@ public final class ExportPipeline {
         trimRange: CMTimeRange?,
         outputURL: URL,
         cameraPlan: CameraPlan? = nil,
+        cameraEvents: [InputEvent]? = nil,
+        autoZoomSettings: AutoZoomSettings? = nil,
+        captureMetadata: CaptureMetadata? = nil,
         timeline: ExportTimelineDocument? = nil,
         backgroundFraming: BackgroundFramingSettings = .defaults
     ) async throws -> URL {
@@ -47,6 +51,9 @@ public final class ExportPipeline {
             trimRange: trimRange,
             outputURL: outputURL,
             cameraPlan: cameraPlan,
+            cameraEvents: cameraEvents,
+            autoZoomSettings: autoZoomSettings,
+            captureMetadata: captureMetadata,
             timeline: timeline,
             backgroundFraming: backgroundFraming
         )
@@ -58,12 +65,30 @@ public final class ExportPipeline {
         trimRange: CMTimeRange?,
         outputURL: URL,
         cameraPlan: CameraPlan? = nil,
+        cameraEvents: [InputEvent]? = nil,
+        autoZoomSettings: AutoZoomSettings? = nil,
+        captureMetadata: CaptureMetadata? = nil,
         timeline: ExportTimelineDocument? = nil,
         backgroundFraming: BackgroundFramingSettings = .defaults
     ) async throws -> URL {
         let videoTracks = try await asset.loadTracks(withMediaType: .video)
-        guard videoTracks.first != nil else {
+        guard let sourceVideoTrack = videoTracks.first else {
             throw ExportError.missingVideoTrack
+        }
+        let renderSize = CGSize(width: preset.width, height: preset.height)
+        let resolvedCameraPlan: CameraPlan? = if let cameraPlan {
+            cameraPlan
+        } else {
+            try await automaticCameraPlan(
+                asset: asset,
+                input: AutomaticCameraPlanInput(
+                    track: sourceVideoTrack,
+                    renderSize: renderSize,
+                    events: cameraEvents,
+                    settings: autoZoomSettings,
+                    captureMetadata: captureMetadata
+                )
+            )
         }
 
         let timelineComposition: ExportTimelineComposition?
@@ -96,20 +121,19 @@ public final class ExportPipeline {
             session.timeRange = trimRange
         }
 
-        let renderSize = CGSize(width: preset.width, height: preset.height)
         if let timelineComposition {
             session.videoComposition = TimelineVideoCompositionBuilder.makeComposition(
                 timelineComposition: timelineComposition,
                 renderSize: renderSize,
                 frameRate: Double(preset.fps),
-                plan: cameraPlan,
+                plan: resolvedCameraPlan,
                 backgroundFraming: backgroundFraming
             )
         } else if let composition = try await renderer.makeVideoComposition(
             asset: asset,
             renderSize: renderSize,
             frameRate: Double(preset.fps),
-            plan: cameraPlan,
+            plan: resolvedCameraPlan,
             backgroundFraming: backgroundFraming
         ) {
             session.videoComposition = composition
@@ -127,6 +151,76 @@ public final class ExportPipeline {
         try installExportFileNoSymlink(from: temporaryOutputURL, to: outputURL)
         try rejectSymlinkComponents(in: outputURL)
         return outputURL
+    }
+}
+
+private struct AutomaticCameraPlanInput {
+    let track: AVAssetTrack
+    let renderSize: CGSize
+    let events: [InputEvent]?
+    let settings: AutoZoomSettings?
+    let captureMetadata: CaptureMetadata?
+}
+
+private func automaticCameraPlan(
+    asset: AVAsset,
+    input: AutomaticCameraPlanInput
+) async throws -> CameraPlan? {
+    guard let settings = input.settings, settings.isEnabled else { return nil }
+    let clampedSettings = settings.clamped()
+    let naturalSize = try await input.track.load(.naturalSize)
+    let preferredTransform = try await input.track.load(.preferredTransform)
+    let sourceSize = VideoGeometryTransforms.orientedBounds(
+        naturalSize: naturalSize,
+        preferredTransform: preferredTransform
+    ).size
+    guard sourceSize.width > 0, sourceSize.height > 0 else { return nil }
+
+    let duration = try await asset.load(.duration).seconds
+    let intensity = clampedSettings.intensity
+    let mappedEvents = intensity > 0 ? mapCameraEvents(
+        input.events ?? [],
+        captureMetadata: input.captureMetadata,
+        sourceSize: sourceSize
+    ) : []
+    let constraints = ZoomConstraints(
+        idleZoom: CGFloat(1 + 0.05 * intensity),
+        minimumKeyframeInterval: clampedSettings.minimumKeyframeInterval,
+        motionIntensity: 0.25 * intensity,
+        dwellIntensity: 0.7 * intensity,
+        clickIntensity: intensity
+    )
+    return VirtualCameraPlanner().plan(
+        events: mappedEvents,
+        sourceSize: sourceSize,
+        duration: duration.isFinite ? max(0, duration) : 0,
+        outputSize: input.renderSize,
+        constraints: constraints
+    )
+}
+
+private func mapCameraEvents(
+    _ events: [InputEvent],
+    captureMetadata: CaptureMetadata?,
+    sourceSize: CGSize
+) -> [InputEvent] {
+    guard let captureMetadata else { return events }
+    let contentRect = captureMetadata.contentRect.cgRect
+    guard contentRect.width > 0, contentRect.height > 0 else { return events }
+
+    return events.map { event in
+        let position = event.position.cgPoint
+        let normalizedX = min(max((position.x - contentRect.minX) / contentRect.width, 0), 1)
+        let normalizedY = min(max((position.y - contentRect.minY) / contentRect.height, 0), 1)
+        return InputEvent(
+            type: event.type,
+            timestamp: event.timestamp,
+            position: CGPoint(
+                x: normalizedX * sourceSize.width,
+                y: normalizedY * sourceSize.height
+            ),
+            button: event.button
+        )
     }
 }
 

--- a/engines/macos-swift/modules/export/TimelineVideoCompositionBuilder.swift
+++ b/engines/macos-swift/modules/export/TimelineVideoCompositionBuilder.swift
@@ -21,9 +21,12 @@ public enum TimelineVideoCompositionBuilder {
             naturalSize: sourceNaturalSize,
             preferredTransform: sourcePreferredTransform
         )
+        let compositionContentSize = plan?.outputAspectRatio.map {
+            CGSize(width: $0, height: 1)
+        } ?? sourceBounds.size
         guard let geometry = BackgroundFramingGeometry(
             renderSize: renderSize,
-            orientedSourceSize: sourceBounds.size,
+            orientedSourceSize: compositionContentSize,
             settings: backgroundFraming
         ) else { return nil }
         let baseTransform = VideoGeometryTransforms.sourceToCardTransform(
@@ -32,6 +35,13 @@ public enum TimelineVideoCompositionBuilder {
             cardRect: geometry.cardRect
         )
         let sortedKeyframes = plan?.keyframes.sorted(by: { $0.time < $1.time }) ?? []
+        let cameraContext = TimelineCameraTransformContext(
+            baseTransform: baseTransform,
+            naturalSize: sourceNaturalSize,
+            preferredTransform: sourcePreferredTransform,
+            cardRect: geometry.cardRect,
+            outputAspectRatio: plan?.outputAspectRatio
+        )
 
         let instructions = timelineComposition.items.compactMap { item -> AVMutableVideoCompositionInstruction? in
             let range = item.programRange
@@ -47,8 +57,7 @@ public enum TimelineVideoCompositionBuilder {
                 let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: videoTrack)
                 applyTimelineClipTransforms(
                     layerInstruction: layerInstruction,
-                    baseTransform: baseTransform,
-                    sourceSize: sourceNaturalSize,
+                    cameraContext: cameraContext,
                     sourceRange: sourceRange,
                     programRange: programRange,
                     keyframes: sortedKeyframes
@@ -88,14 +97,24 @@ public enum TimelineVideoCompositionBuilder {
     }
 }
 
+private struct TimelineCameraTransformContext {
+    let baseTransform: CGAffineTransform
+    let naturalSize: CGSize
+    let preferredTransform: CGAffineTransform
+    let cardRect: CGRect
+    let outputAspectRatio: CGFloat?
+}
+
 private func applyTimelineClipTransforms(
     layerInstruction: AVMutableVideoCompositionLayerInstruction,
-    baseTransform: CGAffineTransform,
-    sourceSize: CGSize,
+    cameraContext: TimelineCameraTransformContext,
     sourceRange: CMTimeRange,
     programRange: CMTimeRange,
     keyframes: [CameraKeyframe]
 ) {
+    let baseTransform = cameraContext.baseTransform
+    let naturalSize = cameraContext.naturalSize
+
     guard !keyframes.isEmpty else {
         layerInstruction.setTransform(baseTransform, at: programRange.start)
         return
@@ -106,41 +125,35 @@ private func applyTimelineClipTransforms(
     let initialKeyframe = interpolatedKeyframe(
         at: sourceStartSeconds,
         keyframes: keyframes,
-        sourceSize: sourceSize
+        sourceSize: naturalSize
     )
     layerInstruction.setTransform(
-        timelineClipTransform(baseTransform: baseTransform, keyframe: initialKeyframe, sourceSize: sourceSize),
+        timelineClipTransform(cameraContext: cameraContext, keyframe: initialKeyframe),
         at: programRange.start
     )
 
     var previous = initialKeyframe
     for keyframe in keyframes where keyframe.time > sourceStartSeconds && keyframe.time < sourceEndSeconds {
-        let rampStartSourceSeconds = previous.time
-        let rampEndSourceSeconds = keyframe.time
         let startTime = sourceSecondsToProgramTime(
-            rampStartSourceSeconds,
+            previous.time,
             sourceRange: sourceRange,
             programRange: programRange
         )
         let endTime = sourceSecondsToProgramTime(
-            rampEndSourceSeconds,
+            keyframe.time,
             sourceRange: sourceRange,
             programRange: programRange
         )
         if endTime > startTime {
-            let startTransform = timelineClipTransform(
-                baseTransform: baseTransform,
-                keyframe: previous,
-                sourceSize: sourceSize
-            )
-            let endTransform = timelineClipTransform(
-                baseTransform: baseTransform,
-                keyframe: keyframe,
-                sourceSize: sourceSize
-            )
             layerInstruction.setTransformRamp(
-                fromStart: startTransform,
-                toEnd: endTransform,
+                fromStart: timelineClipTransform(
+                    cameraContext: cameraContext,
+                    keyframe: previous
+                ),
+                toEnd: timelineClipTransform(
+                    cameraContext: cameraContext,
+                    keyframe: keyframe
+                ),
                 timeRange: CMTimeRange(start: startTime, end: endTime)
             )
         }
@@ -150,7 +163,7 @@ private func applyTimelineClipTransforms(
     let finalKeyframe = interpolatedKeyframe(
         at: sourceEndSeconds,
         keyframes: keyframes,
-        sourceSize: sourceSize
+        sourceSize: naturalSize
     )
     let finalStartTime = sourceSecondsToProgramTime(
         previous.time,
@@ -158,19 +171,15 @@ private func applyTimelineClipTransforms(
         programRange: programRange
     )
     if programRange.end > finalStartTime {
-        let startTransform = timelineClipTransform(
-            baseTransform: baseTransform,
-            keyframe: previous,
-            sourceSize: sourceSize
-        )
-        let endTransform = timelineClipTransform(
-            baseTransform: baseTransform,
-            keyframe: finalKeyframe,
-            sourceSize: sourceSize
-        )
         layerInstruction.setTransformRamp(
-            fromStart: startTransform,
-            toEnd: endTransform,
+            fromStart: timelineClipTransform(
+                cameraContext: cameraContext,
+                keyframe: previous
+            ),
+            toEnd: timelineClipTransform(
+                cameraContext: cameraContext,
+                keyframe: finalKeyframe
+            ),
             timeRange: CMTimeRange(start: finalStartTime, end: programRange.end)
         )
     }
@@ -222,13 +231,21 @@ private func interpolatedKeyframe(
 }
 
 private func timelineClipTransform(
-    baseTransform: CGAffineTransform,
-    keyframe: CameraKeyframe,
-    sourceSize: CGSize
+    cameraContext: TimelineCameraTransformContext,
+    keyframe: CameraKeyframe
 ) -> CGAffineTransform {
-    VideoGeometryTransforms.sourceTransform(
-        baseTransform: baseTransform,
+    guard let outputAspectRatio = cameraContext.outputAspectRatio else {
+        return VideoGeometryTransforms.sourceTransform(
+            baseTransform: cameraContext.baseTransform,
+            keyframe: keyframe,
+            sourceSize: cameraContext.naturalSize
+        )
+    }
+    return VideoGeometryTransforms.sourceToCameraViewportTransform(
+        naturalSize: cameraContext.naturalSize,
+        preferredTransform: cameraContext.preferredTransform,
+        cardRect: cameraContext.cardRect,
         keyframe: keyframe,
-        sourceSize: sourceSize
+        outputAspectRatio: outputAspectRatio
     )
 }

--- a/engines/macos-swift/modules/project/AutoZoomSettings.swift
+++ b/engines/macos-swift/modules/project/AutoZoomSettings.swift
@@ -20,6 +20,12 @@ public struct AutoZoomSettings: Codable, Equatable {
         self.minimumKeyframeInterval = minimumKeyframeInterval
     }
 
+    /// Whether camera planning needs the persisted input-event artifact.
+    public var requiresInputEvents: Bool {
+        let settings = clamped()
+        return settings.isEnabled && settings.intensity > 0
+    }
+
     public func clamped() -> AutoZoomSettings {
         var clamped = self
         let intensity = intensity.isFinite ? intensity : 1.0

--- a/engines/macos-swift/modules/rendering/CameraPlanVideoCompositionBuilder.swift
+++ b/engines/macos-swift/modules/rendering/CameraPlanVideoCompositionBuilder.swift
@@ -30,22 +30,23 @@ enum CameraPlanVideoCompositionBuilder {
             naturalSize: naturalSize,
             preferredTransform: preferredTransform
         )
+        let compositionContentSize = plan?.outputAspectRatio.map {
+            CGSize(width: $0, height: 1)
+        } ?? sourceBounds.size
         guard let geometry = BackgroundFramingGeometry(
             renderSize: renderSize,
-            orientedSourceSize: sourceBounds.size,
+            orientedSourceSize: compositionContentSize,
             settings: backgroundFraming
         ) else { return nil }
-        let baseTransform = VideoGeometryTransforms.sourceToCardTransform(
-            naturalSize: naturalSize,
-            preferredTransform: preferredTransform,
-            cardRect: geometry.cardRect
-        )
 
         let layerInstruction = makeLayerInstruction(
             track: track,
-            baseTransform: baseTransform,
-            plan: plan,
-            sourceSize: naturalSize,
+            context: CameraTransformContext(
+                naturalSize: naturalSize,
+                preferredTransform: preferredTransform,
+                cardRect: geometry.cardRect,
+                plan: plan
+            ),
             duration: duration
         )
 
@@ -76,24 +77,36 @@ enum CameraPlanVideoCompositionBuilder {
     }
 }
 
+private struct CameraTransformContext {
+    let naturalSize: CGSize
+    let preferredTransform: CGAffineTransform
+    let cardRect: CGRect
+    let plan: CameraPlan?
+}
+
 private func makeLayerInstruction(
     track: AVAssetTrack,
-    baseTransform: CGAffineTransform,
-    plan: CameraPlan?,
-    sourceSize: CGSize,
+    context: CameraTransformContext,
     duration: CMTime
 ) -> AVMutableVideoCompositionLayerInstruction {
     let layerInstruction = AVMutableVideoCompositionLayerInstruction(assetTrack: track)
-    guard let plan, !plan.keyframes.isEmpty else {
-        layerInstruction.setTransform(baseTransform, at: .zero)
+    guard let plan = context.plan, !plan.keyframes.isEmpty else {
+        layerInstruction.setTransform(
+            VideoGeometryTransforms.sourceToCardTransform(
+                naturalSize: context.naturalSize,
+                preferredTransform: context.preferredTransform,
+                cardRect: context.cardRect
+            ),
+            at: .zero
+        )
         return layerInstruction
     }
 
     let keyframes = plan.keyframes.sorted(by: { $0.time < $1.time })
-    let firstTransform = VideoGeometryTransforms.sourceTransform(
-        baseTransform: baseTransform,
+    let firstTransform = cameraTransform(
+        context: context,
         keyframe: keyframes[0],
-        sourceSize: sourceSize
+        plan: plan
     )
     layerInstruction.setTransform(firstTransform, at: .zero)
 
@@ -106,16 +119,8 @@ private func makeLayerInstruction(
             continue
         }
 
-        let startTransform = VideoGeometryTransforms.sourceTransform(
-            baseTransform: baseTransform,
-            keyframe: previous,
-            sourceSize: sourceSize
-        )
-        let endTransform = VideoGeometryTransforms.sourceTransform(
-            baseTransform: baseTransform,
-            keyframe: keyframe,
-            sourceSize: sourceSize
-        )
+        let startTransform = cameraTransform(context: context, keyframe: previous, plan: plan)
+        let endTransform = cameraTransform(context: context, keyframe: keyframe, plan: plan)
         let timeRange = CMTimeRange(start: startTime, end: endTime)
         layerInstruction.setTransformRamp(
             fromStart: startTransform,
@@ -126,6 +131,32 @@ private func makeLayerInstruction(
     }
 
     return layerInstruction
+}
+
+private func cameraTransform(
+    context: CameraTransformContext,
+    keyframe: CameraKeyframe,
+    plan: CameraPlan
+) -> CGAffineTransform {
+    guard let outputAspectRatio = plan.outputAspectRatio else {
+        let baseTransform = VideoGeometryTransforms.sourceToCardTransform(
+            naturalSize: context.naturalSize,
+            preferredTransform: context.preferredTransform,
+            cardRect: context.cardRect
+        )
+        return VideoGeometryTransforms.sourceTransform(
+            baseTransform: baseTransform,
+            keyframe: keyframe,
+            sourceSize: context.naturalSize
+        )
+    }
+    return VideoGeometryTransforms.sourceToCameraViewportTransform(
+        naturalSize: context.naturalSize,
+        preferredTransform: context.preferredTransform,
+        cardRect: context.cardRect,
+        keyframe: keyframe,
+        outputAspectRatio: outputAspectRatio
+    )
 }
 
 private func clampTime(_ time: TimeInterval, duration: CMTime) -> CMTime {

--- a/engines/macos-swift/modules/rendering/VideoGeometryTransforms.swift
+++ b/engines/macos-swift/modules/rendering/VideoGeometryTransforms.swift
@@ -66,4 +66,78 @@ public enum VideoGeometryTransforms {
     ) -> CGAffineTransform {
         cameraTransform(for: keyframe, sourceSize: sourceSize).concatenating(baseTransform)
     }
+
+    public static func sourceToCameraViewportTransform(
+        naturalSize: CGSize,
+        preferredTransform: CGAffineTransform,
+        cardRect: CGRect,
+        keyframe: CameraKeyframe,
+        outputAspectRatio: CGFloat
+    ) -> CGAffineTransform {
+        let bounds = orientedBounds(naturalSize: naturalSize, preferredTransform: preferredTransform)
+        guard bounds.width > 0,
+              bounds.height > 0,
+              cardRect.width > 0,
+              cardRect.height > 0,
+              outputAspectRatio.isFinite,
+              outputAspectRatio > 0
+        else {
+            return sourceToCardTransform(
+                naturalSize: naturalSize,
+                preferredTransform: preferredTransform,
+                cardRect: cardRect
+            )
+        }
+
+        let viewport = cameraViewportRect(
+            sourceSize: bounds.size,
+            keyframe: keyframe,
+            outputAspectRatio: outputAspectRatio
+        )
+        let scale = min(cardRect.width / viewport.width, cardRect.height / viewport.height)
+        let scaledSize = CGSize(width: viewport.width * scale, height: viewport.height * scale)
+        let destinationOrigin = CGPoint(
+            x: cardRect.midX - scaledSize.width / 2,
+            y: cardRect.midY - scaledSize.height / 2
+        )
+
+        var destinationTransform = CGAffineTransform(
+            translationX: destinationOrigin.x,
+            y: destinationOrigin.y
+        )
+        destinationTransform = destinationTransform.scaledBy(x: scale, y: scale)
+        destinationTransform = destinationTransform.translatedBy(
+            x: -bounds.minX - viewport.minX,
+            y: -bounds.minY - viewport.minY
+        )
+        return preferredTransform.concatenating(destinationTransform)
+    }
+
+    public static func cameraViewportRect(
+        sourceSize: CGSize,
+        keyframe: CameraKeyframe,
+        outputAspectRatio: CGFloat
+    ) -> CGRect {
+        let sourceAspectRatio = sourceSize.width / sourceSize.height
+        let baseSize = if sourceAspectRatio > outputAspectRatio {
+            CGSize(width: sourceSize.height * outputAspectRatio, height: sourceSize.height)
+        } else {
+            CGSize(width: sourceSize.width, height: sourceSize.width / outputAspectRatio)
+        }
+
+        let zoom = max(1, keyframe.zoom)
+        let viewportSize = CGSize(width: baseSize.width / zoom, height: baseSize.height / zoom)
+        let halfWidth = viewportSize.width / 2
+        let halfHeight = viewportSize.height / 2
+        let center = CGPoint(
+            x: min(max(keyframe.center.x, halfWidth), sourceSize.width - halfWidth),
+            y: min(max(keyframe.center.y, halfHeight), sourceSize.height - halfHeight)
+        )
+        return CGRect(
+            x: center.x - halfWidth,
+            y: center.y - halfHeight,
+            width: viewportSize.width,
+            height: viewportSize.height
+        )
+    }
 }

--- a/engines/protocol-rust/src/models.rs
+++ b/engines/protocol-rust/src/models.rs
@@ -1845,6 +1845,179 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentRunSumm
     }
 }
 
+/// User-configurable automatic zoom settings stored with a project or export override.
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AutoZoomSettings {
+    #[serde(rename = "isEnabled")]
+    pub is_enabled: bool,
+
+    #[serde(rename = "intensity")]
+    pub intensity: f64,
+
+    #[serde(rename = "minimumKeyframeInterval")]
+    pub minimum_keyframe_interval: f64,
+}
+
+impl AutoZoomSettings {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(
+        is_enabled: bool,
+        intensity: f64,
+        minimum_keyframe_interval: f64,
+    ) -> AutoZoomSettings {
+        AutoZoomSettings {
+            is_enabled,
+            intensity,
+            minimum_keyframe_interval,
+        }
+    }
+}
+
+/// Converts the AutoZoomSettings value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AutoZoomSettings {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("isEnabled".to_string()),
+            Some(self.is_enabled.to_string()),
+            Some("intensity".to_string()),
+            Some(self.intensity.to_string()),
+            Some("minimumKeyframeInterval".to_string()),
+            Some(self.minimum_keyframe_interval.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AutoZoomSettings value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AutoZoomSettings {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub is_enabled: Vec<bool>,
+            pub intensity: Vec<f64>,
+            pub minimum_keyframe_interval: Vec<f64>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AutoZoomSettings".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "isEnabled" => intermediate_rep.is_enabled.push(
+                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "intensity" => intermediate_rep.intensity.push(
+                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "minimumKeyframeInterval" => intermediate_rep.minimum_keyframe_interval.push(
+                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AutoZoomSettings".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AutoZoomSettings {
+            is_enabled: intermediate_rep
+                .is_enabled
+                .into_iter()
+                .next()
+                .ok_or_else(|| "isEnabled missing in AutoZoomSettings".to_string())?,
+            intensity: intermediate_rep
+                .intensity
+                .into_iter()
+                .next()
+                .ok_or_else(|| "intensity missing in AutoZoomSettings".to_string())?,
+            minimum_keyframe_interval: intermediate_rep
+                .minimum_keyframe_interval
+                .into_iter()
+                .next()
+                .ok_or_else(|| "minimumKeyframeInterval missing in AutoZoomSettings".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AutoZoomSettings> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AutoZoomSettings>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AutoZoomSettings>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AutoZoomSettings - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AutoZoomSettings> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AutoZoomSettings as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AutoZoomSettings - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
 /// Versioned project-global background stage and source-card framing settings.
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
@@ -7190,6 +7363,11 @@ pub struct ExportRunPayload {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timeline: Option<models::ExportRunPayloadTimeline>,
 
+    #[serde(rename = "autoZoom")]
+    #[validate(nested)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub auto_zoom: Option<models::AutoZoomSettings>,
+
     #[serde(rename = "backgroundFraming")]
     #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -7205,6 +7383,7 @@ impl ExportRunPayload {
             trim_start_seconds: None,
             trim_end_seconds: None,
             timeline: None,
+            auto_zoom: None,
             background_framing: None,
         }
     }
@@ -7231,6 +7410,8 @@ impl std::fmt::Display for ExportRunPayload {
                 ["trimEndSeconds".to_string(), trim_end_seconds.to_string()].join(",")
             }),
             // Skipping timeline in query parameter serialization
+
+            // Skipping autoZoom in query parameter serialization
 
             // Skipping backgroundFraming in query parameter serialization
         ];
@@ -7259,6 +7440,7 @@ impl std::str::FromStr for ExportRunPayload {
             pub trim_start_seconds: Vec<f64>,
             pub trim_end_seconds: Vec<f64>,
             pub timeline: Vec<models::ExportRunPayloadTimeline>,
+            pub auto_zoom: Vec<models::AutoZoomSettings>,
             pub background_framing: Vec<models::BackgroundFramingSettings>,
         }
 
@@ -7303,6 +7485,11 @@ impl std::str::FromStr for ExportRunPayload {
                             .map_err(|x| x.to_string())?,
                     ),
                     #[allow(clippy::redundant_clone)]
+                    "autoZoom" => intermediate_rep.auto_zoom.push(
+                        <models::AutoZoomSettings as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
                     "backgroundFraming" => intermediate_rep.background_framing.push(
                         <models::BackgroundFramingSettings as std::str::FromStr>::from_str(val)
                             .map_err(|x| x.to_string())?,
@@ -7334,6 +7521,7 @@ impl std::str::FromStr for ExportRunPayload {
             trim_start_seconds: intermediate_rep.trim_start_seconds.into_iter().next(),
             trim_end_seconds: intermediate_rep.trim_end_seconds.into_iter().next(),
             timeline: intermediate_rep.timeline.into_iter().next(),
+            auto_zoom: intermediate_rep.auto_zoom.into_iter().next(),
             background_framing: intermediate_rep.background_framing.into_iter().next(),
         })
     }
@@ -9151,7 +9339,7 @@ pub struct ProjectSavePayload {
     #[serde(rename = "autoZoom")]
     #[validate(nested)]
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub auto_zoom: Option<models::ProjectStateAutoZoom>,
+    pub auto_zoom: Option<models::AutoZoomSettings>,
 
     #[serde(rename = "backgroundFraming")]
     #[validate(nested)]
@@ -9212,7 +9400,7 @@ impl std::str::FromStr for ProjectSavePayload {
         #[allow(dead_code)]
         struct IntermediateRep {
             pub project_path: Vec<String>,
-            pub auto_zoom: Vec<models::ProjectStateAutoZoom>,
+            pub auto_zoom: Vec<models::AutoZoomSettings>,
             pub background_framing: Vec<models::BackgroundFramingSettings>,
             pub timeline: Vec<models::ExportRunPayloadTimeline>,
         }
@@ -9242,7 +9430,7 @@ impl std::str::FromStr for ProjectSavePayload {
                     ),
                     #[allow(clippy::redundant_clone)]
                     "autoZoom" => intermediate_rep.auto_zoom.push(
-                        <models::ProjectStateAutoZoom as std::str::FromStr>::from_str(val)
+                        <models::AutoZoomSettings as std::str::FromStr>::from_str(val)
                             .map_err(|x| x.to_string())?,
                     ),
                     #[allow(clippy::redundant_clone)]
@@ -9344,7 +9532,7 @@ pub struct ProjectState {
 
     #[serde(rename = "autoZoom")]
     #[validate(nested)]
-    pub auto_zoom: models::ProjectStateAutoZoom,
+    pub auto_zoom: models::AutoZoomSettings,
 
     #[serde(rename = "backgroundFraming")]
     #[validate(nested)]
@@ -9368,7 +9556,7 @@ pub struct ProjectState {
 impl ProjectState {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new(
-        auto_zoom: models::ProjectStateAutoZoom,
+        auto_zoom: models::AutoZoomSettings,
         background_framing: models::BackgroundFramingSettings,
         timeline: models::ExportRunPayloadTimeline,
     ) -> ProjectState {
@@ -9437,7 +9625,7 @@ impl std::str::FromStr for ProjectState {
             pub recording_url: Vec<String>,
             pub events_url: Vec<String>,
             pub last_recording_telemetry: Vec<models::CaptureTelemetry>,
-            pub auto_zoom: Vec<models::ProjectStateAutoZoom>,
+            pub auto_zoom: Vec<models::AutoZoomSettings>,
             pub background_framing: Vec<models::BackgroundFramingSettings>,
             pub timeline: Vec<models::ExportRunPayloadTimeline>,
             pub capture_metadata: Vec<models::CaptureStatusResultCaptureMetadata>,
@@ -9472,7 +9660,7 @@ impl std::str::FromStr for ProjectState {
                     #[allow(clippy::redundant_clone)]
                     "lastRecordingTelemetry" => intermediate_rep.last_recording_telemetry.push(<models::CaptureTelemetry as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
-                    "autoZoom" => intermediate_rep.auto_zoom.push(<models::ProjectStateAutoZoom as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "autoZoom" => intermediate_rep.auto_zoom.push(<models::AutoZoomSettings as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
                     "backgroundFraming" => intermediate_rep.background_framing.push(<models::BackgroundFramingSettings as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
@@ -9548,180 +9736,6 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ProjectState
                     }
                     std::result::Result::Err(err) => std::result::Result::Err(format!(
                         r#"Unable to convert header value '{value}' into ProjectState - {err}"#
-                    )),
-                }
-            }
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
-            )),
-        }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
-#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct ProjectStateAutoZoom {
-    #[serde(rename = "isEnabled")]
-    pub is_enabled: bool,
-
-    #[serde(rename = "intensity")]
-    pub intensity: f64,
-
-    #[serde(rename = "minimumKeyframeInterval")]
-    pub minimum_keyframe_interval: f64,
-}
-
-impl ProjectStateAutoZoom {
-    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(
-        is_enabled: bool,
-        intensity: f64,
-        minimum_keyframe_interval: f64,
-    ) -> ProjectStateAutoZoom {
-        ProjectStateAutoZoom {
-            is_enabled,
-            intensity,
-            minimum_keyframe_interval,
-        }
-    }
-}
-
-/// Converts the ProjectStateAutoZoom value to the Query Parameters representation (style=form, explode=false)
-/// specified in https://swagger.io/docs/specification/serialization/
-/// Should be implemented in a serde serializer
-impl std::fmt::Display for ProjectStateAutoZoom {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let params: Vec<Option<String>> = vec![
-            Some("isEnabled".to_string()),
-            Some(self.is_enabled.to_string()),
-            Some("intensity".to_string()),
-            Some(self.intensity.to_string()),
-            Some("minimumKeyframeInterval".to_string()),
-            Some(self.minimum_keyframe_interval.to_string()),
-        ];
-
-        write!(
-            f,
-            "{}",
-            params.into_iter().flatten().collect::<Vec<_>>().join(",")
-        )
-    }
-}
-
-/// Converts Query Parameters representation (style=form, explode=false) to a ProjectStateAutoZoom value
-/// as specified in https://swagger.io/docs/specification/serialization/
-/// Should be implemented in a serde deserializer
-impl std::str::FromStr for ProjectStateAutoZoom {
-    type Err = String;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        /// An intermediate representation of the struct to use for parsing.
-        #[derive(Default)]
-        #[allow(dead_code)]
-        struct IntermediateRep {
-            pub is_enabled: Vec<bool>,
-            pub intensity: Vec<f64>,
-            pub minimum_keyframe_interval: Vec<f64>,
-        }
-
-        let mut intermediate_rep = IntermediateRep::default();
-
-        // Parse into intermediate representation
-        let mut string_iter = s.split(',');
-        let mut key_result = string_iter.next();
-
-        while key_result.is_some() {
-            let val = match string_iter.next() {
-                Some(x) => x,
-                None => {
-                    return std::result::Result::Err(
-                        "Missing value while parsing ProjectStateAutoZoom".to_string(),
-                    );
-                }
-            };
-
-            if let Some(key) = key_result {
-                #[allow(clippy::match_single_binding)]
-                match key {
-                    #[allow(clippy::redundant_clone)]
-                    "isEnabled" => intermediate_rep.is_enabled.push(
-                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    #[allow(clippy::redundant_clone)]
-                    "intensity" => intermediate_rep.intensity.push(
-                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    #[allow(clippy::redundant_clone)]
-                    "minimumKeyframeInterval" => intermediate_rep.minimum_keyframe_interval.push(
-                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
-                    ),
-                    _ => {
-                        return std::result::Result::Err(
-                            "Unexpected key while parsing ProjectStateAutoZoom".to_string(),
-                        );
-                    }
-                }
-            }
-
-            // Get the next key
-            key_result = string_iter.next();
-        }
-
-        // Use the intermediate representation to return the struct
-        std::result::Result::Ok(ProjectStateAutoZoom {
-            is_enabled: intermediate_rep
-                .is_enabled
-                .into_iter()
-                .next()
-                .ok_or_else(|| "isEnabled missing in ProjectStateAutoZoom".to_string())?,
-            intensity: intermediate_rep
-                .intensity
-                .into_iter()
-                .next()
-                .ok_or_else(|| "intensity missing in ProjectStateAutoZoom".to_string())?,
-            minimum_keyframe_interval: intermediate_rep
-                .minimum_keyframe_interval
-                .into_iter()
-                .next()
-                .ok_or_else(|| {
-                    "minimumKeyframeInterval missing in ProjectStateAutoZoom".to_string()
-                })?,
-        })
-    }
-}
-
-// Methods for converting between header::IntoHeaderValue<ProjectStateAutoZoom> and HeaderValue
-
-#[cfg(feature = "server")]
-impl std::convert::TryFrom<header::IntoHeaderValue<ProjectStateAutoZoom>> for HeaderValue {
-    type Error = String;
-
-    fn try_from(
-        hdr_value: header::IntoHeaderValue<ProjectStateAutoZoom>,
-    ) -> std::result::Result<Self, Self::Error> {
-        let hdr_value = hdr_value.to_string();
-        match HeaderValue::from_str(&hdr_value) {
-            std::result::Result::Ok(value) => std::result::Result::Ok(value),
-            std::result::Result::Err(e) => std::result::Result::Err(format!(
-                r#"Invalid header value for ProjectStateAutoZoom - value: {hdr_value} is invalid {e}"#
-            )),
-        }
-    }
-}
-
-#[cfg(feature = "server")]
-impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<ProjectStateAutoZoom> {
-    type Error = String;
-
-    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
-        match hdr_value.to_str() {
-            std::result::Result::Ok(value) => {
-                match <ProjectStateAutoZoom as std::str::FromStr>::from_str(value) {
-                    std::result::Result::Ok(value) => {
-                        std::result::Result::Ok(header::IntoHeaderValue(value))
-                    }
-                    std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        r#"Unable to convert header value '{value}' into ProjectStateAutoZoom - {err}"#
                     )),
                 }
             }

--- a/engines/protocol-swift/Sources/EngineProtocol/openapi.json
+++ b/engines/protocol-swift/Sources/EngineProtocol/openapi.json
@@ -3904,6 +3904,37 @@
         ],
         "additionalProperties": false
       },
+      "AutoZoomSettings": {
+        "type": "object",
+        "properties": {
+          "isEnabled": {
+            "type": "boolean"
+          },
+          "intensity": {
+            "type": "number",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          },
+          "minimumKeyframeInterval": {
+            "type": "number",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          }
+        },
+        "required": [
+          "isEnabled",
+          "intensity",
+          "minimumKeyframeInterval"
+        ],
+        "additionalProperties": false,
+        "description": "User-configurable automatic zoom settings stored with a project or export override."
+      },
       "BackgroundFramingSettings": {
         "type": "object",
         "properties": {
@@ -4111,6 +4142,9 @@
             ],
             "additionalProperties": false
           },
+          "autoZoom": {
+            "$ref": "#/components/schemas/AutoZoomSettings"
+          },
           "backgroundFraming": {
             "$ref": "#/components/schemas/BackgroundFramingSettings"
           }
@@ -4301,34 +4335,7 @@
             "$ref": "#/components/schemas/CaptureTelemetry"
           },
           "autoZoom": {
-            "type": "object",
-            "properties": {
-              "isEnabled": {
-                "type": "boolean"
-              },
-              "intensity": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              },
-              "minimumKeyframeInterval": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              }
-            },
-            "required": [
-              "isEnabled",
-              "intensity",
-              "minimumKeyframeInterval"
-            ],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/AutoZoomSettings"
           },
           "backgroundFraming": {
             "$ref": "#/components/schemas/BackgroundFramingSettings"
@@ -4579,34 +4586,7 @@
             ]
           },
           "autoZoom": {
-            "type": "object",
-            "properties": {
-              "isEnabled": {
-                "type": "boolean"
-              },
-              "intensity": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              },
-              "minimumKeyframeInterval": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              }
-            },
-            "required": [
-              "isEnabled",
-              "intensity",
-              "minimumKeyframeInterval"
-            ],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/AutoZoomSettings"
           },
           "backgroundFraming": {
             "$ref": "#/components/schemas/BackgroundFramingSettings"

--- a/packages/engine-contract/generated/engine.openapi.json
+++ b/packages/engine-contract/generated/engine.openapi.json
@@ -3904,6 +3904,37 @@
         ],
         "additionalProperties": false
       },
+      "AutoZoomSettings": {
+        "type": "object",
+        "properties": {
+          "isEnabled": {
+            "type": "boolean"
+          },
+          "intensity": {
+            "type": "number",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          },
+          "minimumKeyframeInterval": {
+            "type": "number",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          }
+        },
+        "required": [
+          "isEnabled",
+          "intensity",
+          "minimumKeyframeInterval"
+        ],
+        "additionalProperties": false,
+        "description": "User-configurable automatic zoom settings stored with a project or export override."
+      },
       "BackgroundFramingSettings": {
         "type": "object",
         "properties": {
@@ -4111,6 +4142,9 @@
             ],
             "additionalProperties": false
           },
+          "autoZoom": {
+            "$ref": "#/components/schemas/AutoZoomSettings"
+          },
           "backgroundFraming": {
             "$ref": "#/components/schemas/BackgroundFramingSettings"
           }
@@ -4301,34 +4335,7 @@
             "$ref": "#/components/schemas/CaptureTelemetry"
           },
           "autoZoom": {
-            "type": "object",
-            "properties": {
-              "isEnabled": {
-                "type": "boolean"
-              },
-              "intensity": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              },
-              "minimumKeyframeInterval": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              }
-            },
-            "required": [
-              "isEnabled",
-              "intensity",
-              "minimumKeyframeInterval"
-            ],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/AutoZoomSettings"
           },
           "backgroundFraming": {
             "$ref": "#/components/schemas/BackgroundFramingSettings"
@@ -4579,34 +4586,7 @@
             ]
           },
           "autoZoom": {
-            "type": "object",
-            "properties": {
-              "isEnabled": {
-                "type": "boolean"
-              },
-              "intensity": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              },
-              "minimumKeyframeInterval": {
-                "type": "number",
-                "allOf": [
-                  {
-                    "minimum": 0
-                  }
-                ]
-              }
-            },
-            "required": [
-              "isEnabled",
-              "intensity",
-              "minimumKeyframeInterval"
-            ],
-            "additionalProperties": false
+            "$ref": "#/components/schemas/AutoZoomSettings"
           },
           "backgroundFraming": {
             "$ref": "#/components/schemas/BackgroundFramingSettings"

--- a/packages/engine-contract/src/httpApi.ts
+++ b/packages/engine-contract/src/httpApi.ts
@@ -92,6 +92,7 @@ export const exportRunPayloadSchema = Schema.Struct({
   trimStartSeconds: Schema.optionalKey(NonNegativeNumber),
   trimEndSeconds: Schema.optionalKey(NonNegativeNumber),
   timeline: Schema.optionalKey(timelineDocumentSchema),
+  autoZoom: Schema.optionalKey(autoZoomSettingsSchema),
   backgroundFraming: Schema.optionalKey(backgroundFramingSettingsSchema),
 }).annotate({ identifier: "ExportRunPayload" });
 

--- a/packages/engine-contract/src/shared/valueObjects.ts
+++ b/packages/engine-contract/src/shared/valueObjects.ts
@@ -69,6 +69,10 @@ export const autoZoomSettingsSchema = Schema.Struct({
   isEnabled: Schema.Boolean,
   intensity: NonNegativeNumber,
   minimumKeyframeInterval: NonNegativeNumber,
+}).annotate({
+  identifier: "AutoZoomSettings",
+  description:
+    "User-configurable automatic zoom settings stored with a project or export override.",
 });
 
 /**

--- a/packages/engine-contract/tests/vertical-camera.test.ts
+++ b/packages/engine-contract/tests/vertical-camera.test.ts
@@ -1,0 +1,31 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+import { exportRunPayloadSchema } from "../src/httpApi";
+
+const basePayload = {
+  outputURL: "/tmp/vertical.mp4",
+  presetId: "h264-vertical-1080p-30",
+};
+
+describe("vertical camera export contract", () => {
+  it("accepts an optional per-export auto-zoom override", () => {
+    const decoded = Schema.decodeUnknownSync(exportRunPayloadSchema)({
+      ...basePayload,
+      autoZoom: {
+        isEnabled: true,
+        intensity: 0.75,
+        minimumKeyframeInterval: 1 / 30,
+      },
+    });
+
+    expect(decoded.autoZoom).toEqual({
+      isEnabled: true,
+      intensity: 0.75,
+      minimumKeyframeInterval: 1 / 30,
+    });
+  });
+
+  it("keeps the override optional for older clients", () => {
+    expect(Schema.decodeUnknownSync(exportRunPayloadSchema)(basePayload).autoZoom).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- derive macOS camera plans from persisted input events, capture metadata, auto-zoom settings, and the selected output aspect ratio
- add deterministic portrait viewport transforms shared by direct and timeline export, including preferred-orientation and background-framing composition
- pass an explicit auto-zoom export override through the Effect/OpenAPI contract so unsaved inspector settings affect the current export
- make Capture/Edit previews switch between legacy aspect-fit and auto-zoom aspect-aware cover composition
- mark `phase2/vertical-camera-replan` implemented in the roadmap

## Validation

- `bun run repo:check`
- `bun run gate`
- `bun run gate:typescript`
- `bun run protocol:check-determinism`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `swift test` (101 tests)
- `bun run desktop:acceptance`
- native raster export verifies event-directed 9:16 output, framing stage color, and encoded portrait dimensions
- packaged app exercised with Peekaboo: selected the 1080×1920 preset, navigated Deliver → Edit, verified portrait preview with Auto Zoom, enabled background framing, and retained screenshots in `.tmp/peekaboo-vertical-camera/`

## Benchmark note

`capture:benchmark:check` could not produce metrics: the default command first resolved a stale nested Swift build path, and the explicit root engine retry lost the engine connection before `/v1/sources`. This slice does not change capture code; the full gate and packaged runtime acceptance pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds aspect-aware camera replanning for portrait exports.
- Propagates explicit auto-zoom settings through the desktop bridge and generated engine contract.
- Loads persisted input events only when effective auto-zoom settings require them.
- Shares portrait viewport and background-framing geometry across direct export, timeline export, and editor previews.
- Adds Swift and TypeScript coverage for portrait planning, rendering, bridge propagation, and preview behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| engines/macos-swift/EngineService+Export.swift | Resolves export auto-zoom overrides and conditionally loads input events; the previously reported disabled-zoom failure is fixed. |
| engines/macos-swift/modules/export/ExportPipeline.swift | Builds an output-aspect-aware camera plan from effective settings, capture metadata, and input events. |
| engines/macos-swift/modules/export/TimelineVideoCompositionBuilder.swift | Applies the shared aspect-aware camera viewport transform while preserving timeline source-to-program timing. |
| engines/macos-swift/modules/rendering/VideoGeometryTransforms.swift | Adds deterministic viewport and source transforms used by portrait camera composition. |
| apps/desktop-electrobun/src/mainview/app/studio/hooks/core/useStudioMutations.ts | Sends the current unsaved auto-zoom settings as an explicit export override. |
| apps/desktop-electrobun/src/mainview/app/studio/panels/BackgroundFramingPreview.tsx | Switches preview framing between legacy source fitting and aspect-aware camera-reframe composition. |
| packages/engine-contract/src/httpApi.ts | Extends the export request contract with the optional auto-zoom override. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    UI[Editor export settings] --> Bridge[Desktop bridge contract]
    Bridge --> Service[macOS export service]
    Service --> Resolve[Resolve auto-zoom settings]
    Resolve -->|Enabled with positive intensity| Events[Load persisted input events]
    Resolve -->|Disabled or zero intensity| Skip[Skip event loading]
    Events --> Plan[Create aspect-aware camera plan]
    Skip --> Pipeline[Export pipeline]
    Plan --> Pipeline
    Pipeline --> Direct[Direct composition]
    Pipeline --> Timeline[Timeline composition]
    Direct --> Output[Portrait or landscape output]
    Timeline --> Output
```

<sub>Reviews (2): Last reviewed commit: ["fix(export): skip event loading when aut..."](https://github.com/okikesolutions/guerillaglass/commit/75aabdafd0433f94b24c91cca1a63c8d04827dae) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47220030)</sub>

<!-- /greptile_comment -->