### PR TITLE
feat(agent): make local runs discoverable and verifiable

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,8 @@ Normative product requirements live in `docs/SPEC.md`. Execution status and sequ
 | Timeline semantics          | `docs/TIMELINE_EDITING_DESIGN.md`   |
 | Background framing v1       | `docs/BACKGROUND_FRAMING_DESIGN.md` |
 | Accessibility and shortcuts | `docs/DESKTOP_ACCESSIBILITY.md`     |
+| Agent Mode operations       | `docs/AGENT_MODE_RUNBOOK.md`        |
+| Agent discoverability audit | `docs/AGENT_DISCOVERABILITY_AUDIT.md` |
 | Release hardening           | `docs/RELEASE_HARDENING.md`         |
 
 Documents named `ENGINE_CONTRACT_V2_*` and `MIGRATION.md` preserve migration history. They are useful rationale, but are not the active backlog unless `docs/ROADMAP.md` references them.

--- a/Package.swift
+++ b/Package.swift
@@ -90,6 +90,11 @@ let package = Package(
             path: "Tests/projectMigrationTests"
         ),
         .testTarget(
+            name: "AgentModeTests",
+            dependencies: ["Project"],
+            path: "Tests/agentModeTests"
+        ),
+        .testTarget(
             name: "RenderingDeterminismTests",
             dependencies: ["Project", "Rendering"],
             path: "Tests/renderingDeterminismTests"

--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ bun run i18n:compile
 - Completed migration notes: `docs/MIGRATION.md`
 - Docs coverage thresholds: `docs/doc_coverage_policy.json`
 - Desktop accessibility + hotkey policy: `docs/DESKTOP_ACCESSIBILITY.md`
+- Local Agent Mode runbook: [`docs/AGENT_MODE_RUNBOOK.md`](docs/AGENT_MODE_RUNBOOK.md)
+- Agent discoverability audit: [`docs/AGENT_DISCOVERABILITY_AUDIT.md`](docs/AGENT_DISCOVERABILITY_AUDIT.md)
 - Agent repo conventions: [`AGENTS.md`](AGENTS.md)
 - Change propagation guide: [`docs/CHANGE_MAP.md`](docs/CHANGE_MAP.md)
 - Review rubric: [`REVIEW.md`](REVIEW.md)

--- a/Scripts/agent_mode_smoke.ts
+++ b/Scripts/agent_mode_smoke.ts
@@ -1,0 +1,515 @@
+#!/usr/bin/env bun
+
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  truncateSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const root = resolve(import.meta.dir, "..");
+const enginePath = join(root, ".build", "debug", "guerillaglass-engine");
+if (process.platform !== "darwin") {
+  throw new Error("Agent Mode smoke requires the production macOS engine.");
+}
+if (!existsSync(enginePath)) {
+  throw new Error(`Missing ${enginePath}; run bun run swift:build first.`);
+}
+
+const resolvedTemporaryDirectory = tmpdir().startsWith("/var/") ? `/private${tmpdir()}` : tmpdir();
+const temporaryRoot = mkdtempSync(join(resolvedTemporaryDirectory, "guerillaglass-agent-smoke-"));
+const projectPath = join(temporaryRoot, "AgentSmoke.gglassproj");
+const transcriptPath = join(temporaryRoot, "transcript.json");
+const outputPath = join(temporaryRoot, "agent-output.mp4");
+const bearerToken = crypto.randomUUID().replaceAll("-", "");
+mkdirSync(projectPath, { recursive: true });
+await Bun.write(
+  transcriptPath,
+  JSON.stringify(
+    {
+      segments: [
+        { text: "Opening hook", startSeconds: 0.25, endSeconds: 1 },
+        { text: "Action steps", startSeconds: 2, endSeconds: 3 },
+        { text: "Result payoff", startSeconds: 4, endSeconds: 5 },
+        { text: "Conclusion takeaway", startSeconds: 6, endSeconds: 7.25 },
+      ],
+    },
+    null,
+    2,
+  ),
+);
+
+const launchEngine = () =>
+  Bun.spawn([enginePath], {
+    cwd: root,
+    env: {
+      ...process.env,
+      GG_ENGINE_TRANSPORT: "http",
+      GG_ENGINE_HTTP_AUTH_TOKEN: bearerToken,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+let engine = launchEngine();
+
+async function readinessBaseUrl(process: typeof engine): Promise<string> {
+  const reader = process.stdout.getReader();
+  const decoder = new TextDecoder();
+  let buffered = "";
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const next = await reader.read();
+    if (next.done) {
+      break;
+    }
+    buffered += decoder.decode(next.value, { stream: true });
+    const lines = buffered.split("\n");
+    buffered = lines.pop() ?? "";
+    for (const line of lines) {
+      const value = JSON.parse(line) as { type?: string; host?: string; port?: number };
+      if (value.type === "guerillaglass.engine.http.ready" && value.host && value.port) {
+        return `http://${value.host}:${value.port}`;
+      }
+    }
+  }
+  throw new Error("Engine did not emit its HTTP readiness envelope.");
+}
+
+let baseUrl = await readinessBaseUrl(engine);
+async function request(path: string, init: RequestInit = {}) {
+  const response = await fetch(`${baseUrl}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${bearerToken}`,
+      ...(init.body ? { "Content-Type": "application/json" } : {}),
+      ...init.headers,
+    },
+  });
+  const body = (await response.json()) as Record<string, unknown>;
+  return { response, body };
+}
+
+function expectStatus(actual: number, expected: number, body: unknown) {
+  if (actual !== expected) {
+    throw new Error(`Expected HTTP ${expected}, received ${actual}: ${JSON.stringify(body)}`);
+  }
+}
+
+try {
+  const capabilities = await request("/v1/engine/capabilities");
+  expectStatus(capabilities.response.status, 200, capabilities.body);
+  const agentCapabilities = capabilities.body.agent as Record<string, unknown>;
+  if (
+    agentCapabilities.apply !== true ||
+    agentCapabilities.preflightTokenTtlSeconds !== 60 ||
+    !Array.isArray(agentCapabilities.supportedTranscriptionProviders) ||
+    !agentCapabilities.supportedTranscriptionProviders.includes("imported_transcript")
+  ) {
+    throw new Error(`Agent capabilities are not truthful: ${JSON.stringify(agentCapabilities)}`);
+  }
+
+  let opened = await request("/v1/project/open", {
+    method: "POST",
+    body: JSON.stringify({ projectPath }),
+  });
+  expectStatus(opened.response.status, 200, opened.body);
+
+  const fixture = Bun.spawnSync(
+    ["swift", "Scripts/macos_agent_fixture.swift", join(projectPath, "recording.mov")],
+    { cwd: root, stdout: "pipe", stderr: "pipe" },
+  );
+  if (fixture.exitCode !== 0) {
+    throw new Error(`Unable to create Agent fixture: ${fixture.stderr.toString()}`);
+  }
+
+  opened = await request("/v1/project/open", {
+    method: "POST",
+    body: JSON.stringify({ projectPath }),
+  });
+  expectStatus(opened.response.status, 200, opened.body);
+
+  const runParameters = {
+    runtimeBudgetMinutes: 10,
+    transcriptionProvider: "imported_transcript",
+    importedTranscriptPath: transcriptPath,
+  };
+  const preflight = await request("/v1/agent/preflight", {
+    method: "POST",
+    body: JSON.stringify(runParameters),
+  });
+  expectStatus(preflight.response.status, 200, preflight.body);
+  if (
+    preflight.body.ready !== true ||
+    typeof preflight.body.preflightToken !== "string" ||
+    typeof preflight.body.preflightTokenExpiresAt !== "string"
+  ) {
+    throw new Error(`Agent preflight was not ready: ${JSON.stringify(preflight.body)}`);
+  }
+  const tokenLifetimeSeconds =
+    (Date.parse(preflight.body.preflightTokenExpiresAt) - Date.now()) / 1000;
+  if (tokenLifetimeSeconds < 50 || tokenLifetimeSeconds > 61) {
+    throw new Error(`Unexpected preflight token lifetime: ${tokenLifetimeSeconds}`);
+  }
+
+  const run = await request("/v1/agent/runs", {
+    method: "POST",
+    body: JSON.stringify({ ...runParameters, preflightToken: preflight.body.preflightToken }),
+  });
+  expectStatus(run.response.status, 200, run.body);
+  const jobId = run.body.jobId;
+  if (run.body.status !== "completed" || typeof jobId !== "string") {
+    throw new Error(`Agent run did not complete: ${JSON.stringify(run.body)}`);
+  }
+  const reusedToken = await request("/v1/agent/runs", {
+    method: "POST",
+    body: JSON.stringify({ ...runParameters, preflightToken: preflight.body.preflightToken }),
+  });
+  expectStatus(reusedToken.response.status, 400, reusedToken.body);
+  if (reusedToken.body.code !== "preflight_expired") {
+    throw new Error(
+      `Reused preflight token was not rejected predictably: ${JSON.stringify(reusedToken.body)}`,
+    );
+  }
+
+  const status = await request(`/v1/agent/runs/${encodeURIComponent(jobId)}`);
+  expectStatus(status.response.status, 200, status.body);
+  const cutPlan = status.body.cutPlan as { segments?: unknown[] };
+  const artifacts = status.body.artifacts as Array<{ path: string }>;
+  if (
+    status.body.status !== "completed" ||
+    cutPlan.segments?.length !== 4 ||
+    artifacts.length !== 6
+  ) {
+    throw new Error(`Agent status is not reviewable: ${JSON.stringify(status.body)}`);
+  }
+  for (const artifact of artifacts) {
+    if (artifact.path.startsWith("/") || !existsSync(join(projectPath, artifact.path))) {
+      throw new Error(`Invalid or missing project-relative artifact: ${artifact.path}`);
+    }
+    JSON.parse(readFileSync(join(projectPath, artifact.path), "utf8"));
+  }
+
+  const info = await request("/v1/export/info");
+  expectStatus(info.response.status, 200, info.body);
+  const presets = info.body.presets as Array<{ id: string }>;
+  const presetId = presets.find((preset) => preset.id.includes("1080p-30"))?.id ?? presets[0]?.id;
+  if (!presetId) {
+    throw new Error("Engine did not advertise an export preset.");
+  }
+  const independentOutputPath = join(temporaryRoot, "agent-output-before-apply.mp4");
+  const independentExport = await request("/v1/exports/from-cut-plan", {
+    method: "POST",
+    body: JSON.stringify({ jobId, presetId, outputURL: independentOutputPath }),
+  });
+  expectStatus(independentExport.response.status, 200, independentExport.body);
+  if (independentExport.body.appliedSegments !== 4 || !existsSync(independentOutputPath)) {
+    throw new Error(
+      `Cut-plan export incorrectly depended on prior apply: ${JSON.stringify(independentExport.body)}`,
+    );
+  }
+
+  const changedTimeline = {
+    version: 2,
+    updatedAt: new Date().toISOString(),
+    items: [
+      {
+        kind: "clip",
+        id: "manual-edit",
+        sourceAssetId: "recording",
+        sourceStartSeconds: 0,
+        sourceEndSeconds: 1,
+      },
+    ],
+  };
+  const saved = await request("/v1/project/save", {
+    method: "POST",
+    body: JSON.stringify({ timeline: changedTimeline }),
+  });
+  expectStatus(saved.response.status, 200, saved.body);
+
+  const confirmation = await request(`/v1/agent/runs/${encodeURIComponent(jobId)}/apply`, {
+    method: "POST",
+    body: "{}",
+  });
+  expectStatus(confirmation.response.status, 409, confirmation.body);
+  if (confirmation.body.code !== "needs_confirmation") {
+    throw new Error(`Apply confirmation was not typed: ${JSON.stringify(confirmation.body)}`);
+  }
+
+  const applied = await request(`/v1/agent/runs/${encodeURIComponent(jobId)}/apply`, {
+    method: "POST",
+    body: JSON.stringify({ destructiveIntent: true }),
+  });
+  expectStatus(applied.response.status, 200, applied.body);
+  if (applied.body.status !== "applied" || applied.body.appliedSegments !== 4) {
+    throw new Error(`Apply result was not verifiable: ${JSON.stringify(applied.body)}`);
+  }
+  const currentAfterApply = await request("/v1/project/current");
+  expectStatus(currentAfterApply.response.status, 200, currentAfterApply.body);
+  const currentTimeline = currentAfterApply.body.timeline as
+    | { items?: Array<{ kind: string; sourceStartSeconds: number; sourceEndSeconds: number }> }
+    | undefined;
+  const appliedItems = currentTimeline?.items;
+  const reviewPlan = status.body.cutPlan as {
+    sourceFps: { numerator: number; denominator: number };
+    segments: Array<{ startFrame: number; endFrame: number }>;
+  };
+  if (
+    appliedItems?.length !== reviewPlan.segments.length ||
+    appliedItems.some((item, index) => {
+      const segment = reviewPlan.segments[index]!;
+      const secondsPerFrame = reviewPlan.sourceFps.denominator / reviewPlan.sourceFps.numerator;
+      return (
+        item.kind !== "clip" ||
+        Math.abs(item.sourceStartSeconds - segment.startFrame * secondsPerFrame) > 1e-6 ||
+        Math.abs(item.sourceEndSeconds - segment.endFrame * secondsPerFrame) > 1e-6
+      );
+    })
+  ) {
+    throw new Error(
+      `Applied working timeline differs from the reviewed frame plan: ${JSON.stringify(currentAfterApply.body.timeline)}`,
+    );
+  }
+
+  const exported = await request("/v1/exports/from-cut-plan", {
+    method: "POST",
+    body: JSON.stringify({ jobId, presetId, outputURL: outputPath }),
+  });
+  expectStatus(exported.response.status, 200, exported.body);
+  if (exported.body.appliedSegments !== 4 || !existsSync(outputPath)) {
+    throw new Error(`Cut-plan export failed verification: ${JSON.stringify(exported.body)}`);
+  }
+  const statusCutPlan = status.body.cutPlan as {
+    sourceFps: { numerator: number; denominator: number };
+    segments: Array<{ startFrame: number; endFrame: number }>;
+  };
+  const secondsPerFrame = statusCutPlan.sourceFps.denominator / statusCutPlan.sourceFps.numerator;
+  let outputCursor = 0;
+  const outputSampleTimes = statusCutPlan.segments.map((segment) => {
+    const duration = (segment.endFrame - segment.startFrame) * secondsPerFrame;
+    const sampleTime = outputCursor + duration / 2;
+    outputCursor += duration;
+    return sampleTime;
+  });
+  const mediaProbe = Bun.spawnSync(
+    [
+      "swift",
+      "Scripts/macos_agent_fixture.swift",
+      "--probe",
+      outputPath,
+      outputSampleTimes.join(","),
+    ],
+    { cwd: root, stdout: "pipe", stderr: "pipe" },
+  );
+  if (mediaProbe.exitCode !== 0) {
+    throw new Error(`Unable to inspect Agent export: ${mediaProbe.stderr.toString()}`);
+  }
+  const media = JSON.parse(mediaProbe.stdout.toString()) as {
+    durationSeconds: number;
+    hasVideo: boolean;
+    sampleColors: Array<[number, number, number]>;
+  };
+  const expectedDuration =
+    statusCutPlan.segments.reduce(
+      (duration, segment) => duration + segment.endFrame - segment.startFrame,
+      0,
+    ) *
+    (statusCutPlan.sourceFps.denominator / statusCutPlan.sourceFps.numerator);
+  const dominantChannels = media.sampleColors.map((color) => color.indexOf(Math.max(...color)));
+  if (
+    !media.hasVideo ||
+    Math.abs(media.durationSeconds - expectedDuration) > 0.1 ||
+    dominantChannels.join(",") !== "2,0,2,0"
+  ) {
+    throw new Error(
+      `Decoded Agent export content does not match its ordered frame plan: ${JSON.stringify({ media, expectedDuration, dominantChannels })}`,
+    );
+  }
+
+  const summary = JSON.parse(
+    readFileSync(join(projectPath, "analysis", "run-summary.v1.json"), "utf8"),
+  ) as { jobId?: string };
+  if (summary.jobId !== jobId) {
+    throw new Error(`Run summary did not persist run identity: ${JSON.stringify(summary)}`);
+  }
+
+  engine.kill("SIGTERM");
+  await engine.exited;
+  engine = launchEngine();
+  baseUrl = await readinessBaseUrl(engine);
+  const reopened = await request("/v1/project/open", {
+    method: "POST",
+    body: JSON.stringify({ projectPath }),
+  });
+  expectStatus(reopened.response.status, 200, reopened.body);
+  const recovered = await request(`/v1/agent/runs/${encodeURIComponent(jobId)}`);
+  expectStatus(recovered.response.status, 200, recovered.body);
+  if (recovered.body.status !== "completed" || recovered.body.cutPlan == null) {
+    throw new Error(`Agent run did not recover after restart: ${JSON.stringify(recovered.body)}`);
+  }
+  const recoveredOutputPath = join(temporaryRoot, "agent-output-after-restart.mp4");
+  const recoveredExport = await request("/v1/exports/from-cut-plan", {
+    method: "POST",
+    body: JSON.stringify({ jobId, presetId, outputURL: recoveredOutputPath }),
+  });
+  expectStatus(recoveredExport.response.status, 200, recoveredExport.body);
+  if (recoveredExport.body.appliedSegments !== 4 || !existsSync(recoveredOutputPath)) {
+    throw new Error(
+      `Recovered run was not exportable after restart: ${JSON.stringify(recoveredExport.body)}`,
+    );
+  }
+
+  const recordingPath = join(projectPath, "recording.mov");
+  const originalRecordingSize = statSync(recordingPath).size;
+  appendFileSync(recordingPath, new Uint8Array([0]));
+  const staleRecordingExport = await request("/v1/exports/from-cut-plan", {
+    method: "POST",
+    body: JSON.stringify({ jobId, presetId, outputURL: join(temporaryRoot, "stale.mp4") }),
+  });
+  expectStatus(staleRecordingExport.response.status, 409, staleRecordingExport.body);
+  if (staleRecordingExport.body.code !== "project_mismatch") {
+    throw new Error(
+      `Changed recording was not rejected predictably: ${JSON.stringify(staleRecordingExport.body)}`,
+    );
+  }
+  truncateSync(recordingPath, originalRecordingSize);
+
+  const transcriptAliasDirectory = join(temporaryRoot, "transcript-alias");
+  symlinkSync(temporaryRoot, transcriptAliasDirectory, "dir");
+  const symlinkedTranscriptPreflight = await request("/v1/agent/preflight", {
+    method: "POST",
+    body: JSON.stringify({
+      runtimeBudgetMinutes: 10,
+      transcriptionProvider: "imported_transcript",
+      importedTranscriptPath: join(transcriptAliasDirectory, "transcript.json"),
+    }),
+  });
+  expectStatus(
+    symlinkedTranscriptPreflight.response.status,
+    200,
+    symlinkedTranscriptPreflight.body,
+  );
+  const symlinkedTranscriptBlockers = symlinkedTranscriptPreflight.body.blockingReasons as
+    | unknown[]
+    | undefined;
+  if (
+    symlinkedTranscriptPreflight.body.ready !== false ||
+    !symlinkedTranscriptBlockers?.includes("invalid_imported_transcript")
+  ) {
+    throw new Error(
+      `A transcript below a symlinked ancestor was not rejected: ${JSON.stringify(symlinkedTranscriptPreflight.body)}`,
+    );
+  }
+
+  const malformedTranscriptPath = join(temporaryRoot, "malformed-transcript.json");
+  await Bun.write(malformedTranscriptPath, "not-json");
+  const malformedPreflight = await request("/v1/agent/preflight", {
+    method: "POST",
+    body: JSON.stringify({
+      runtimeBudgetMinutes: 10,
+      transcriptionProvider: "imported_transcript",
+      importedTranscriptPath: malformedTranscriptPath,
+    }),
+  });
+  expectStatus(malformedPreflight.response.status, 200, malformedPreflight.body);
+  const malformedTranscriptBlockers = malformedPreflight.body.blockingReasons as
+    | unknown[]
+    | undefined;
+  if (
+    malformedPreflight.body.ready !== false ||
+    !malformedTranscriptBlockers?.includes("invalid_imported_transcript")
+  ) {
+    throw new Error(
+      `Malformed transcript did not produce a typed blocker: ${JSON.stringify(malformedPreflight.body)}`,
+    );
+  }
+
+  const blockedTranscriptPath = join(temporaryRoot, "blocked-transcript.json");
+  await Bun.write(
+    blockedTranscriptPath,
+    JSON.stringify({
+      segments: [{ text: "Opening hook only", startSeconds: 0.25, endSeconds: 1 }],
+    }),
+  );
+  const blockedParameters = {
+    runtimeBudgetMinutes: 10,
+    transcriptionProvider: "imported_transcript",
+    importedTranscriptPath: blockedTranscriptPath,
+  };
+  const blockedPreflight = await request("/v1/agent/preflight", {
+    method: "POST",
+    body: JSON.stringify(blockedParameters),
+  });
+  expectStatus(blockedPreflight.response.status, 200, blockedPreflight.body);
+  const blockedRun = await request("/v1/agent/runs", {
+    method: "POST",
+    body: JSON.stringify({
+      ...blockedParameters,
+      preflightToken: blockedPreflight.body.preflightToken,
+    }),
+  });
+  expectStatus(blockedRun.response.status, 200, blockedRun.body);
+  if (blockedRun.body.status !== "blocked" || typeof blockedRun.body.jobId !== "string") {
+    throw new Error(`Weak narrative was not blocked: ${JSON.stringify(blockedRun.body)}`);
+  }
+  const blockedApply = await request(
+    `/v1/agent/runs/${encodeURIComponent(blockedRun.body.jobId)}/apply`,
+    { method: "POST", body: JSON.stringify({ destructiveIntent: true }) },
+  );
+  expectStatus(blockedApply.response.status, 422, blockedApply.body);
+  if (blockedApply.body.code !== "qa_failed") {
+    throw new Error(`QA failure was not typed: ${JSON.stringify(blockedApply.body)}`);
+  }
+
+  const otherProjectPath = join(temporaryRoot, "Other.gglassproj");
+  mkdirSync(otherProjectPath, { recursive: true });
+  await Bun.write(join(otherProjectPath, "recording.mov"), readFileSync(recordingPath));
+  const switched = await request("/v1/project/open", {
+    method: "POST",
+    body: JSON.stringify({ projectPath: otherProjectPath }),
+  });
+  expectStatus(switched.response.status, 200, switched.body);
+  const crossProject = await request(`/v1/agent/runs/${encodeURIComponent(blockedRun.body.jobId)}`);
+  expectStatus(crossProject.response.status, 404, crossProject.body);
+  const crossProjectApply = await request(
+    `/v1/agent/runs/${encodeURIComponent(blockedRun.body.jobId)}/apply`,
+    { method: "POST", body: JSON.stringify({ destructiveIntent: true }) },
+  );
+  expectStatus(crossProjectApply.response.status, 404, crossProjectApply.body);
+  const crossProjectExport = await request("/v1/exports/from-cut-plan", {
+    method: "POST",
+    body: JSON.stringify({
+      jobId: blockedRun.body.jobId,
+      presetId,
+      outputURL: join(temporaryRoot, "cross-project.mp4"),
+    }),
+  });
+  expectStatus(crossProjectExport.response.status, 404, crossProjectExport.body);
+
+  console.log(
+    JSON.stringify(
+      {
+        success: true,
+        jobId,
+        appliedSegments: 4,
+        artifactCount: artifacts.length,
+        outputPath,
+      },
+      null,
+      2,
+    ),
+  );
+} finally {
+  engine.kill("SIGTERM");
+  await Promise.race([engine.exited, Bun.sleep(5000)]);
+  if (!process.argv.includes("--keep")) {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}

--- a/Scripts/macos_agent_fixture.swift
+++ b/Scripts/macos_agent_fixture.swift
@@ -1,0 +1,129 @@
+#!/usr/bin/env swift
+
+import AppKit
+import AVFoundation
+import CoreVideo
+import Foundation
+
+func makePixelBuffer(width: Int, height: Int, frameIndex: Int) -> CVPixelBuffer? {
+    var pixelBuffer: CVPixelBuffer?
+    let status = CVPixelBufferCreate(
+        kCFAllocatorDefault,
+        width,
+        height,
+        kCVPixelFormatType_32BGRA,
+        [
+            kCVPixelBufferCGImageCompatibilityKey: true,
+            kCVPixelBufferCGBitmapContextCompatibilityKey: true,
+        ] as CFDictionary,
+        &pixelBuffer
+    )
+    guard status == kCVReturnSuccess, let pixelBuffer else { return nil }
+    CVPixelBufferLockBaseAddress(pixelBuffer, [])
+    defer { CVPixelBufferUnlockBaseAddress(pixelBuffer, []) }
+    guard let base = CVPixelBufferGetBaseAddress(pixelBuffer) else { return nil }
+    let bytes = base.assumingMemoryBound(to: UInt8.self)
+    let rowBytes = CVPixelBufferGetBytesPerRow(pixelBuffer)
+    let section = (frameIndex / 30) % 4
+    let colors: [(UInt8, UInt8, UInt8)] = [
+        (20, 40, 220),
+        (40, 200, 60),
+        (220, 80, 30),
+        (180, 40, 180),
+    ]
+    let color = colors[section]
+    for row in 0 ..< height {
+        for column in 0 ..< width {
+            let offset = row * rowBytes + column * 4
+            bytes[offset] = color.2
+            bytes[offset + 1] = color.1
+            bytes[offset + 2] = color.0
+            bytes[offset + 3] = 255
+        }
+    }
+    return pixelBuffer
+}
+
+if CommandLine.arguments.count >= 3, CommandLine.arguments[1] == "--probe" {
+    let asset = AVAsset(url: URL(fileURLWithPath: CommandLine.arguments[2]))
+    let duration = try await asset.load(.duration).seconds
+    let tracks = try await asset.loadTracks(withMediaType: .video)
+    let size = try await tracks.first?.load(.naturalSize) ?? .zero
+    var sampleColors: [[Int]] = []
+    if CommandLine.arguments.count == 4 {
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        for value in CommandLine.arguments[3].split(separator: ",") {
+            guard let seconds = Double(value) else { continue }
+            let (image, _) = try await generator.image(at: CMTime(seconds: seconds, preferredTimescale: 600))
+            let bitmap = NSBitmapImageRep(cgImage: image)
+            let color = bitmap.colorAt(x: image.width / 2, y: image.height / 2)?.usingColorSpace(.sRGB)
+            sampleColors.append([
+                Int((color?.redComponent ?? 0) * 255),
+                Int((color?.greenComponent ?? 0) * 255),
+                Int((color?.blueComponent ?? 0) * 255),
+            ])
+        }
+    }
+    let payload: [String: Any] = [
+        "durationSeconds": duration,
+        "width": size.width,
+        "height": size.height,
+        "hasVideo": !tracks.isEmpty,
+        "sampleColors": sampleColors,
+    ]
+    let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+    print(String(decoding: data, as: UTF8.self))
+    exit(0)
+}
+
+guard CommandLine.arguments.count == 2 else {
+    FileHandle.standardError.write(Data("usage: macos_agent_fixture.swift <output.mov> | --probe <media>\n".utf8))
+    exit(2)
+}
+
+let outputURL = URL(fileURLWithPath: CommandLine.arguments[1])
+try? FileManager.default.removeItem(at: outputURL)
+let writer = try AVAssetWriter(outputURL: outputURL, fileType: .mov)
+let width = 320
+let height = 180
+let fps: Int32 = 30
+let input = AVAssetWriterInput(
+    mediaType: .video,
+    outputSettings: [
+        AVVideoCodecKey: AVVideoCodecType.h264,
+        AVVideoWidthKey: width,
+        AVVideoHeightKey: height,
+    ]
+)
+input.expectsMediaDataInRealTime = false
+guard writer.canAdd(input) else { throw NSError(domain: "AgentFixture", code: 1) }
+writer.add(input)
+let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+    assetWriterInput: input,
+    sourcePixelBufferAttributes: [
+        kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32BGRA,
+        kCVPixelBufferWidthKey as String: width,
+        kCVPixelBufferHeightKey as String: height,
+    ]
+)
+guard writer.startWriting() else { throw writer.error ?? NSError(domain: "AgentFixture", code: 2) }
+writer.startSession(atSourceTime: .zero)
+for frame in 0 ..< 240 {
+    while !input.isReadyForMoreMediaData {
+        Thread.sleep(forTimeInterval: 0.001)
+    }
+    guard let pixelBuffer = makePixelBuffer(width: width, height: height, frameIndex: frame),
+          adaptor.append(pixelBuffer, withPresentationTime: CMTime(value: Int64(frame), timescale: fps))
+    else { throw writer.error ?? NSError(domain: "AgentFixture", code: 3) }
+}
+
+input.markAsFinished()
+let semaphore = DispatchSemaphore(value: 0)
+writer.finishWriting { semaphore.signal() }
+semaphore.wait()
+guard writer.status == .completed else {
+    throw writer.error ?? NSError(domain: "AgentFixture", code: 4)
+}
+
+print(outputURL.path)

--- a/Tests/agentModeTests/AgentModeTests.swift
+++ b/Tests/agentModeTests/AgentModeTests.swift
@@ -1,0 +1,202 @@
+@testable import Project
+import XCTest
+
+final class AgentModeTests: XCTestCase {
+    func testPlannerProducesDeterministicOrderedFramePlan() throws {
+        let transcript = Data(#"""
+        {
+          "segments": [
+            {"text":"Opening hook", "startSeconds":0.25, "endSeconds":1.0},
+            {"text":"Action steps", "startSeconds":2.0, "endSeconds":3.0},
+            {"text":"Result payoff", "startSeconds":4.0, "endSeconds":5.0},
+            {"text":"Conclusion takeaway", "startSeconds":6.0, "endSeconds":7.25}
+          ]
+        }
+        """#.utf8)
+
+        let first = try ImportedTranscriptAgentPlanner.plan(
+            data: transcript,
+            sourceDuration: 10,
+            sourceFps: AgentFrameRate(numerator: 30)
+        )
+        let second = try ImportedTranscriptAgentPlanner.plan(
+            data: transcript,
+            sourceDuration: 10,
+            sourceFps: AgentFrameRate(numerator: 30)
+        )
+
+        XCTAssertEqual(first, second)
+        XCTAssertTrue(first.qaReport.passed)
+        XCTAssertEqual(first.cutPlan.segments, [
+            .init(id: "agent-hook-0", beat: .hook, startFrame: 7, endFrame: 30),
+            .init(id: "agent-action-1", beat: .action, startFrame: 60, endFrame: 90),
+            .init(id: "agent-payoff-2", beat: .payoff, startFrame: 120, endFrame: 150),
+            .init(id: "agent-takeaway-3", beat: .takeaway, startFrame: 180, endFrame: 218),
+        ])
+        let timeline = try first.cutPlan.timeline()
+        XCTAssertEqual(timeline.items.count, 4)
+        guard case let .clip(firstClip) = timeline.items[0] else {
+            return XCTFail("Expected a clip")
+        }
+        XCTAssertEqual(firstClip.sourceStartSeconds, 7.0 / 30.0, accuracy: 0.000_001)
+        XCTAssertEqual(firstClip.sourceEndSeconds, 1, accuracy: 0.000_001)
+    }
+
+    func testCutPlanRetainsFractionalFrameRateWithoutRounding() throws {
+        let rate = AgentFrameRate(numerator: 30000, denominator: 1001)
+        let plan = AgentCutPlanArtifact(
+            sourceFps: rate,
+            sourceFrameCount: 300,
+            segments: [
+                .init(id: "agent-hook-0", beat: .hook, startFrame: 1, endFrame: 30),
+                .init(id: "agent-action-1", beat: .action, startFrame: 30, endFrame: 60),
+                .init(id: "agent-payoff-2", beat: .payoff, startFrame: 60, endFrame: 90),
+                .init(id: "agent-takeaway-3", beat: .takeaway, startFrame: 90, endFrame: 120),
+            ]
+        )
+
+        let timeline = try plan.timeline()
+        guard case let .clip(clip) = timeline.items[0] else {
+            return XCTFail("Expected a clip")
+        }
+        XCTAssertEqual(clip.sourceStartSeconds, 1001.0 / 30000.0, accuracy: 0.000_000_1)
+        XCTAssertEqual(clip.sourceEndSeconds, 1.001, accuracy: 0.000_000_1)
+    }
+
+    func testPlannerBlocksMissingOrOutOfOrderNarrativeBeats() throws {
+        let transcript = Data(#"""
+        {
+          "segments": [
+            {"text":"payoff result", "startSeconds":0, "endSeconds":1},
+            {"text":"opening hook", "startSeconds":1, "endSeconds":2},
+            {"text":"action process", "startSeconds":2, "endSeconds":3}
+          ]
+        }
+        """#.utf8)
+
+        let result = try ImportedTranscriptAgentPlanner.plan(
+            data: transcript,
+            sourceDuration: 5,
+            sourceFps: AgentFrameRate(numerator: 30)
+        )
+
+        XCTAssertFalse(result.qaReport.passed)
+        XCTAssertTrue(result.cutPlan.segments.isEmpty)
+        XCTAssertEqual(result.qaReport.missingBeats, ["payoff", "takeaway"])
+    }
+
+    func testArtifactStorePersistsAndRecoversCanonicalRun() throws {
+        let root = URL(fileURLWithPath: "/private\(FileManager.default.temporaryDirectory.path)", isDirectory: true)
+            .appendingPathComponent("gg-agent-store-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let transcript = Data(#"""
+        {
+          "segments": [
+            {"text":"hook", "startSeconds":0, "endSeconds":1},
+            {"text":"action", "startSeconds":1, "endSeconds":2},
+            {"text":"payoff", "startSeconds":2, "endSeconds":3},
+            {"text":"takeaway", "startSeconds":3, "endSeconds":4}
+          ]
+        }
+        """#.utf8)
+        let planned = try ImportedTranscriptAgentPlanner.plan(
+            data: transcript,
+            sourceDuration: 5,
+            sourceFps: AgentFrameRate(numerator: 30)
+        )
+        let projectId = UUID()
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let summary = AgentRunSummaryArtifact(
+            jobId: "agent-test",
+            projectId: projectId,
+            recordingFileName: ProjectFile.recordingMov,
+            recordingRevision: "fixture-revision",
+            status: .completed,
+            runtimeBudgetMinutes: 10,
+            qaReport: planned.qaReport,
+            artifacts: AgentArtifactStore.references,
+            cutPlan: planned.cutPlan,
+            baseTimeline: TimelineDocument(),
+            requiresDestructiveConfirmation: false,
+            createdAt: now,
+            updatedAt: now
+        )
+
+        let store = AgentArtifactStore()
+        let persisted = try store.write(plannedRun: planned, summary: summary, projectURL: root)
+        let recovered = try XCTUnwrap(store.loadLatest(projectURL: root, projectId: projectId))
+
+        XCTAssertEqual(recovered, persisted)
+        XCTAssertTrue(persisted.artifacts.dropLast().allSatisfy { $0.sha256?.count == 64 })
+        var invalidReplacement = planned
+        invalidReplacement.qaReport.score = .nan
+        XCTAssertThrowsError(try store.write(
+            plannedRun: invalidReplacement,
+            summary: summary,
+            projectURL: root
+        ))
+        XCTAssertEqual(
+            try store.loadLatest(projectURL: root, projectId: projectId),
+            persisted,
+            "a failed replacement must preserve the prior generation"
+        )
+        for reference in AgentArtifactStore.references {
+            XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(reference.path).path))
+        }
+        XCTAssertThrowsError(try store.loadLatest(projectURL: root, projectId: UUID()))
+        try Data("{}".utf8).write(
+            to: root.appendingPathComponent("analysis/\(ProjectFile.cutPlanV1JSON)"),
+            options: .atomic
+        )
+        XCTAssertThrowsError(try store.loadLatest(projectURL: root, projectId: projectId))
+    }
+
+    func testArtifactStoreRejectsSymlinkedAnalysisDirectory() throws {
+        let temporaryDirectory = URL(
+            fileURLWithPath: "/private\(FileManager.default.temporaryDirectory.path)",
+            isDirectory: true
+        )
+        let root = temporaryDirectory
+            .appendingPathComponent("gg-agent-symlink-\(UUID().uuidString)", isDirectory: true)
+        let outside = temporaryDirectory
+            .appendingPathComponent("gg-agent-outside-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: root)
+            try? FileManager.default.removeItem(at: outside)
+        }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: root.appendingPathComponent(ProjectFile.analysisDirectory),
+            withDestinationURL: outside
+        )
+
+        let planned = try ImportedTranscriptAgentPlanner.plan(
+            data: Data(#"{"segments":[{"text":"hook action payoff takeaway","startSeconds":0,"endSeconds":1}]}"#.utf8),
+            sourceDuration: 2,
+            sourceFps: AgentFrameRate(numerator: 30)
+        )
+        let summary = AgentRunSummaryArtifact(
+            jobId: "agent-test",
+            projectId: UUID(),
+            recordingFileName: ProjectFile.recordingMov,
+            recordingRevision: "fixture-revision",
+            status: .blocked,
+            runtimeBudgetMinutes: 10,
+            qaReport: planned.qaReport,
+            artifacts: AgentArtifactStore.references,
+            cutPlan: planned.cutPlan,
+            baseTimeline: TimelineDocument(),
+            requiresDestructiveConfirmation: false,
+            createdAt: Date(),
+            updatedAt: Date()
+        )
+
+        XCTAssertThrowsError(try AgentArtifactStore().write(
+            plannedRun: planned,
+            summary: summary,
+            projectURL: root
+        ))
+    }
+}

--- a/Tests/agentModeTests/AgentModeTests.swift
+++ b/Tests/agentModeTests/AgentModeTests.swift
@@ -141,6 +141,14 @@ final class AgentModeTests: XCTestCase {
             persisted,
             "a failed replacement must preserve the prior generation"
         )
+        let quarantine = try XCTUnwrap(store.quarantineLatest(projectURL: root))
+        XCTAssertNil(try store.loadLatest(projectURL: root, projectId: projectId))
+        try store.restoreQuarantined(quarantine, projectURL: root)
+        XCTAssertEqual(
+            try store.loadLatest(projectURL: root, projectId: projectId),
+            persisted,
+            "a failed Save As must restore the destination generation"
+        )
         for reference in AgentArtifactStore.references {
             XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(reference.path).path))
         }

--- a/apps/desktop-electrobun/src/mainview/lib/engine.ts
+++ b/apps/desktop-electrobun/src/mainview/lib/engine.ts
@@ -129,7 +129,6 @@ export const engineApi = {
   async agentPreflight(params?: {
     runtimeBudgetMinutes?: number;
     transcriptionProvider?: "none" | "imported_transcript";
-    importedTranscriptPath?: string;
   }) {
     return await invokeBridgeContract("ggEngineAgentPreflight", "agent preflight result", params);
   },
@@ -138,7 +137,6 @@ export const engineApi = {
     preflightToken: string;
     runtimeBudgetMinutes?: number;
     transcriptionProvider?: "none" | "imported_transcript";
-    importedTranscriptPath?: string;
     force?: boolean;
   }) {
     return await invokeBridgeContract("ggEngineAgentRun", "agent run result", params);

--- a/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
+++ b/apps/desktop-electrobun/src/shared/bridge/desktopBridgeContract.ts
@@ -1,7 +1,10 @@
 import {
+  agentApplyResultSchema,
   agentPreflightResultSchema,
+  type AgentApplyResult,
   agentRunResultSchema,
   agentStatusResultSchema,
+  transcriptionProviderSchema,
   type AgentPreflightResult,
   type AgentRunResult,
   type AgentStatusResult,
@@ -43,6 +46,7 @@ import {
   type CapabilitiesResult,
   type PingResult,
 } from "@guerillaglass/engine-contract/domains/system";
+import { RuntimeBudgetMinutesSchema } from "@guerillaglass/engine-contract/shared/helpers";
 import type {
   AutoZoomSettings,
   BackgroundFramingSettings,
@@ -81,8 +85,6 @@ import {
 } from "@guerillaglass/engine-contract/schema-primitives";
 import { Schema } from "effect";
 import {
-  agentPreflightPayloadSchema,
-  agentRunPayloadSchema,
   captureStartCurrentWindowPayloadSchema,
   captureStartDisplayPayloadSchema,
   captureStartWindowPayloadSchema,
@@ -229,8 +231,17 @@ export const studioDiagnosticsEntrySchema = Schema.Struct({
   ),
 });
 const undefinedBridgeParamsSchema = Schema.Void;
-const engineAgentPreflightBridgeParamsSchema = agentPreflightPayloadSchema;
-const engineAgentRunBridgeParamsSchema = agentRunPayloadSchema;
+// Renderer callers cannot supply local transcript paths. A future UI must use a host-minted grant.
+const engineAgentPreflightBridgeParamsSchema = Schema.Struct({
+  runtimeBudgetMinutes: Schema.optionalKey(RuntimeBudgetMinutesSchema),
+  transcriptionProvider: Schema.optionalKey(transcriptionProviderSchema),
+});
+const engineAgentRunBridgeParamsSchema = Schema.Struct({
+  preflightToken: agentPreflightTokenSchema,
+  runtimeBudgetMinutes: Schema.optionalKey(RuntimeBudgetMinutesSchema),
+  transcriptionProvider: Schema.optionalKey(transcriptionProviderSchema),
+  force: Schema.optionalKey(Schema.Boolean),
+});
 const engineAgentStatusBridgeParamsSchema = Schema.Struct({ jobId: agentJobIdSchema });
 const engineAgentApplyBridgeParamsSchema = Schema.Struct({
   jobId: agentJobIdSchema,
@@ -254,7 +265,7 @@ const engineSuccessSchemas = {
   "agent.preflight": agentPreflightResultSchema,
   "agent.run": agentRunResultSchema,
   "agent.status": agentStatusResultSchema,
-  "agent.apply": actionResultSchema,
+  "agent.apply": agentApplyResultSchema,
   "permissions.requestScreenRecording": actionResultSchema,
   "permissions.requestMicrophone": actionResultSchema,
   "permissions.requestInputMonitoring": actionResultSchema,
@@ -444,21 +455,16 @@ export const bridgeRequestDefinitions = {
     {
       runtimeBudgetMinutes?: number;
       transcriptionProvider?: "none" | "imported_transcript";
-      importedTranscriptPath?: ProjectPath;
     },
     AgentPreflightResult,
     [
       params?: {
         runtimeBudgetMinutes?: number;
         transcriptionProvider?: "none" | "imported_transcript";
-        importedTranscriptPath?: string;
       },
     ]
   >(
-    (params) => ({
-      ...params,
-      importedTranscriptPath: makeOptionalProjectPath(params?.importedTranscriptPath),
-    }),
+    (params) => params ?? {},
     engineAgentPreflightBridgeParamsSchema,
     engineSuccessSchema("agent.preflight"),
   ),
@@ -467,7 +473,6 @@ export const bridgeRequestDefinitions = {
       preflightToken: AgentPreflightToken;
       runtimeBudgetMinutes?: number;
       transcriptionProvider?: "none" | "imported_transcript";
-      importedTranscriptPath?: ProjectPath;
       force?: boolean;
     },
     AgentRunResult,
@@ -476,7 +481,6 @@ export const bridgeRequestDefinitions = {
         preflightToken: string;
         runtimeBudgetMinutes?: number;
         transcriptionProvider?: "none" | "imported_transcript";
-        importedTranscriptPath?: string;
         force?: boolean;
       },
     ]
@@ -484,7 +488,6 @@ export const bridgeRequestDefinitions = {
     (params) => ({
       ...params,
       preflightToken: makeAgentPreflightToken(params.preflightToken),
-      importedTranscriptPath: makeOptionalProjectPath(params.importedTranscriptPath),
     }),
     engineAgentRunBridgeParamsSchema,
     engineSuccessSchema("agent.run"),
@@ -500,7 +503,7 @@ export const bridgeRequestDefinitions = {
   ),
   ggEngineAgentApply: defineValidatedBridgeRequest<
     { jobId: AgentJobId; destructiveIntent?: boolean },
-    ActionResult,
+    AgentApplyResult,
     [params: { jobId: string; destructiveIntent?: boolean }]
   >(
     (params) => ({ ...params, jobId: makeAgentJobId(params.jobId) }),

--- a/apps/desktop-electrobun/tests/engine-api.test.ts
+++ b/apps/desktop-electrobun/tests/engine-api.test.ts
@@ -108,6 +108,32 @@ describe("renderer engine bridge", () => {
     }
   });
 
+  test("strips renderer-supplied transcript paths from Agent requests", async () => {
+    let received: unknown;
+    const bindings = installWindowBridge({
+      ggEngineAgentPreflight: async (params) => {
+        received = params;
+        return {
+          ready: false,
+          blockingReasons: ["missing_imported_transcript"],
+          canApplyDestructive: false,
+          transcriptionProvider: "imported_transcript",
+        };
+      },
+    });
+
+    await (bindings.ggEngineAgentPreflight as (params: unknown) => Promise<unknown>)({
+      runtimeBudgetMinutes: 10,
+      transcriptionProvider: "imported_transcript",
+      importedTranscriptPath: "/tmp/untrusted.json",
+    });
+
+    expect(received).toEqual({
+      runtimeBudgetMinutes: 10,
+      transcriptionProvider: "imported_transcript",
+    });
+  });
+
   test("parses parity command payloads", async () => {
     let lastMenuState: unknown;
     let lastStudioDiagnostics: unknown;

--- a/docs/AGENT_DISCOVERABILITY_AUDIT.md
+++ b/docs/AGENT_DISCOVERABILITY_AUDIT.md
@@ -1,0 +1,45 @@
+# Agent discoverability audit
+
+Date: 2026-07-25
+
+This audit examined two separate experiences:
+
+1. whether a fresh coding agent can find repository ownership, constraints, and validation commands; and
+2. whether an automation agent can discover and safely drive local Agent Mode against Creator Studio projects.
+
+Evidence included source/document tracing, generated OpenAPI inspection, authenticated live-engine probes, packaged Electrobun accessibility inspection with Peekaboo, and two independent Herdr agent reviews.
+
+## Findings and disposition
+
+| Severity | Finding | Disposition |
+| --- | --- | --- |
+| Blocker | macOS cut-plan export accepted any job ID and exported the current recording without resolving QA or a cut plan. | Addressed by resolving the project-bound persisted run and exporting its exact frame-derived timeline. |
+| Blocker | `agent.apply` could report success without applying a generated cut plan. | Addressed by applying the exact persisted cut-plan timeline and returning a typed, verifiable result. |
+| Blocker | In-memory jobs were not project-bound and survived project switches. | Addressed by binding run summaries to the project UUID and a sampled recording fingerprint, clearing state on project switch, and restoring only a validated current-project manifest. |
+| High | Required Agent artifacts were modeled but never persisted. | Addressed for the macOS imported-transcript path with six atomic project-relative v1 artifacts and summary-last commit semantics. |
+| High | macOS returned generic HTTP 400 responses where OpenAPI promised typed 404/409/422 outcomes. | Addressed for status, apply, and cut-plan export, including typed preflight-expiry/mismatch and project-mismatch outcomes. |
+| High | Capabilities overstated Agent and cut-plan support on Rust foundation shells. | Addressed by advertising those capabilities as unavailable and returning typed `unsupported_method` failures from every Agent and cut-plan HTTP endpoint. Generated bindings still enforce wire-shape conformance without implying runtime support. |
+| High | No focused, executable Agent Mode documentation existed. | Addressed by `docs/AGENT_MODE_RUNBOOK.md` and root source-of-truth links. |
+| High | Agent Mode had no visible packaged-workspace entry point. | Open. This remains on the Agent Mode productization track; direct local HTTP/engine-client automation is the supported agent-driving surface until that UI lands. |
+| High | Run state disappeared after engine restart. | Addressed for the latest macOS run by recovering `analysis/run-summary.v1.json` on project open. |
+| High | Analysis itself marked the project dirty and manufactured destructive confirmation. | Addressed: analysis artifacts persist independently; confirmation is based on pre-run unsaved state or subsequent timeline drift. |
+| Medium | Swift preflight token TTL differed from the normative 60 seconds. | Addressed and exposed in capabilities. |
+| Medium | OpenAPI accepted a 60-minute runtime budget while engines allowed only 10. | Addressed by narrowing the contract to 1–10. |
+| Medium | Preflight did not inspect source duration. | Addressed for positive duration, video-track presence, frame rate, and the 10-minute source limit. |
+| Medium | Spec required a nullable blocked token while the wire contract omitted it. | Resolved in favor of existing omission semantics and documented in the runbook/spec. |
+| Medium | Imported-transcript paths can reach the native engine without a dedicated desktop file-grant flow. | Open. Direct authenticated engine clients may use trusted local paths. A future workspace import flow must use a host picker/capability and copy the validated transcript into the project package before exposing Agent Mode in UI. |
+| Medium | Save As does not yet copy and revalidate the analysis artifact set. | Open. Treat Save As as creating a project without a recovered Agent run until artifact-copy semantics are implemented. |
+| Low | Generated OpenAPI operations lacked workflow descriptions. | Addressed with summaries and prerequisite/behavior descriptions at the Effect `HttpApi` source. |
+
+## Verification boundary
+
+The implemented path is deliberately narrow:
+
+- macOS production engine;
+- existing saved project and recording;
+- `imported_transcript` provider;
+- synchronous deterministic four-beat planning;
+- latest run only;
+- frame-based cut plan retaining the source track's rational minimum-frame duration, with nominal integer FPS only as a fallback.
+
+The audit does not claim a local speech-to-text model, multiple run history, background cancellation, Agent workspace UI, or production media parity on Windows/Linux.

--- a/docs/AGENT_MODE_RUNBOOK.md
+++ b/docs/AGENT_MODE_RUNBOOK.md
@@ -1,0 +1,187 @@
+# Local Agent Mode runbook
+
+Agent Mode is a local, project-scoped rough-cut workflow. The supported production path is currently the macOS native engine with an existing saved project/recording and an imported timed transcript.
+
+## Discover support first
+
+Call `GET /v1/engine/capabilities` before using Agent Mode. A client must require all relevant Agent flags and `export.cutPlan=true`; endpoint presence alone does not imply production support.
+
+The macOS capability response also advertises:
+
+- `supportedTranscriptionProviders`
+- `maxSourceDurationSeconds`
+- `preflightTokenTtlSeconds`
+- `artifactVersion`
+- `cutPlanVersion`
+
+Windows/Linux foundation shells intentionally advertise Agent and cut-plan export as unavailable. If a client calls those generated routes anyway, every Agent operation and cut-plan export returns HTTP 400 with `code: "unsupported_method"`; they do not simulate jobs or artifacts.
+
+## Engine transport
+
+The desktop host normally launches and authenticates the engine through `packages/engine-client`. For a focused direct-HTTP session:
+
+```bash
+export GG_ENGINE_TRANSPORT=http
+export GG_ENGINE_HTTP_AUTH_TOKEN="$(openssl rand -hex 32)"
+.build/debug/guerillaglass-engine > /tmp/gg-engine-ready.jsonl 2>/tmp/gg-engine.log &
+export GG_ENGINE_PID=$!
+
+# Read host/port from the one-line guerillaglass.engine.http.ready JSON envelope.
+export GG_ENGINE_BASE_URL="$(
+  jq -r 'select(.type == "guerillaglass.engine.http.ready") | "http://\(.host):\(.port)"' \
+    /tmp/gg-engine-ready.jsonl
+)"
+```
+
+Every request requires:
+
+```text
+Authorization: Bearer $GG_ENGINE_HTTP_AUTH_TOKEN
+Content-Type: application/json
+```
+
+Do not log or persist the bearer token. Stop the manually launched process when finished:
+
+```bash
+kill "$GG_ENGINE_PID"
+```
+
+## Prerequisites
+
+1. Open an existing `.gglassproj` package using `POST /v1/project/open`.
+2. Confirm `GET /v1/project/current` returns its recording.
+3. Prepare an imported transcript JSON with timed `segments`, `words`, or both.
+4. Keep the recording at or below the advertised source-duration limit.
+
+Example transcript:
+
+```json
+{
+  "segments": [
+    { "text": "Opening hook", "startSeconds": 0.25, "endSeconds": 1.0 },
+    { "text": "Action steps", "startSeconds": 2.0, "endSeconds": 3.0 },
+    { "text": "Result payoff", "startSeconds": 4.0, "endSeconds": 5.0 },
+    { "text": "Conclusion takeaway", "startSeconds": 6.0, "endSeconds": 7.25 }
+  ]
+}
+```
+
+The four narrative anchors must occur in canonical order: `hook -> action -> payoff -> takeaway`.
+
+Direct authenticated engine clients may pass a trusted local transcript path. The desktop workspace must not expose this field until a host file-picker/capability flow exists.
+
+## Required call order
+
+### 1. Preflight
+
+```bash
+curl --fail-with-body \
+  -H "Authorization: Bearer $GG_ENGINE_HTTP_AUTH_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d "{\"runtimeBudgetMinutes\":10,\"transcriptionProvider\":\"imported_transcript\",\"importedTranscriptPath\":\"/absolute/path/transcript.json\"}" \
+  "$GG_ENGINE_BASE_URL/v1/agent/preflight"
+```
+
+Proceed only when `ready=true`. A ready response includes `preflightToken` and `preflightTokenExpiresAt`. The token:
+
+- expires after the advertised TTL (currently 60 seconds);
+- is single-use;
+- is bound to the current project, recording, timeline baseline, provider, transcript path, and runtime budget.
+
+Blocked responses omit both token fields.
+
+### 2. Run
+
+Call `POST /v1/agent/runs` with the token and the exact same run parameters. The current imported-transcript pipeline is synchronous, so the initial response is normally already `completed` or `blocked`.
+
+### 3. Inspect status and plan
+
+Call `GET /v1/agent/runs/{jobId}`. Do not apply or export unless:
+
+- `status == "completed"`;
+- `qaReport.passed == true`;
+- `cutPlan.segments` is non-empty;
+- all artifact paths are project-relative.
+
+The cut plan uses end-exclusive frame ranges and rational source FPS metadata. Clients should render this response for review rather than reverse-engineering artifact files.
+
+Terminal statuses are `completed`, `blocked`, `failed`, and `cancelled`. If a future engine returns `queued` or `running`, poll with bounded backoff and an overall deadline no greater than the advertised runtime budget.
+
+### 4. Apply, when desired
+
+Call `POST /v1/agent/runs/{jobId}/apply` with `{}`. If HTTP 409 returns `needs_confirmation`, review the changed timeline and retry with:
+
+```json
+{ "destructiveIntent": true }
+```
+
+A successful response includes the Agent job ID and applied segment count. The working timeline must match the status response's cut-plan frame ranges converted through its rational FPS.
+
+### 5. Export the cut plan
+
+Call `POST /v1/exports/from-cut-plan` with:
+
+```json
+{
+  "jobId": "the-agent-job-id",
+  "presetId": "an-id-from-v1-export-info",
+  "outputURL": "/absolute/output/path.mp4"
+}
+```
+
+Export resolves and validates the persisted run independently; `agent.apply` is not a prerequisite. Apply and export consume the same canonical cut plan.
+
+## Persisted artifacts
+
+The latest macOS run writes these files atomically under the project package:
+
+```text
+analysis/transcript.full.v1.json
+analysis/transcript.words.v1.json
+analysis/beat-map.v1.json
+analysis/qa-report.v1.json
+analysis/cut-plan.v1.json
+analysis/run-summary.v1.json
+```
+
+`run-summary.v1.json` is committed last. Project reopen restores a run only when the manifest is valid and bound to the same project UUID. Artifact paths returned over the API remain project-relative.
+
+## Failure remediation
+
+| HTTP/code or blocker | Action |
+| --- | --- |
+| `missing_project` | Open a saved project package. |
+| `missing_recording` | Record/save media into the active project. |
+| `missing_local_model` | Select `imported_transcript`; no local model ships yet. |
+| `missing_imported_transcript` | Supply the trusted transcript path to preflight and run. |
+| `invalid_imported_transcript` | Validate JSON, non-empty text, and finite increasing timestamps. |
+| `source_too_long` | Use a source within the capability-advertised limit. |
+| `source_duration_invalid` | Verify the recording has a readable video track and duration. |
+| HTTP 400 `preflight_expired` | Token expired, was consumed, or is unknown; preflight again. |
+| HTTP 400 `preflight_mismatch` | Run parameters or active project/recording differ from preflight; preflight again. |
+| HTTP 404 `not_found` | The job is not the current project's recoverable latest run. |
+| HTTP 409 `needs_confirmation` | Review timeline drift and retry with explicit destructive intent only when intended. |
+| HTTP 409 `project_mismatch` | Reopen the bound project and restore the original recording, or create a fresh run. |
+| HTTP 422 `qa_failed` | Fix missing/out-of-order narrative beats and rerun. |
+| HTTP 422 `invalid_cut_plan` | Do not apply/export; rerun analysis or repair the project artifact set. |
+
+## Verification checklist
+
+On macOS, the repository's executable golden-path probe builds a synthetic recording, runs the authenticated workflow, validates confirmation and typed errors, checks all six artifacts, decodes exported media duration against the frame plan, restarts the engine, verifies recovery, and rejects the job after switching projects:
+
+```bash
+bun run swift:build
+bun run agent:smoke:macos
+```
+
+A successful integration proves more than HTTP success:
+
+- capabilities truthfully advertise the path;
+- all six artifacts exist and decode;
+- status exposes QA and the exact frame plan;
+- apply returns a positive segment count and the timeline matches the plan;
+- cut-plan export returns that same count;
+- decoded output duration matches the selected frame ranges;
+- restarting the engine and reopening the project restores status;
+- a job from another project cannot be applied or exported;
+- malformed transcript, failed QA, missing/cross-project jobs, confirmation, and consumed-token reuse use their documented machine-readable outcomes; the ready response's expiry timestamp is also checked against the advertised TTL.

--- a/docs/CHANGE_MAP.md
+++ b/docs/CHANGE_MAP.md
@@ -96,6 +96,19 @@ shared bridge contract
 
 Do not add application logic directly to bridge handlers. Acquire windows, menus, trays, servers, processes, and subscriptions through scoped services. Test lifecycle cleanup and recoverable host-dialog timeouts. For UI-facing host changes on macOS, run `bun run desktop:acceptance` so the packaged Electrobun host, renderer, and native engine are exercised together.
 
+## Agent Mode operation
+
+```text
+packages/engine-contract/src/domains/agent.ts + src/httpApi.ts
+  -> generated OpenAPI and native bindings
+  -> packages/engine-client AgentService
+  -> native preflight/run/status/apply and artifact storage
+  -> cut-plan export
+  -> desktop bridge/workspace when UI is in scope
+```
+
+Use `docs/AGENT_MODE_RUNBOOK.md` as the operational contract and keep `docs/AGENT_DISCOVERABILITY_AUDIT.md` dispositions current. Capabilities must identify unsupported foundation targets instead of inferring parity from generated endpoints. Verify project/run binding, token expiry, QA failure, persisted artifact recovery, destructive confirmation, exact apply results, and decoded cut-plan export media.
+
 ## Native capture or export behavior
 
 - macOS production behavior belongs under `engines/macos-swift`.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -119,6 +119,10 @@ Groundwork already present:
 - [x] Preflight token handshake and blocking semantics are implemented
 - [x] Agent artifacts persist inside project packages under `analysis/*.v1.json`
 - [x] Deterministic cut-plan apply/export path exists in the engine contract
+  - The supported production path is macOS plus an imported timed transcript; foundation shells advertise Agent/cut-plan capabilities as unavailable.
+  - Status exposes QA, project-relative artifacts, and the exact rational-FPS frame plan used by both apply and export.
+  - The latest run is project-bound and recovered from `run-summary.v1` when reopening a project.
+  - Operational guidance and remaining discoverability gaps are tracked in `docs/AGENT_MODE_RUNBOOK.md` and `docs/AGENT_DISCOVERABILITY_AUDIT.md`.
 
 ---
 

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -313,13 +313,13 @@ Hard rules:
 
 - `agent.apply` and `export.runCutPlan` are blocked when narrative QA fails.
 - Destructive apply operations require explicit confirmation (`destructiveIntent=true`) when unsaved project changes are present.
-- `agent.apply` is a strict alias to `export.runCutPlan`; there is one canonical cut-plan execution engine.
+- `agent.apply` and `export.runCutPlan` consume the same canonical persisted frame-based cut plan; apply updates the working timeline, while export renders that plan without requiring prior apply.
 - `run-summary.v1` is the canonical agent manifest; project summary state derives from this artifact.
-- Agent artifacts are written under the project package `analysis/` directory.
-- Cut-plan segments are frame-based (`startFrame`/`endFrame`) with source FPS metadata.
+- Agent artifacts are written atomically under the project package `analysis/` directory; `run-summary.v1.json` is committed last and binds the latest run to the project UUID.
+- Cut-plan segments are frame-based with end-exclusive `startFrame`/`endFrame` bounds and rational source FPS metadata (`numerator`/`denominator`).
 - `force` is debug-only (disabled in production unless `GG_AGENT_ALLOW_FORCE=1`).
 - v1 source target: recordings up to 10 minutes.
-- `agent.status` is intentionally compact: one `status` field plus optional `blockingReason`.
+- `agent.status` is the reviewable run response: lifecycle state plus optional blocking reason, QA report, project-relative artifact references, and cut-plan summary.
 - `agent.run` requires a valid short-lived `preflightToken` from `agent.preflight` (TTL: 60 seconds).
 
 Protocol surface:
@@ -335,7 +335,7 @@ Protocol surface:
 - `ready: boolean`
 - `blockingReasons: AgentBlockingReason[]`
 - `canApplyDestructive: boolean`
-- `preflightToken: string | null` (`null` unless `ready=true`)
+- `preflightToken?: string` and `preflightTokenExpiresAt?: string` (both omitted unless `ready=true`)
 
 `agent.run` request contract additions:
 
@@ -366,7 +366,7 @@ Agent runbook (required order):
 
 1. `agent.preflight`
 2. If `ready=true`, call `agent.run` with returned `preflightToken`.
-3. Poll `agent.status` until terminal (`completed` or `blocked`/`failed`).
+3. Inspect or poll `agent.status` until terminal (`completed`, `blocked`, `failed`, or `cancelled`) using bounded backoff and an overall deadline.
 4. Call `agent.apply` (handle `needs_confirmation` by retrying with `destructiveIntent=true` when intended).
 5. Call `export.runCutPlan` for deterministic export.
 

--- a/engines/macos-swift/EngineService+Agent.swift
+++ b/engines/macos-swift/EngineService+Agent.swift
@@ -1,202 +1,547 @@
+import AVFoundation
+import CryptoKit
 import EngineProtocol
 import Foundation
 import Project
 
-private let agentPreflightTTLSeconds: TimeInterval = 15 * 60
-
-private struct ImportedTranscript: Decodable {
-    struct Segment: Decodable {
-        let text: String
-        let startSeconds: Double
-        let endSeconds: Double
-    }
-
-    struct Word: Decodable {
-        let word: String
-        let startSeconds: Double
-        let endSeconds: Double
-    }
-
-    let segments: [Segment]?
-    let words: [Word]?
-}
+private let agentPreflightTTLSeconds: TimeInterval = 60
+private let agentMaximumSourceDurationSeconds: Double = 10 * 60
 
 extension EngineService {
     func agent_period_agentPreflight(
         _ input: Operations.agent_period_agentPreflight.Input
     ) async throws -> Operations.agent_period_agentPreflight.Output {
         let payload: Components.Schemas.AgentPreflightPayload = switch input.body { case let .json(body): body }
-        let evaluation = evaluateAgentPreflight(
-            runtimeBudgetMinutes: Int(payload.runtimeBudgetMinutes?.value1 ?? 10),
-            transcriptionProvider: payload.transcriptionProvider?.rawValue ?? "none",
-            importedTranscriptPath: payload.importedTranscriptPath?.value1
-        )
-        let token: String?
-        if evaluation.ready {
+        let runtimeBudgetMinutes = Int(payload.runtimeBudgetMinutes?.value1 ?? 10)
+        let provider = payload.transcriptionProvider?.rawValue ?? "none"
+        let transcriptPath = payload.importedTranscriptPath?.value1
+        var reasons: [String] = []
+
+        let projectURL = currentProjectURL
+        let recordingURL = availableAgentRecordingURL()
+        let projectContext = recordingURL.flatMap(agentProjectContext)
+        if projectURL == nil {
+            reasons.append("missing_project")
+        }
+        if recordingURL == nil {
+            reasons.append("missing_recording")
+        }
+        if !(1 ... 10).contains(runtimeBudgetMinutes) {
+            reasons.append("invalid_runtime_budget")
+        }
+        var transcriptData: Data?
+        switch provider {
+        case "imported_transcript":
+            if transcriptPath?.isEmpty ?? true {
+                reasons.append("missing_imported_transcript")
+            } else {
+                transcriptData = try? readAgentTranscript(path: transcriptPath!)
+                if transcriptData == nil {
+                    reasons.append("invalid_imported_transcript")
+                }
+            }
+        default:
+            reasons.append("missing_local_model")
+        }
+
+        var sourceRevision: String?
+        if reasons.isEmpty, let recordingURL {
+            do {
+                let source = try await agentSource(recordingURL: recordingURL)
+                guard let projectContext, matchesAgentProjectContext(projectContext) else {
+                    reasons.append("source_duration_invalid")
+                    return .ok(.init(body: .json(preflightResult(
+                        reasons: reasons,
+                        provider: provider,
+                        token: nil,
+                        expiresAt: nil
+                    ))))
+                }
+                sourceRevision = source.revision
+                if source.duration > agentMaximumSourceDurationSeconds {
+                    reasons.append("source_too_long")
+                } else if provider == "imported_transcript",
+                          let transcriptData,
+                          (try? ImportedTranscriptAgentPlanner.plan(
+                              data: transcriptData,
+                              sourceDuration: source.duration,
+                              sourceFps: source.fps
+                          )) == nil
+                {
+                    reasons.append("invalid_imported_transcript")
+                }
+            } catch {
+                reasons.append("source_duration_invalid")
+            }
+        }
+
+        var token: String?
+        var expiresAt: Date?
+        if reasons.isEmpty, let projectURL, let recordingURL, let projectContext,
+           matchesAgentProjectContext(projectContext), let sourceRevision, let transcriptData
+        {
             let value = "macos-preflight-\(UUID().uuidString)"
+            let createdAt = Date()
+            let expiry = createdAt.addingTimeInterval(agentPreflightTTLSeconds)
             preflightSessions[value] = EngineAgentPreflightSession(
                 token: value,
-                runtimeBudgetMinutes: evaluation.runtimeBudgetMinutes,
-                transcriptionProvider: evaluation.transcriptionProvider,
-                importedTranscriptPath: evaluation.importedTranscriptPath,
-                projectPath: currentProjectURL?.path,
-                recordingURL: availableAgentRecordingURL()?.path,
-                createdAt: Date()
+                runtimeBudgetMinutes: runtimeBudgetMinutes,
+                transcriptionProvider: provider,
+                importedTranscriptPath: transcriptPath,
+                importedTranscriptData: transcriptData,
+                projectId: currentProjectDocument.project.id,
+                projectPath: projectURL.path,
+                recordingURL: recordingURL.path,
+                recordingRevision: sourceRevision,
+                baseTimeline: currentProjectDocument.project.timeline,
+                requiresDestructiveConfirmation: hasUnsavedProjectChanges,
+                createdAt: createdAt
             )
             token = value
-        } else {
-            token = nil
+            expiresAt = expiry
         }
-        return .ok(.init(body: .json(.init(
-            ready: evaluation.ready,
-            blockingReasons: evaluation.blockingReasons,
-            canApplyDestructive: hasUnsavedProjectChanges,
-            transcriptionProvider: .init(rawValue: evaluation.transcriptionProvider) ?? .none,
-            preflightToken: token.map { .init(value1: $0) }
+        return .ok(.init(body: .json(preflightResult(
+            reasons: reasons,
+            provider: provider,
+            token: token,
+            expiresAt: expiresAt
         ))))
     }
 
+    // swiftlint:disable:next function_body_length
     func agent_period_agentRun(
         _ input: Operations.agent_period_agentRun.Input
     ) async throws -> Operations.agent_period_agentRun.Output {
         let payload: Components.Schemas.AgentRunPayload = switch input.body { case let .json(body): body }
         let runtimeBudgetMinutes = Int(payload.runtimeBudgetMinutes?.value1 ?? 10)
-        let transcriptionProvider = payload.transcriptionProvider?.rawValue ?? "none"
-        let importedTranscriptPath = payload.importedTranscriptPath?.value1
-        guard validatePreflightToken(
-            payload.preflightToken.value1,
-            runtimeBudgetMinutes: runtimeBudgetMinutes,
-            transcriptionProvider: transcriptionProvider,
-            importedTranscriptPath: importedTranscriptPath
-        ) else {
+        let provider = payload.transcriptionProvider?.rawValue ?? "none"
+        let transcriptPath = payload.importedTranscriptPath?.value1
+        let session: EngineAgentPreflightSession
+        do {
+            session = try validatePreflightToken(
+                payload.preflightToken.value1,
+                runtimeBudgetMinutes: runtimeBudgetMinutes,
+                transcriptionProvider: provider,
+                importedTranscriptPath: transcriptPath
+            )
+        } catch PreflightTokenValidationError.expired {
             return .badRequest(.init(body: .json(badRequest(
-                .invalid_params,
-                "preflightToken is missing, expired, or does not match current run parameters. Run agent.preflight again."
+                .preflight_expired,
+                "preflightToken is missing, expired, or already consumed. Run agent.preflight again."
+            ))))
+        } catch {
+            return .badRequest(.init(body: .json(badRequest(
+                .preflight_mismatch,
+                "preflightToken does not match the active project, recording, or run parameters. Run agent.preflight again."
             ))))
         }
-        if payload.force == true && ProcessInfo.processInfo.environment["GG_AGENT_ALLOW_FORCE"] != "1" {
+        guard payload.force != true || ProcessInfo.processInfo.environment["GG_AGENT_ALLOW_FORCE"] == "1" else {
             return .badRequest(.init(body: .json(badRequest(
                 .invalid_params,
                 "force is disabled for production runs. Set GG_AGENT_ALLOW_FORCE=1 for local debugging."
             ))))
         }
+        guard let projectURL = currentProjectURL,
+              let recordingURL = availableAgentRecordingURL()
+        else {
+            return .badRequest(.init(body: .json(badRequest(.invalid_request, "Agent Mode inputs are no longer available."))))
+        }
 
-        let coverage = payload.force == true
-            ? AgentCoverage(hook: true, action: true, payoff: true, takeaway: true)
-            : coverageForAgentRun(
-                transcriptionProvider: transcriptionProvider,
-                importedTranscriptPath: importedTranscriptPath
+        do {
+            let transcriptData = session.importedTranscriptData
+            let source: AgentSource
+            do {
+                source = try await agentSource(recordingURL: recordingURL)
+            } catch {
+                return .badRequest(.init(body: .json(badRequest(
+                    .preflight_mismatch,
+                    "The recording became unavailable after preflight. Run agent.preflight again."
+                ))))
+            }
+            guard source.revision == session.recordingRevision,
+                  currentProjectDocument.project.id == session.projectId,
+                  currentProjectURL?.path == session.projectPath,
+                  availableAgentRecordingURL()?.path == session.recordingURL
+            else {
+                return .badRequest(.init(body: .json(badRequest(
+                    .preflight_mismatch,
+                    "The recording changed after preflight. Run agent.preflight again."
+                ))))
+            }
+            let plannedRun = try ImportedTranscriptAgentPlanner.plan(
+                data: transcriptData,
+                sourceDuration: source.duration,
+                sourceFps: source.fps
             )
-        let run = buildAgentRun(
-            jobId: "macos-agent-\(UUID().uuidString)",
-            runtimeBudgetMinutes: runtimeBudgetMinutes,
-            coverage: coverage,
-            blockingReason: coverage.passed ? nil : .weak_narrative_structure
-        )
-        agentRuns[run.jobId] = run
-        latestAgentJobId = run.jobId
-        latestAgentUpdatedAt = run.updatedAt
-        currentProjectDocument.project.agentAnalysis = AgentAnalysisMetadata(
-            latestRunID: run.jobId,
-            latestAppliedRunID: currentProjectDocument.project.agentAnalysis?.latestAppliedRunID,
-            latestRunSummaryPath: currentProjectDocument.project.agentAnalysis?.latestRunSummaryPath
-        )
-        hasUnsavedProjectChanges = true
-        return .ok(.init(body: .json(.init(
-            jobId: .init(value1: run.jobId),
-            status: Components.Schemas.AgentRunResult.statusPayload(rawValue: run.status.rawValue) ?? .failed
-        ))))
+            let jobId = "macos-agent-\(UUID().uuidString)"
+            let now = Date()
+            let status: AgentJobStatus = plannedRun.qaReport.passed ? .completed : .blocked
+            let summaryCandidate = AgentRunSummaryArtifact(
+                jobId: jobId,
+                projectId: session.projectId,
+                recordingFileName: currentProjectDocument.recordingFileName,
+                recordingRevision: source.revision,
+                status: status,
+                runtimeBudgetMinutes: runtimeBudgetMinutes,
+                qaReport: plannedRun.qaReport,
+                artifacts: AgentArtifactStore.references,
+                cutPlan: plannedRun.cutPlan,
+                baseTimeline: session.baseTimeline,
+                requiresDestructiveConfirmation: session.requiresDestructiveConfirmation,
+                createdAt: now,
+                updatedAt: now
+            )
+            let summary = try agentArtifactStore.write(
+                plannedRun: plannedRun,
+                summary: summaryCandidate,
+                projectURL: projectURL
+            )
+            agentRuns = [jobId: EngineAgentRunRecord(summary: summary)]
+            agentRecoveryFailureJobId = nil
+            latestAgentJobId = jobId
+            latestAgentUpdatedAt = isoString(now)
+            var document = currentProjectDocument
+            document.project.agentAnalysis = AgentAnalysisMetadata(
+                latestRunID: jobId,
+                latestAppliedRunID: document.project.agentAnalysis?.latestAppliedRunID,
+                latestRunSummaryPath: "analysis/\(ProjectFile.runSummaryV1JSON)"
+            )
+            do {
+                currentProjectDocument = try projectStore.writeProject(
+                    document: document,
+                    assets: .init(),
+                    to: projectURL
+                )
+            } catch {
+                // The atomic run summary is canonical and remains recoverable even if this
+                // denormalized project.json pointer cannot be refreshed.
+                currentProjectDocument = document
+            }
+            return .ok(.init(body: .json(.init(
+                jobId: .init(value1: jobId),
+                status: plannedRun.qaReport.passed ? .completed : .blocked
+            ))))
+        } catch AgentArtifactError.projectMismatch {
+            return .conflict(.init(body: .json(conflict(
+                .project_mismatch,
+                "The project or recording changed while Agent Mode was running."
+            ))))
+        } catch AgentArtifactError.invalidTranscript {
+            return .badRequest(.init(body: .json(badRequest(
+                .invalid_params,
+                "The imported transcript is invalid."
+            ))))
+        } catch AgentArtifactError.invalidCutPlan,
+            AgentArtifactError.invalidRunSummary,
+            AgentArtifactError.unsafeArtifactPath
+        {
+            return .unprocessableContent(.init(body: .json(unprocessable(
+                .invalid_cut_plan,
+                "Agent Mode could not commit a safe, valid artifact generation."
+            ))))
+        } catch {
+            return .badRequest(.init(body: .json(badRequest(.invalid_request, error.localizedDescription))))
+        }
     }
 
     func agent_period_agentStatus(
         _ input: Operations.agent_period_agentStatus.Input
     ) async throws -> Operations.agent_period_agentStatus.Output {
-        guard let run = agentRuns[input.path.jobId.value1] else {
-            return .badRequest(.init(body: .json(badRequest(.invalid_params, "Unknown jobId: \(input.path.jobId.value1)"))))
+        do {
+            let run = try await resolvedAgentRun(jobId: input.path.jobId.value1)
+            return .ok(.init(body: .json(agentRunSummary(run.summary))))
+        } catch AgentRunResolutionError.notFound {
+            return .notFound(.init(body: .json(notFound("Unknown Agent Mode job."))))
+        } catch AgentRunResolutionError.projectMismatch {
+            return .conflict(.init(body: .json(conflict(
+                .project_mismatch,
+                "Agent Mode job does not match the active project or recording."
+            ))))
+        } catch {
+            return .unprocessableContent(.init(body: .json(unprocessable(
+                .invalid_cut_plan,
+                "Agent Mode artifacts are missing, unsafe, or invalid."
+            ))))
         }
-        return .ok(.init(body: .json(summary(for: run))))
     }
 
     func agent_period_agentApply(
         _ input: Operations.agent_period_agentApply.Input
     ) async throws -> Operations.agent_period_agentApply.Output {
         let payload: Components.Schemas.AgentApplyPayload = switch input.body { case let .json(body): body }
-        guard let run = agentRuns[input.path.jobId.value1] else {
-            return .badRequest(.init(body: .json(badRequest(.invalid_params, "Unknown jobId: \(input.path.jobId.value1)"))))
-        }
-        guard run.qaReport.passed else {
-            return .badRequest(.init(body: .json(badRequest(.invalid_request, "Narrative QA failed. Apply is blocked."))))
-        }
-        guard !hasUnsavedProjectChanges || payload.destructiveIntent == true else {
-            return .badRequest(.init(body: .json(badRequest(
-                .invalid_request,
-                "Unsaved project changes detected. Retry with destructiveIntent=true to continue."
+        let jobId = input.path.jobId.value1
+        let run: EngineAgentRunRecord
+        do {
+            run = try await resolvedAgentRun(jobId: jobId)
+        } catch AgentRunResolutionError.notFound {
+            return .notFound(.init(body: .json(notFound("Unknown Agent Mode job."))))
+        } catch AgentRunResolutionError.projectMismatch {
+            return .conflict(.init(body: .json(conflict(
+                .project_mismatch,
+                "Agent Mode job does not match the active project or recording."
+            ))))
+        } catch {
+            return .unprocessableContent(.init(body: .json(unprocessable(
+                .invalid_cut_plan,
+                "Agent Mode artifacts are missing, unsafe, or invalid."
             ))))
         }
-        if currentProjectDocument.project.timeline.items.isEmpty {
-            currentProjectDocument.project.timeline = TimelineDocument.singleSegment(
-                recordingDuration: max(captureEngine.recordingDuration, 0)
-            )
+        guard run.summary.qaReport.passed else {
+            return .unprocessableContent(.init(body: .json(unprocessable(.qa_failed, "Narrative QA failed. Apply is blocked."))))
         }
+        let timeline: TimelineDocument
+        do {
+            timeline = try run.summary.cutPlan.timeline()
+        } catch {
+            return .unprocessableContent(.init(body: .json(unprocessable(.invalid_cut_plan, "Cut plan is missing or invalid."))))
+        }
+        let timelineChanged = currentProjectDocument.project.timeline != run.summary.baseTimeline
+        if run.summary.requiresDestructiveConfirmation || timelineChanged, payload.destructiveIntent != true {
+            return .conflict(.init(body: .json(conflict(.needs_confirmation, "The working timeline changed or had unsaved edits. Retry with destructiveIntent=true to apply."))))
+        }
+
+        // Apply is explicitly a working-copy mutation. Project persistence remains the save operation.
+        currentProjectDocument.project.timeline = timeline
         var metadata = currentProjectDocument.project.agentAnalysis ?? AgentAnalysisMetadata()
-        metadata.latestRunID = run.jobId
-        metadata.latestAppliedRunID = run.jobId
+        metadata.latestRunID = jobId
+        metadata.latestAppliedRunID = jobId
+        metadata.latestRunSummaryPath = "analysis/\(ProjectFile.runSummaryV1JSON)"
         currentProjectDocument.project.agentAnalysis = metadata
         hasUnsavedProjectChanges = true
-        return .ok(.init(body: .json(actionResult(true, message: "Applied cut plan to working timeline."))))
+        agentRuns[jobId] = run
+        return .ok(.init(body: .json(.init(
+            success: true,
+            message: .init(value1: "Applied the verified cut plan to the working timeline."),
+            jobId: .init(value1: jobId),
+            status: .applied,
+            appliedSegments: .init(value1: Double(timeline.items.count)),
+            projectHasUnsavedChanges: true
+        ))))
     }
 
-    private struct AgentPreflightEvaluation {
-        let ready: Bool
-        let blockingReasons: [Components.Schemas.AgentPreflightResult.blockingReasonsPayloadPayload]
-        let runtimeBudgetMinutes: Int
-        let transcriptionProvider: String
-        let importedTranscriptPath: String?
+    enum AgentRunResolutionError: Error {
+        case notFound
+        case projectMismatch
+        case invalidArtifacts
     }
 
-    private struct AgentCoverage {
-        let hook: Bool
-        let action: Bool
-        let payoff: Bool
-        let takeaway: Bool
-
-        var passed: Bool {
-            hook && action && payoff && takeaway
+    func resolvedAgentRun(jobId: String) async throws -> EngineAgentRunRecord {
+        guard let projectURL = currentProjectURL else {
+            throw AgentRunResolutionError.projectMismatch
         }
+        let summary: AgentRunSummaryArtifact
+        do {
+            guard let loaded = try agentArtifactStore.loadLatest(
+                projectURL: projectURL,
+                projectId: currentProjectDocument.project.id
+            ) else { throw AgentRunResolutionError.notFound }
+            summary = loaded
+        } catch let error as AgentRunResolutionError {
+            throw error
+        } catch {
+            throw AgentRunResolutionError.invalidArtifacts
+        }
+        guard summary.jobId == jobId else { throw AgentRunResolutionError.notFound }
+        let projectId = currentProjectDocument.project.id
+        let recordingFileName = currentProjectDocument.recordingFileName
+        guard let recordingURL = availableAgentRecordingURL(),
+              summary.recordingFileName == recordingFileName,
+              let source = try? await agentSource(recordingURL: recordingURL),
+              source.revision == summary.recordingRevision,
+              currentProjectURL?.path == projectURL.path,
+              currentProjectDocument.project.id == projectId,
+              currentProjectDocument.recordingFileName == recordingFileName,
+              availableAgentRecordingURL()?.path == recordingURL.path
+        else { throw AgentRunResolutionError.projectMismatch }
+        let run = EngineAgentRunRecord(summary: summary)
+        agentRuns = [jobId: run]
+        latestAgentJobId = jobId
+        latestAgentUpdatedAt = isoString(summary.updatedAt)
+        return run
     }
 
-    private func evaluateAgentPreflight(
-        runtimeBudgetMinutes: Int,
-        transcriptionProvider: String,
-        importedTranscriptPath: String?
-    ) -> AgentPreflightEvaluation {
-        var reasons: [Components.Schemas.AgentPreflightResult.blockingReasonsPayloadPayload] = []
-        if !(1 ... 10).contains(runtimeBudgetMinutes) {
-            reasons.append(.invalid_runtime_budget)
-        }
-        if currentProjectURL == nil {
-            reasons.append(.missing_project)
-        }
-        if availableAgentRecordingURL() == nil {
-            reasons.append(.missing_recording)
-        }
-        switch transcriptionProvider {
-        case "imported_transcript":
-            if importedTranscriptPath?.isEmpty ?? true {
-                reasons.append(.missing_imported_transcript)
-            } else if !importedTranscriptIsValid(importedTranscriptPath!) {
-                reasons.append(.invalid_imported_transcript)
+    func restoreAgentRunIfAvailable() async {
+        agentRuns.removeAll()
+        agentRecoveryFailureJobId = nil
+        latestAgentJobId = nil
+        latestAgentUpdatedAt = nil
+        guard let projectURL = currentProjectURL else { return }
+        do {
+            guard let summary = try agentArtifactStore.loadLatest(
+                projectURL: projectURL,
+                projectId: currentProjectDocument.project.id
+            ) else { return }
+            guard let recordingURL = availableAgentRecordingURL() else {
+                throw AgentRunResolutionError.projectMismatch
             }
-        default:
-            reasons.append(.missing_local_model)
+            let source = try await agentSource(recordingURL: recordingURL)
+            guard source.revision == summary.recordingRevision else {
+                throw AgentRunResolutionError.projectMismatch
+            }
+            agentRuns[summary.jobId] = EngineAgentRunRecord(summary: summary)
+            latestAgentJobId = summary.jobId
+            latestAgentUpdatedAt = isoString(summary.updatedAt)
+        } catch {
+            agentRecoveryFailureJobId = currentProjectDocument.project.agentAnalysis?.latestRunID
+            latestAgentUpdatedAt = isoNow()
         }
-        return .init(
-            ready: reasons.isEmpty,
-            blockingReasons: reasons,
-            runtimeBudgetMinutes: runtimeBudgetMinutes,
-            transcriptionProvider: transcriptionProvider == "imported_transcript" ? transcriptionProvider : "none",
-            importedTranscriptPath: importedTranscriptPath
+    }
+
+    struct AgentProjectContext {
+        let projectId: UUID
+        let projectPath: String
+        let recordingPath: String
+    }
+
+    struct AgentSource {
+        let duration: Double
+        let fps: AgentFrameRate
+        let revision: String
+    }
+
+    func agentProjectContext(recordingURL: URL) -> AgentProjectContext? {
+        guard let projectPath = currentProjectURL?.path else { return nil }
+        return AgentProjectContext(
+            projectId: currentProjectDocument.project.id,
+            projectPath: projectPath,
+            recordingPath: recordingURL.path
         )
+    }
+
+    func matchesAgentProjectContext(_ context: AgentProjectContext) -> Bool {
+        currentProjectDocument.project.id == context.projectId &&
+            currentProjectURL?.path == context.projectPath &&
+            availableAgentRecordingURL()?.path == context.recordingPath
+    }
+
+    func agentSource(recordingURL: URL) async throws -> AgentSource {
+        let asset = AVAsset(url: recordingURL)
+        let durationTime = try await asset.load(.duration)
+        let duration = durationTime.seconds
+        guard duration.isFinite, duration > 0 else { throw AgentArtifactError.invalidCutPlan }
+        let tracks = try await asset.loadTracks(withMediaType: .video)
+        guard let track = tracks.first else { throw AgentArtifactError.invalidCutPlan }
+        let minimumFrameDuration = try await track.load(.minFrameDuration)
+        let fps: AgentFrameRate
+        if minimumFrameDuration.isValid,
+           minimumFrameDuration.value > 0,
+           minimumFrameDuration.timescale > 0
+        {
+            fps = AgentFrameRate(
+                numerator: Int(minimumFrameDuration.timescale),
+                denominator: Int(minimumFrameDuration.value)
+            )
+        } else {
+            let nominalFrameRate = try await track.load(.nominalFrameRate)
+            fps = rationalFrameRate(from: Double(nominalFrameRate))
+        }
+        let attributes = try FileManager.default.attributesOfItem(atPath: recordingURL.path)
+        let fileSize = (attributes[.size] as? NSNumber)?.uint64Value ?? 0
+        let descriptor = [
+            String(fileSize),
+            String(durationTime.value),
+            String(durationTime.timescale),
+            String(fps.numerator),
+            String(fps.denominator),
+        ].joined(separator: ":")
+        let revision = try recordingRevision(
+            recordingURL: recordingURL,
+            fileSize: fileSize,
+            descriptor: descriptor
+        )
+        return AgentSource(duration: duration, fps: fps, revision: revision)
+    }
+
+    private func rationalFrameRate(from nominal: Double) -> AgentFrameRate {
+        let ntscRates: [(value: Double, numerator: Int)] = [
+            (23.976, 24000),
+            (29.97, 30000),
+            (59.94, 60000),
+            (119.88, 120_000),
+        ]
+        if let match = ntscRates.first(where: { abs($0.value - nominal) < 0.02 }) {
+            return AgentFrameRate(numerator: match.numerator, denominator: 1001)
+        }
+        let denominator = 1000
+        let numerator = max(1, Int((nominal * Double(denominator)).rounded()))
+        let divisor = greatestCommonDivisor(numerator, denominator)
+        return AgentFrameRate(numerator: numerator / divisor, denominator: denominator / divisor)
+    }
+
+    private func greatestCommonDivisor(_ left: Int, _ right: Int) -> Int {
+        var firstValue = abs(left)
+        var secondValue = abs(right)
+        while secondValue != 0 {
+            (firstValue, secondValue) = (secondValue, firstValue % secondValue)
+        }
+        return max(1, firstValue)
+    }
+
+    private func recordingRevision(
+        recordingURL: URL,
+        fileSize: UInt64,
+        descriptor: String
+    ) throws -> String {
+        var pathMetadata = stat()
+        guard recordingURL.path.withCString({ Darwin.lstat($0, &pathMetadata) }) == 0,
+              pathMetadata.st_mode & S_IFMT == S_IFREG,
+              UInt64(pathMetadata.st_size) == fileSize
+        else { throw AgentArtifactError.projectMismatch }
+        let descriptorHandle = recordingURL.path.withCString { Darwin.open($0, O_RDONLY | O_NOFOLLOW) }
+        guard descriptorHandle >= 0 else { throw AgentArtifactError.projectMismatch }
+        let handle = FileHandle(fileDescriptor: descriptorHandle, closeOnDealloc: true)
+        var openedMetadata = stat()
+        guard Darwin.fstat(descriptorHandle, &openedMetadata) == 0,
+              openedMetadata.st_dev == pathMetadata.st_dev,
+              openedMetadata.st_ino == pathMetadata.st_ino,
+              openedMetadata.st_size == pathMetadata.st_size
+        else { throw AgentArtifactError.projectMismatch }
+
+        var hasher = SHA256()
+        hasher.update(data: Data(descriptor.utf8))
+        while let chunk = try handle.read(upToCount: 4 * 1024 * 1024), !chunk.isEmpty {
+            hasher.update(data: chunk)
+        }
+        var completedMetadata = stat()
+        guard Darwin.fstat(descriptorHandle, &completedMetadata) == 0,
+              completedMetadata.st_size == openedMetadata.st_size,
+              completedMetadata.st_mtimespec.tv_sec == openedMetadata.st_mtimespec.tv_sec,
+              completedMetadata.st_mtimespec.tv_nsec == openedMetadata.st_mtimespec.tv_nsec
+        else { throw AgentArtifactError.projectMismatch }
+        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private func preflightResult(
+        reasons: [String],
+        provider: String,
+        token: String?,
+        expiresAt: Date?
+    ) -> Components.Schemas.AgentPreflightResult {
+        if reasons.isEmpty, let token, let expiresAt {
+            return .init(value1: .init(
+                ready: true,
+                blockingReasons: .init(value1: .init(), value2: .init()),
+                canApplyDestructive: hasUnsavedProjectChanges,
+                transcriptionProvider: .init(rawValue: provider) ?? .none,
+                preflightToken: .init(value1: token),
+                preflightTokenExpiresAt: .init(value1: isoString(expiresAt))
+            ))
+        }
+        return .init(value2: .init(
+            ready: false,
+            blockingReasons: reasons.compactMap {
+                Components.Schemas.AgentPreflightBlockedResult.blockingReasonsPayloadPayload(
+                    rawValue: $0
+                )
+            },
+            canApplyDestructive: hasUnsavedProjectChanges,
+            transcriptionProvider: .init(rawValue: provider) ?? .none
+        ))
+    }
+
+    private enum PreflightTokenValidationError: Error {
+        case expired
+        case mismatch
     }
 
     private func validatePreflightToken(
@@ -204,54 +549,125 @@ extension EngineService {
         runtimeBudgetMinutes: Int,
         transcriptionProvider: String,
         importedTranscriptPath: String?
-    ) -> Bool {
-        guard let session = preflightSessions.removeValue(forKey: token) else { return false }
-        guard Date().timeIntervalSince(session.createdAt) <= agentPreflightTTLSeconds else { return false }
-        return session.runtimeBudgetMinutes == runtimeBudgetMinutes &&
-            session.transcriptionProvider == transcriptionProvider &&
-            session.importedTranscriptPath == importedTranscriptPath &&
-            session.projectPath == currentProjectURL?.path &&
-            session.recordingURL == availableAgentRecordingURL()?.path
+    ) throws -> EngineAgentPreflightSession {
+        guard let session = preflightSessions.removeValue(forKey: token),
+              Date().timeIntervalSince(session.createdAt) <= agentPreflightTTLSeconds
+        else { throw PreflightTokenValidationError.expired }
+        guard session.runtimeBudgetMinutes == runtimeBudgetMinutes,
+              session.transcriptionProvider == transcriptionProvider,
+              session.importedTranscriptPath == importedTranscriptPath,
+              session.projectId == currentProjectDocument.project.id,
+              session.projectPath == currentProjectURL?.path,
+              session.recordingURL == availableAgentRecordingURL()?.path
+        else { throw PreflightTokenValidationError.mismatch }
+        return session
     }
 
-    private func buildAgentRun(
-        jobId: String,
-        runtimeBudgetMinutes: Int,
-        coverage: AgentCoverage,
-        blockingReason: Components.Schemas.AgentRunSummary.blockingReasonPayload?
-    ) -> EngineAgentRunRecord {
-        let missingBeats = missingBeats(for: coverage)
-        let score = Double(4 - missingBeats.count) / 4
-        let report = Components.Schemas.AgentQAReport(
-            passed: missingBeats.isEmpty,
-            score: .init(value1: .init(value1: score)),
-            coverage: .init(
-                hook: coverage.hook,
-                action: coverage.action,
-                payoff: coverage.payoff,
-                takeaway: coverage.takeaway
-            ),
-            missingBeats: missingBeats
-        )
-        return EngineAgentRunRecord(
-            jobId: jobId,
-            status: report.passed ? .completed : .blocked,
-            runtimeBudgetMinutes: runtimeBudgetMinutes,
-            qaReport: report,
-            blockingReason: report.passed ? nil : blockingReason,
-            updatedAt: isoNow()
-        )
+    private func readAgentTranscript(path: String) throws -> Data {
+        let maximumBytes: Int64 = 10 * 1024 * 1024
+        let descriptor = try openAgentReadOnlyFile(path: path)
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        var openedMetadata = stat()
+        guard Darwin.fstat(descriptor, &openedMetadata) == 0,
+              openedMetadata.st_mode & S_IFMT == S_IFREG,
+              openedMetadata.st_size >= 0,
+              openedMetadata.st_size <= maximumBytes
+        else { throw AgentArtifactError.invalidTranscript }
+        let expectedSize = Int(openedMetadata.st_size)
+        let data = try handle.read(upToCount: expectedSize + 1) ?? Data()
+        var completedMetadata = stat()
+        guard data.count == expectedSize,
+              Darwin.fstat(descriptor, &completedMetadata) == 0,
+              completedMetadata.st_size == openedMetadata.st_size,
+              completedMetadata.st_mtimespec.tv_sec == openedMetadata.st_mtimespec.tv_sec,
+              completedMetadata.st_mtimespec.tv_nsec == openedMetadata.st_mtimespec.tv_nsec
+        else { throw AgentArtifactError.invalidTranscript }
+        return data
     }
 
-    private func summary(for run: EngineAgentRunRecord) -> Components.Schemas.AgentRunSummary {
-        .init(
-            jobId: .init(value1: run.jobId),
-            status: run.status,
-            runtimeBudgetMinutes: .init(value1: Double(run.runtimeBudgetMinutes)),
-            qaReport: run.qaReport,
-            blockingReason: run.blockingReason,
-            updatedAt: .init(value1: run.updatedAt)
-        )
+    private func openAgentReadOnlyFile(path: String) throws -> Int32 {
+        guard path.hasPrefix("/") else { throw AgentArtifactError.invalidTranscript }
+        let components = path.split(separator: "/").map(String.init)
+        guard let fileName = components.last else { throw AgentArtifactError.invalidTranscript }
+        var directoryFD = Darwin.open("/", O_RDONLY | O_DIRECTORY)
+        guard directoryFD >= 0 else { throw AgentArtifactError.invalidTranscript }
+        for component in components.dropLast() {
+            let nextFD = component.withCString {
+                Darwin.openat(directoryFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+            }
+            Darwin.close(directoryFD)
+            guard nextFD >= 0 else { throw AgentArtifactError.invalidTranscript }
+            directoryFD = nextFD
+        }
+        let descriptor = fileName.withCString {
+            Darwin.openat(directoryFD, $0, O_RDONLY | O_NOFOLLOW)
+        }
+        Darwin.close(directoryFD)
+        guard descriptor >= 0 else { throw AgentArtifactError.invalidTranscript }
+        return descriptor
+    }
+
+    func makeAgentRecordingSnapshot(
+        recordingURL: URL,
+        expectedRevision: String
+    ) async throws -> URL {
+        let sourceFD = try openAgentReadOnlyFile(path: recordingURL.path)
+        defer { Darwin.close(sourceFD) }
+        var metadata = stat()
+        guard Darwin.fstat(sourceFD, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFREG
+        else { throw AgentArtifactError.projectMismatch }
+
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("guerillaglass-agent-source-\(UUID().uuidString)", isDirectory: true)
+        guard directoryURL.path.withCString({ Darwin.mkdir($0, 0o700) }) == 0 else {
+            throw AgentArtifactError.projectMismatch
+        }
+        let snapshotURL = directoryURL.appendingPathComponent("recording.mov")
+        let destinationFD = snapshotURL.path.withCString {
+            Darwin.open($0, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        }
+        guard destinationFD >= 0 else {
+            try? FileManager.default.removeItem(at: directoryURL)
+            throw AgentArtifactError.projectMismatch
+        }
+        var destinationIsOpen = true
+        do {
+            var buffer = [UInt8](repeating: 0, count: 4 * 1024 * 1024)
+            while true {
+                let count = buffer.withUnsafeMutableBytes {
+                    Darwin.read(sourceFD, $0.baseAddress, $0.count)
+                }
+                guard count >= 0 else { throw AgentArtifactError.projectMismatch }
+                if count == 0 {
+                    break
+                }
+                var offset = 0
+                while offset < count {
+                    let written = buffer.withUnsafeBytes {
+                        Darwin.write(destinationFD, $0.baseAddress?.advanced(by: offset), count - offset)
+                    }
+                    guard written > 0 else { throw AgentArtifactError.projectMismatch }
+                    offset += written
+                }
+            }
+            guard Darwin.fsync(destinationFD) == 0 else {
+                throw AgentArtifactError.projectMismatch
+            }
+            Darwin.close(destinationFD)
+            destinationIsOpen = false
+            let snapshotSource = try await agentSource(recordingURL: snapshotURL)
+            guard snapshotSource.revision == expectedRevision else {
+                throw AgentArtifactError.projectMismatch
+            }
+            return snapshotURL
+        } catch {
+            if destinationIsOpen {
+                Darwin.close(destinationFD)
+            }
+            try? FileManager.default.removeItem(at: directoryURL)
+            throw error
+        }
     }
 
     private func availableAgentRecordingURL() -> URL? {
@@ -261,55 +677,95 @@ extension EngineService {
         return captureEngine.recordingURL
     }
 
-    private func importedTranscriptIsValid(_ path: String) -> Bool {
-        normalizedTranscriptTokens(path: path) != nil
+    private func isoString(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter.string(from: date)
     }
 
-    private func coverageForAgentRun(transcriptionProvider: String, importedTranscriptPath: String?) -> AgentCoverage {
-        if transcriptionProvider == "imported_transcript", let importedTranscriptPath,
-           let tokens = normalizedTranscriptTokens(path: importedTranscriptPath)
-        {
-            return AgentCoverage(
-                hook: tokens.contains("hook") || tokens.contains("intro") || tokens.contains("opening"),
-                action: tokens.contains("action") || tokens.contains("step") || tokens.contains("steps") || tokens.contains("process"),
-                payoff: tokens.contains("payoff") || tokens.contains("result") || tokens.contains("outcome"),
-                takeaway: tokens.contains("takeaway") || tokens.contains("lesson") || tokens.contains("conclusion")
-            )
-        }
-        let duration = captureEngine.recordingDuration
-        return AgentCoverage(hook: true, action: duration >= 15, payoff: duration >= 30, takeaway: duration >= 45)
+    private func agentRunSummary(_ summary: AgentRunSummaryArtifact) -> Components.Schemas.AgentRunSummary {
+        .init(
+            jobId: .init(value1: summary.jobId),
+            status: .init(rawValue: summary.status.rawValue) ?? .failed,
+            runtimeBudgetMinutes: .init(value1: Double(summary.runtimeBudgetMinutes)),
+            qaReport: agentQAReport(summary.qaReport),
+            blockingReason: summary.qaReport.passed ? nil : .weak_narrative_structure,
+            artifacts: summary.artifacts.compactMap(agentArtifactReference),
+            cutPlan: summary.qaReport.passed ? agentCutPlan(summary.cutPlan) : nil,
+            updatedAt: .init(value1: isoString(summary.updatedAt))
+        )
     }
 
-    private func normalizedTranscriptTokens(path: String) -> Set<String>? {
-        guard let data = FileManager.default.contents(atPath: path),
-              let transcript = try? JSONDecoder().decode(ImportedTranscript.self, from: data) else { return nil }
-        let segmentText = (transcript.segments ?? [])
-            .filter { !$0.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && $0.startSeconds >= 0 && $0.endSeconds > $0.startSeconds }
-            .map(\.text)
-        let wordText = (transcript.words ?? [])
-            .filter { !$0.word.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && $0.startSeconds >= 0 && $0.endSeconds > $0.startSeconds }
-            .map(\.word)
-        let text = (segmentText + wordText).joined(separator: " ").lowercased()
-        let tokens = Set(text.split { !$0.isLetter && !$0.isNumber }.map(String.init))
-        return tokens.isEmpty ? nil : tokens
+    private func agentQAReport(_ report: AgentQAReport) -> Components.Schemas.AgentQAReport {
+        .init(
+            passed: report.passed,
+            score: .init(value1: report.score),
+            coverage: .init(
+                hook: report.coverage.hook,
+                action: report.coverage.action,
+                payoff: report.coverage.payoff,
+                takeaway: report.coverage.takeaway
+            ),
+            missingBeats: report.missingBeats.compactMap {
+                Components.Schemas.AgentQAReport.missingBeatsPayloadPayload(rawValue: $0)
+            }
+        )
     }
 
-    private func missingBeats(
-        for coverage: AgentCoverage
-    ) -> [Components.Schemas.AgentQAReport.missingBeatsPayloadPayload] {
-        var missing: [Components.Schemas.AgentQAReport.missingBeatsPayloadPayload] = []
-        if !coverage.hook {
-            missing.append(.hook)
+    private func agentArtifactReference(
+        _ reference: AgentArtifactReference
+    ) -> Components.Schemas.AgentArtifactReference? {
+        let kind = reference.kind.rawValue
+        let path = reference.path
+        switch reference.kind {
+        case .transcriptFullV1:
+            return .init(value1: .init(
+                kind: .init(rawValue: kind)!, path: .init(rawValue: path)!,
+                sha256: reference.sha256.map { .init(value1: $0) }
+            ))
+        case .transcriptWordsV1:
+            return .init(value2: .init(
+                kind: .init(rawValue: kind)!, path: .init(rawValue: path)!,
+                sha256: reference.sha256.map { .init(value1: $0) }
+            ))
+        case .beatMapV1:
+            return .init(value3: .init(
+                kind: .init(rawValue: kind)!, path: .init(rawValue: path)!,
+                sha256: reference.sha256.map { .init(value1: $0) }
+            ))
+        case .qaReportV1:
+            return .init(value4: .init(
+                kind: .init(rawValue: kind)!, path: .init(rawValue: path)!,
+                sha256: reference.sha256.map { .init(value1: $0) }
+            ))
+        case .cutPlanV1:
+            return .init(value5: .init(
+                kind: .init(rawValue: kind)!, path: .init(rawValue: path)!,
+                sha256: reference.sha256.map { .init(value1: $0) }
+            ))
+        case .runSummaryV1:
+            return .init(value6: .init(
+                kind: .init(rawValue: kind)!, path: .init(rawValue: path)!
+            ))
         }
-        if !coverage.action {
-            missing.append(.action)
-        }
-        if !coverage.payoff {
-            missing.append(.payoff)
-        }
-        if !coverage.takeaway {
-            missing.append(.takeaway)
-        }
-        return missing
+    }
+
+    private func agentCutPlan(_ cutPlan: AgentCutPlanArtifact) -> Components.Schemas.AgentCutPlanSummary {
+        .init(
+            version: 1,
+            sourceFps: .init(
+                numerator: .init(value1: Double(cutPlan.sourceFps.numerator)),
+                denominator: .init(value1: Double(cutPlan.sourceFps.denominator))
+            ),
+            sourceFrameCount: .init(value1: Double(cutPlan.sourceFrameCount)),
+            segments: cutPlan.segments.map { segment in
+                .init(
+                    id: .init(value1: segment.id),
+                    beat: .init(rawValue: segment.beat.rawValue) ?? .hook,
+                    startFrame: .init(value1: Double(segment.startFrame)),
+                    endFrame: .init(value1: Double(segment.endFrame))
+                )
+            }
+        )
     }
 }

--- a/engines/macos-swift/EngineService+Export.swift
+++ b/engines/macos-swift/EngineService+Export.swift
@@ -82,20 +82,73 @@ extension EngineService {
         guard let preset = Presets.all.first(where: { $0.id == payload.presetId.value1 }) else {
             return .badRequest(.init(body: .json(badRequest(.invalid_params, "Unknown export preset."))))
         }
-        guard let recordingURL = availableRecordingURL() else {
+        guard let recordingURL = availableRecordingURL(),
+              let projectContext = agentProjectContext(recordingURL: recordingURL)
+        else {
             return .badRequest(.init(body: .json(badRequest(.invalid_request, "No recording is available to export."))))
         }
+        let run: EngineAgentRunRecord
         do {
-            let exportedURL = try await exportPipeline.export(
+            run = try await resolvedAgentRun(jobId: payload.jobId.value1)
+        } catch AgentRunResolutionError.notFound {
+            return .notFound(.init(body: .json(notFound("Unknown Agent Mode job."))))
+        } catch AgentRunResolutionError.projectMismatch {
+            return .conflict(.init(body: .json(conflict(
+                .project_mismatch,
+                "Agent Mode job does not match the active project or recording."
+            ))))
+        } catch {
+            return .unprocessableContent(.init(body: .json(unprocessable(
+                .invalid_cut_plan,
+                "Agent Mode artifacts are missing, unsafe, or invalid."
+            ))))
+        }
+        guard matchesAgentProjectContext(projectContext) else {
+            return .conflict(.init(body: .json(conflict(
+                .project_mismatch,
+                "The active project changed while resolving the Agent Mode run."
+            ))))
+        }
+        guard run.summary.qaReport.passed else {
+            return .unprocessableContent(.init(body: .json(unprocessable(
+                .qa_failed,
+                "Narrative QA failed. Cut-plan export is blocked."
+            ))))
+        }
+        do {
+            let snapshotURL = try await makeAgentRecordingSnapshot(
                 recordingURL: recordingURL,
+                expectedRevision: run.summary.recordingRevision
+            )
+            defer { try? FileManager.default.removeItem(at: snapshotURL.deletingLastPathComponent()) }
+            guard matchesAgentProjectContext(projectContext) else {
+                return .conflict(.init(body: .json(conflict(
+                    .project_mismatch,
+                    "The active project changed while snapshotting the recording."
+                ))))
+            }
+            let autoZoom = currentProjectDocument.project.autoZoom
+            let captureMetadata = currentProjectDocument.project.captureMetadata
+            let backgroundFraming = currentProjectDocument.project.backgroundFraming
+            let cameraEvents = try availableCameraEvents(for: autoZoom)
+            let timeline = try run.summary.cutPlan.timeline()
+            let exportedURL = try await exportPipeline.export(
+                recordingURL: snapshotURL,
                 preset: preset,
                 trimRange: nil,
                 outputURL: URL(fileURLWithPath: payload.outputURL.value1),
-                cameraEvents: availableCameraEvents(for: currentProjectDocument.project.autoZoom),
-                autoZoomSettings: currentProjectDocument.project.autoZoom,
-                captureMetadata: currentProjectDocument.project.captureMetadata,
-                backgroundFraming: currentProjectDocument.project.backgroundFraming
+                cameraEvents: cameraEvents,
+                autoZoomSettings: autoZoom,
+                captureMetadata: captureMetadata,
+                timeline: exportTimeline(from: timeline),
+                backgroundFraming: backgroundFraming
             )
+            guard matchesAgentProjectContext(projectContext) else {
+                return .conflict(.init(body: .json(conflict(
+                    .project_mismatch,
+                    "The active project changed while exporting the cut plan."
+                ))))
+            }
             let jobId = "macos-export-cut-plan-\(UUID().uuidString)"
             latestExportJobId = jobId
             latestExportOutputURL = exportedURL
@@ -104,10 +157,17 @@ extension EngineService {
                 jobId: .init(value1: jobId),
                 status: .succeeded,
                 outputURL: .init(value1: exportedURL.path),
-                appliedSegments: .init(value1: Double(currentProjectDocument.project.timeline.items.count))
+                appliedSegments: .init(value1: Double(timeline.items.count))
             ))))
         } catch is CancellationError {
             throw CancellationError()
+        } catch AgentArtifactError.invalidCutPlan {
+            return .unprocessableContent(.init(body: .json(unprocessable(.invalid_cut_plan, "Cut plan is missing or invalid."))))
+        } catch AgentArtifactError.projectMismatch {
+            return .conflict(.init(body: .json(conflict(
+                .project_mismatch,
+                "The recording changed before a stable export snapshot could be created."
+            ))))
         } catch {
             return .badRequest(.init(body: .json(badRequest(.invalid_request, error.localizedDescription))))
         }
@@ -144,6 +204,25 @@ extension EngineService {
         return CMTimeRange(
             start: CMTime(seconds: start, preferredTimescale: 600),
             duration: CMTime(seconds: end - start, preferredTimescale: 600)
+        )
+    }
+
+    private func exportTimeline(from timeline: TimelineDocument) -> ExportTimelineDocument? {
+        guard !timeline.items.isEmpty else { return nil }
+        return ExportTimelineDocument(
+            version: timeline.version,
+            items: timeline.items.map { item in
+                switch item {
+                case let .clip(clip):
+                    .clip(ExportTimelineClip(
+                        id: clip.id,
+                        sourceStartSeconds: clip.sourceStartSeconds,
+                        sourceEndSeconds: clip.sourceEndSeconds
+                    ))
+                case let .gap(gap):
+                    .gap(ExportTimelineGap(id: gap.id, durationSeconds: gap.durationSeconds))
+                }
+            }
         )
     }
 

--- a/engines/macos-swift/EngineService+GeneratedHelpers.swift
+++ b/engines/macos-swift/EngineService+GeneratedHelpers.swift
@@ -11,6 +11,24 @@ extension EngineService {
         .init(success: success, message: message)
     }
 
+    func notFound(_ message: String) -> Components.Schemas.EngineNotFoundError {
+        .init(code: .init(value1: .not_found), message: .init(value1: message))
+    }
+
+    func conflict(
+        _ code: Components.Schemas.EngineConflictError.codePayload,
+        _ message: String
+    ) -> Components.Schemas.EngineConflictError {
+        .init(code: code, message: .init(value1: message))
+    }
+
+    func unprocessable(
+        _ code: Components.Schemas.EngineUnprocessableError.codePayload,
+        _ message: String
+    ) -> Components.Schemas.EngineUnprocessableError {
+        .init(code: code, message: .init(value1: message))
+    }
+
     func isoNow() -> String {
         ISO8601DateFormatter().string(from: Date())
     }
@@ -125,12 +143,22 @@ extension EngineService {
     }
 
     func agentAnalysisState() -> Components.Schemas.ProjectAgentAnalysisSummary? {
+        if let failedJobId = agentRecoveryFailureJobId {
+            return .init(
+                latestJobId: .init(value1: failedJobId),
+                latestStatus: .failed,
+                qaPassed: false,
+                updatedAt: .init(value1: latestAgentUpdatedAt ?? isoNow())
+            )
+        }
         guard let jobId = latestAgentJobId, let run = agentRuns[jobId] else { return nil }
         return .init(
             latestJobId: .init(value1: jobId),
-            latestStatus: Components.Schemas.ProjectAgentAnalysisSummary.latestStatusPayload(rawValue: run.status.rawValue),
-            qaPassed: run.qaReport.passed,
-            updatedAt: .init(value1: run.updatedAt)
+            latestStatus: Components.Schemas.ProjectAgentAnalysisSummary.latestStatusPayload(
+                rawValue: run.summary.status.rawValue
+            ),
+            qaPassed: run.summary.qaReport.passed,
+            updatedAt: .init(value1: latestAgentUpdatedAt ?? isoNow())
         )
     }
 

--- a/engines/macos-swift/EngineService+Project.swift
+++ b/engines/macos-swift/EngineService+Project.swift
@@ -132,7 +132,12 @@ extension EngineService {
                 latestAgentUpdatedAt = nil
             }
             hasUnsavedProjectChanges = false
-            try projectLibraryStore.recordRecentProject(url: projectURL)
+            do {
+                try projectLibraryStore.recordRecentProject(url: projectURL)
+            } catch {
+                // The project save is already committed; a recents-index failure must not
+                // report the save as failed or trigger destructive rollback semantics.
+            }
             return .ok(.init(body: .json(projectState())))
         } catch {
             return .badRequest(.init(body: .json(badRequest(.invalid_request, error.localizedDescription))))

--- a/engines/macos-swift/EngineService+Project.swift
+++ b/engines/macos-swift/EngineService+Project.swift
@@ -14,6 +14,10 @@ extension EngineService {
     ) async throws -> Operations.project_period_projectOpen.Output {
         let payload: Components.Schemas.ProjectOpenPayload = switch input.body { case let .json(body): body }
         let projectURL = URL(fileURLWithPath: payload.projectPath.value1, isDirectory: true)
+        preflightSessions.removeAll()
+        agentRuns.removeAll()
+        latestAgentJobId = nil
+        latestAgentUpdatedAt = nil
         do {
             let openedURL: URL
             let openedDocument: ProjectDocument
@@ -31,6 +35,7 @@ extension EngineService {
             }
             currentProjectURL = openedURL
             currentProjectDocument = openedDocument
+            await restoreAgentRunIfAvailable()
             try projectLibraryStore.recordRecentProject(url: openedURL)
             hasUnsavedProjectChanges = false
             return .ok(.init(body: .json(projectState())))
@@ -50,7 +55,12 @@ extension EngineService {
             return .badRequest(.init(body: .json(badRequest(.invalid_request, "projectPath is required before saving."))))
         }
 
+        let isSaveAs = currentProjectURL?.standardizedFileURL != projectURL.standardizedFileURL
         var document = currentProjectDocument
+        if isSaveAs {
+            // Analysis artifacts are project-bound and are not copied by Save As.
+            document.project.agentAnalysis = AgentAnalysisMetadata()
+        }
         if let autoZoom = payload.autoZoom {
             document.project.autoZoom = projectAutoZoom(from: autoZoom)
         }
@@ -61,7 +71,33 @@ extension EngineService {
                 return .badRequest(.init(body: .json(badRequest(.invalid_params, error.localizedDescription))))
             }
         }
+        if let timeline = payload.timeline {
+            guard Int(timeline.version) == 2 else {
+                return .badRequest(.init(body: .json(badRequest(.invalid_params, "Unsupported timeline version."))))
+            }
+            document.project.timeline = TimelineDocument(
+                items: timeline.items.compactMap { item in
+                    if let clip = item.value1 {
+                        return .clip(TimelineClip(
+                            id: clip.id.value1,
+                            sourceStartSeconds: clip.sourceStartSeconds.value1,
+                            sourceEndSeconds: clip.sourceEndSeconds.value1
+                        ))
+                    }
+                    if let gap = item.value2 {
+                        return .gap(TimelineGap(
+                            id: gap.id.value1,
+                            durationSeconds: gap.durationSeconds.value1
+                        ))
+                    }
+                    return nil
+                }
+            )
+        }
         do {
+            if isSaveAs {
+                try agentArtifactStore.removeLatest(projectURL: projectURL)
+            }
             let savedDocument = try projectStore.writeProject(
                 document: document,
                 assets: .init(
@@ -72,6 +108,12 @@ extension EngineService {
             )
             currentProjectURL = projectURL
             currentProjectDocument = savedDocument
+            if isSaveAs {
+                agentRuns.removeAll()
+                agentRecoveryFailureJobId = nil
+                latestAgentJobId = nil
+                latestAgentUpdatedAt = nil
+            }
             hasUnsavedProjectChanges = false
             try projectLibraryStore.recordRecentProject(url: projectURL)
             return .ok(.init(body: .json(projectState())))

--- a/engines/macos-swift/EngineService+Project.swift
+++ b/engines/macos-swift/EngineService+Project.swift
@@ -95,17 +95,34 @@ extension EngineService {
             )
         }
         do {
-            if isSaveAs {
-                try agentArtifactStore.removeLatest(projectURL: projectURL)
+            let quarantinedAnalysis = isSaveAs
+                ? try agentArtifactStore.quarantineLatest(projectURL: projectURL)
+                : nil
+            let savedDocument: ProjectDocument
+            do {
+                savedDocument = try projectStore.writeProject(
+                    document: document,
+                    assets: .init(
+                        recordingURL: captureEngine.recordingURL,
+                        eventsURL: currentEventsURL
+                    ),
+                    to: projectURL
+                )
+            } catch {
+                if let quarantinedAnalysis {
+                    try agentArtifactStore.restoreQuarantined(
+                        quarantinedAnalysis,
+                        projectURL: projectURL
+                    )
+                }
+                throw error
             }
-            let savedDocument = try projectStore.writeProject(
-                document: document,
-                assets: .init(
-                    recordingURL: captureEngine.recordingURL,
-                    eventsURL: currentEventsURL
-                ),
-                to: projectURL
-            )
+            if let quarantinedAnalysis {
+                agentArtifactStore.discardQuarantined(
+                    quarantinedAnalysis,
+                    projectURL: projectURL
+                )
+            }
             currentProjectURL = projectURL
             currentProjectDocument = savedDocument
             if isSaveAs {

--- a/engines/macos-swift/EngineService+System.swift
+++ b/engines/macos-swift/EngineService+System.swift
@@ -30,7 +30,12 @@ extension EngineService {
                 status: true,
                 apply: true,
                 localOnly: true,
-                runtimeBudgetMinutes: .init(value1: 10)
+                runtimeBudgetMinutes: .init(value1: 10),
+                supportedTranscriptionProviders: [.imported_transcript],
+                maxSourceDurationSeconds: .init(value1: 600),
+                preflightTokenTtlSeconds: .init(value1: 60),
+                artifactVersion: .init(value1: 1),
+                cutPlanVersion: .init(value1: 1)
             )
         ))))
     }

--- a/engines/macos-swift/EngineService.swift
+++ b/engines/macos-swift/EngineService.swift
@@ -10,18 +10,18 @@ struct EngineAgentPreflightSession {
     let runtimeBudgetMinutes: Int
     let transcriptionProvider: String
     let importedTranscriptPath: String?
-    let projectPath: String?
-    let recordingURL: String?
+    let importedTranscriptData: Data
+    let projectId: UUID
+    let projectPath: String
+    let recordingURL: String
+    let recordingRevision: String
+    let baseTimeline: TimelineDocument
+    let requiresDestructiveConfirmation: Bool
     let createdAt: Date
 }
 
 struct EngineAgentRunRecord {
-    let jobId: String
-    let status: Components.Schemas.AgentRunSummary.statusPayload
-    let runtimeBudgetMinutes: Int
-    let qaReport: Components.Schemas.AgentQAReport
-    let blockingReason: Components.Schemas.AgentRunSummary.blockingReasonPayload?
-    let updatedAt: String
+    var summary: AgentRunSummaryArtifact
 }
 
 @MainActor
@@ -30,6 +30,7 @@ final class EngineService: APIProtocol {
     let exportPipeline = ExportPipeline()
     let projectStore = ProjectStore()
     let projectLibraryStore = ProjectLibraryStore()
+    let agentArtifactStore = AgentArtifactStore()
     let inputPermissionManager = InputPermissionManager()
     let inputSession = InputEventSession()
 
@@ -40,6 +41,7 @@ final class EngineService: APIProtocol {
     var hasUnsavedProjectChanges = false
     var latestAgentJobId: String?
     var latestAgentUpdatedAt: String?
+    var agentRecoveryFailureJobId: String?
     var agentRuns: [String: EngineAgentRunRecord] = [:]
     var preflightSessions: [String: EngineAgentPreflightSession] = [:]
     var latestExportJobId: String?

--- a/engines/macos-swift/modules/project/AgentAnalysis.swift
+++ b/engines/macos-swift/modules/project/AgentAnalysis.swift
@@ -24,10 +24,12 @@ public enum AgentArtifactKind: String, Codable, CaseIterable {
 public struct AgentArtifactReference: Codable, Equatable {
     public var kind: AgentArtifactKind
     public var path: String
+    public var sha256: String?
 
-    public init(kind: AgentArtifactKind, path: String) {
+    public init(kind: AgentArtifactKind, path: String, sha256: String? = nil) {
         self.kind = kind
         self.path = path
+        self.sha256 = sha256
     }
 }
 

--- a/engines/macos-swift/modules/project/AgentArtifactStore.swift
+++ b/engines/macos-swift/modules/project/AgentArtifactStore.swift
@@ -1,0 +1,279 @@
+import CryptoKit
+import Darwin
+import Foundation
+
+/// Descriptor-anchored, atomic storage for the latest project-bound Agent Mode run.
+public struct AgentArtifactStore {
+    public static let references: [AgentArtifactReference] = [
+        .init(kind: .transcriptFullV1, path: "analysis/\(ProjectFile.transcriptFullV1JSON)"),
+        .init(kind: .transcriptWordsV1, path: "analysis/\(ProjectFile.transcriptWordsV1JSON)"),
+        .init(kind: .beatMapV1, path: "analysis/\(ProjectFile.beatMapV1JSON)"),
+        .init(kind: .qaReportV1, path: "analysis/\(ProjectFile.qaReportV1JSON)"),
+        .init(kind: .cutPlanV1, path: "analysis/\(ProjectFile.cutPlanV1JSON)"),
+        .init(kind: .runSummaryV1, path: "analysis/\(ProjectFile.runSummaryV1JSON)"),
+    ]
+
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    public init() {
+        encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+    }
+
+    /// Writes a complete generation off to the side and atomically swaps it into `analysis/`.
+    /// A failed write leaves the previous generation intact.
+    @discardableResult
+    public func write(
+        plannedRun: ImportedTranscriptAgentPlanner.Result,
+        summary candidate: AgentRunSummaryArtifact,
+        projectURL: URL
+    ) throws -> AgentRunSummaryArtifact {
+        let projectFD = try openDirectory(path: projectURL.path)
+        defer { Darwin.close(projectFD) }
+        let stagingName = ".agent-analysis-staging-\(UUID().uuidString)"
+        guard Darwin.mkdirat(projectFD, stagingName, 0o700) == 0 else {
+            throw AgentArtifactError.unsafeArtifactPath
+        }
+        var stagingInstalled = false
+        defer {
+            if !stagingInstalled {
+                removeCanonicalGeneration(named: stagingName, projectFD: projectFD)
+            }
+        }
+        let stagingFD = try openDirectory(at: projectFD, name: stagingName)
+        defer { Darwin.close(stagingFD) }
+
+        let artifacts: [(AgentArtifactKind, String, any Encodable)] = [
+            (.transcriptFullV1, ProjectFile.transcriptFullV1JSON, plannedRun.transcript),
+            (.transcriptWordsV1, ProjectFile.transcriptWordsV1JSON, plannedRun.transcript),
+            (.beatMapV1, ProjectFile.beatMapV1JSON, plannedRun.beatMap),
+            (.qaReportV1, ProjectFile.qaReportV1JSON, plannedRun.qaReport),
+            (.cutPlanV1, ProjectFile.cutPlanV1JSON, plannedRun.cutPlan),
+        ]
+        var references: [AgentArtifactReference] = []
+        for (kind, fileName, artifact) in artifacts {
+            let data = try encoder.encode(artifact)
+            try write(data, named: fileName, directoryFD: stagingFD)
+            references.append(.init(
+                kind: kind,
+                path: "analysis/\(fileName)",
+                sha256: digest(data)
+            ))
+        }
+        references.append(Self.references[5])
+        var summary = candidate
+        summary.artifacts = references
+        // The digest-bound manifest is committed last inside the staged generation.
+        try write(encoder.encode(summary), named: ProjectFile.runSummaryV1JSON, directoryFD: stagingFD)
+        guard Darwin.fsync(stagingFD) == 0 else { throw AgentArtifactError.unsafeArtifactPath }
+
+        let analysisExists = try directoryExists(at: projectFD, name: ProjectFile.analysisDirectory)
+        let installStatus = if analysisExists {
+            Darwin.renameatx_np(
+                projectFD,
+                stagingName,
+                projectFD,
+                ProjectFile.analysisDirectory,
+                UInt32(RENAME_SWAP)
+            )
+        } else {
+            Darwin.renameat(projectFD, stagingName, projectFD, ProjectFile.analysisDirectory)
+        }
+        guard installStatus == 0 else { throw AgentArtifactError.unsafeArtifactPath }
+        stagingInstalled = true
+        if Darwin.fsync(projectFD) != 0 {
+            let rollbackStatus = if analysisExists {
+                Darwin.renameatx_np(
+                    projectFD,
+                    stagingName,
+                    projectFD,
+                    ProjectFile.analysisDirectory,
+                    UInt32(RENAME_SWAP)
+                )
+            } else {
+                Darwin.renameat(projectFD, ProjectFile.analysisDirectory, projectFD, stagingName)
+            }
+            _ = Darwin.fsync(projectFD)
+            guard rollbackStatus == 0 else { throw AgentArtifactError.unsafeArtifactPath }
+            stagingInstalled = false
+            throw AgentArtifactError.unsafeArtifactPath
+        }
+        if analysisExists {
+            // After RENAME_SWAP, the prior generation is descriptor-anchored at stagingName.
+            removeCanonicalGeneration(named: stagingName, projectFD: projectFD)
+        }
+        return summary
+    }
+
+    /// Removes a destination package's prior canonical generation before Save As.
+    public func removeLatest(projectURL: URL) throws {
+        var metadata = stat()
+        let status = projectURL.path.withCString { Darwin.lstat($0, &metadata) }
+        if status != 0, errno == ENOENT {
+            return
+        }
+        guard status == 0 else { throw AgentArtifactError.unsafeArtifactPath }
+        let projectFD = try openDirectory(path: projectURL.path)
+        defer { Darwin.close(projectFD) }
+        guard try directoryExists(at: projectFD, name: ProjectFile.analysisDirectory) else { return }
+        let tombstone = ".agent-analysis-removed-\(UUID().uuidString)"
+        guard Darwin.renameat(
+            projectFD,
+            ProjectFile.analysisDirectory,
+            projectFD,
+            tombstone
+        ) == 0 else { throw AgentArtifactError.unsafeArtifactPath }
+        guard Darwin.fsync(projectFD) == 0 else {
+            _ = Darwin.renameat(projectFD, tombstone, projectFD, ProjectFile.analysisDirectory)
+            throw AgentArtifactError.unsafeArtifactPath
+        }
+        removeCanonicalGeneration(named: tombstone, projectFD: projectFD)
+    }
+
+    public func loadLatest(projectURL: URL, projectId: UUID) throws -> AgentRunSummaryArtifact? {
+        let projectFD = try openDirectory(path: projectURL.path)
+        defer { Darwin.close(projectFD) }
+        guard try directoryExists(at: projectFD, name: ProjectFile.analysisDirectory) else { return nil }
+        let analysisFD = try openDirectory(at: projectFD, name: ProjectFile.analysisDirectory)
+        defer { Darwin.close(analysisFD) }
+        guard try fileExists(at: analysisFD, name: ProjectFile.runSummaryV1JSON) else { return nil }
+
+        let summaryData = try readData(named: ProjectFile.runSummaryV1JSON, directoryFD: analysisFD)
+        let summary = try decoder.decode(AgentRunSummaryArtifact.self, from: summaryData)
+        guard summary.version == 1, summary.projectId == projectId, !summary.jobId.isEmpty,
+              summary.recordingFileName == ProjectFile.recordingMov,
+              summary.artifacts.count == Self.references.count,
+              zip(summary.artifacts, Self.references).allSatisfy({ actual, expected in
+                  actual.kind == expected.kind && actual.path == expected.path
+              }),
+              summary.artifacts.dropLast().allSatisfy({ $0.sha256?.count == 64 }),
+              summary.artifacts.last?.sha256 == nil
+        else { throw AgentArtifactError.invalidRunSummary }
+
+        var verifiedData: [String: Data] = [:]
+        for reference in summary.artifacts.dropLast() {
+            guard let fileName = reference.path.split(separator: "/").last.map(String.init) else {
+                throw AgentArtifactError.invalidRunSummary
+            }
+            let data = try readData(named: fileName, directoryFD: analysisFD)
+            guard digest(data) == reference.sha256 else { throw AgentArtifactError.invalidRunSummary }
+            verifiedData[fileName] = data
+        }
+
+        func decode<T: Decodable>(_ type: T.Type, named name: String) throws -> T {
+            guard let data = verifiedData[name] else { throw AgentArtifactError.invalidRunSummary }
+            return try decoder.decode(type, from: data)
+        }
+        let transcriptFull = try decode(AgentTranscriptArtifact.self, named: ProjectFile.transcriptFullV1JSON)
+        let transcriptWords = try decode(AgentTranscriptArtifact.self, named: ProjectFile.transcriptWordsV1JSON)
+        let beatMap = try decode(AgentBeatMapArtifact.self, named: ProjectFile.beatMapV1JSON)
+        let qaReport = try decode(AgentQAReport.self, named: ProjectFile.qaReportV1JSON)
+        let cutPlan = try decode(AgentCutPlanArtifact.self, named: ProjectFile.cutPlanV1JSON)
+        guard transcriptFull == transcriptWords,
+              qaReport == summary.qaReport,
+              cutPlan == summary.cutPlan
+        else { throw AgentArtifactError.invalidRunSummary }
+        if summary.qaReport.passed {
+            guard beatMap.anchors.map(\.beat) == cutPlan.segments.map(\.beat) else {
+                throw AgentArtifactError.invalidRunSummary
+            }
+            _ = try summary.cutPlan.validated()
+        } else if !cutPlan.segments.isEmpty {
+            throw AgentArtifactError.invalidRunSummary
+        }
+        return summary
+    }
+
+    private func openDirectory(path: String) throws -> Int32 {
+        guard path.hasPrefix("/") else { throw AgentArtifactError.unsafeArtifactPath }
+        var directoryFD = Darwin.open("/", O_RDONLY | O_DIRECTORY)
+        guard directoryFD >= 0 else { throw AgentArtifactError.unsafeArtifactPath }
+        for component in path.split(separator: "/").map(String.init) {
+            let nextFD = component.withCString {
+                Darwin.openat(directoryFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW)
+            }
+            Darwin.close(directoryFD)
+            guard nextFD >= 0 else { throw AgentArtifactError.unsafeArtifactPath }
+            directoryFD = nextFD
+        }
+        return directoryFD
+    }
+
+    private func openDirectory(at parentFD: Int32, name: String) throws -> Int32 {
+        let descriptor = name.withCString { Darwin.openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW) }
+        guard descriptor >= 0 else { throw AgentArtifactError.unsafeArtifactPath }
+        return descriptor
+    }
+
+    private func directoryExists(at parentFD: Int32, name: String) throws -> Bool {
+        let descriptor = name.withCString { Darwin.openat(parentFD, $0, O_RDONLY | O_DIRECTORY | O_NOFOLLOW) }
+        if descriptor >= 0 {
+            Darwin.close(descriptor)
+            return true
+        }
+        guard errno == ENOENT else { throw AgentArtifactError.unsafeArtifactPath }
+        return false
+    }
+
+    private func fileExists(at directoryFD: Int32, name: String) throws -> Bool {
+        let descriptor = name.withCString { Darwin.openat(directoryFD, $0, O_RDONLY | O_NOFOLLOW) }
+        if descriptor >= 0 {
+            Darwin.close(descriptor)
+            return true
+        }
+        guard errno == ENOENT else { throw AgentArtifactError.unsafeArtifactPath }
+        return false
+    }
+
+    private func write(_ data: Data, named name: String, directoryFD: Int32) throws {
+        let descriptor = name.withCString {
+            Darwin.openat(directoryFD, $0, O_WRONLY | O_CREAT | O_EXCL | O_NOFOLLOW, 0o600)
+        }
+        guard descriptor >= 0 else { throw AgentArtifactError.unsafeArtifactPath }
+        defer { Darwin.close(descriptor) }
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.baseAddress else { return }
+            var offset = 0
+            while offset < rawBuffer.count {
+                let count = Darwin.write(descriptor, base.advanced(by: offset), rawBuffer.count - offset)
+                guard count > 0 else { throw AgentArtifactError.unsafeArtifactPath }
+                offset += count
+            }
+        }
+        guard Darwin.fsync(descriptor) == 0 else { throw AgentArtifactError.unsafeArtifactPath }
+    }
+
+    private func readData(named name: String, directoryFD: Int32) throws -> Data {
+        let descriptor = name.withCString { Darwin.openat(directoryFD, $0, O_RDONLY | O_NOFOLLOW) }
+        guard descriptor >= 0 else { throw AgentArtifactError.invalidRunSummary }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        var metadata = stat()
+        guard Darwin.fstat(descriptor, &metadata) == 0,
+              metadata.st_mode & S_IFMT == S_IFREG,
+              metadata.st_size >= 0,
+              metadata.st_size <= 50 * 1024 * 1024
+        else { throw AgentArtifactError.invalidRunSummary }
+        let expectedSize = Int(metadata.st_size)
+        let data = try handle.read(upToCount: expectedSize + 1) ?? Data()
+        guard data.count == expectedSize else { throw AgentArtifactError.invalidRunSummary }
+        return data
+    }
+
+    private func removeCanonicalGeneration(named name: String, projectFD: Int32) {
+        guard let directoryFD = try? openDirectory(at: projectFD, name: name) else { return }
+        for reference in Self.references {
+            let fileName = reference.path.split(separator: "/").last.map(String.init)!
+            _ = fileName.withCString { Darwin.unlinkat(directoryFD, $0, 0) }
+        }
+        Darwin.close(directoryFD)
+        _ = name.withCString { Darwin.unlinkat(projectFD, $0, AT_REMOVEDIR) }
+    }
+
+    private func digest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+}

--- a/engines/macos-swift/modules/project/AgentArtifactStore.swift
+++ b/engines/macos-swift/modules/project/AgentArtifactStore.swift
@@ -109,18 +109,18 @@ public struct AgentArtifactStore {
         return summary
     }
 
-    /// Removes a destination package's prior canonical generation before Save As.
-    public func removeLatest(projectURL: URL) throws {
+    /// Hides a destination package's prior generation so Save As can restore it on failure.
+    public func quarantineLatest(projectURL: URL) throws -> String? {
         var metadata = stat()
         let status = projectURL.path.withCString { Darwin.lstat($0, &metadata) }
         if status != 0, errno == ENOENT {
-            return
+            return nil
         }
         guard status == 0 else { throw AgentArtifactError.unsafeArtifactPath }
         let projectFD = try openDirectory(path: projectURL.path)
         defer { Darwin.close(projectFD) }
-        guard try directoryExists(at: projectFD, name: ProjectFile.analysisDirectory) else { return }
-        let tombstone = ".agent-analysis-removed-\(UUID().uuidString)"
+        guard try directoryExists(at: projectFD, name: ProjectFile.analysisDirectory) else { return nil }
+        let tombstone = ".agent-analysis-quarantine-\(UUID().uuidString)"
         guard Darwin.renameat(
             projectFD,
             ProjectFile.analysisDirectory,
@@ -131,7 +131,21 @@ public struct AgentArtifactStore {
             _ = Darwin.renameat(projectFD, tombstone, projectFD, ProjectFile.analysisDirectory)
             throw AgentArtifactError.unsafeArtifactPath
         }
-        removeCanonicalGeneration(named: tombstone, projectFD: projectFD)
+        return tombstone
+    }
+
+    public func restoreQuarantined(_ name: String, projectURL: URL) throws {
+        let projectFD = try openDirectory(path: projectURL.path)
+        defer { Darwin.close(projectFD) }
+        guard Darwin.renameat(projectFD, name, projectFD, ProjectFile.analysisDirectory) == 0,
+              Darwin.fsync(projectFD) == 0
+        else { throw AgentArtifactError.unsafeArtifactPath }
+    }
+
+    public func discardQuarantined(_ name: String, projectURL: URL) {
+        guard let projectFD = try? openDirectory(path: projectURL.path) else { return }
+        defer { Darwin.close(projectFD) }
+        removeCanonicalGeneration(named: name, projectFD: projectFD)
     }
 
     public func loadLatest(projectURL: URL, projectId: UUID) throws -> AgentRunSummaryArtifact? {

--- a/engines/macos-swift/modules/project/AgentArtifacts.swift
+++ b/engines/macos-swift/modules/project/AgentArtifacts.swift
@@ -1,0 +1,337 @@
+import Foundation
+
+/// A normalized timed transcript span consumed by the deterministic Agent Mode planner.
+public struct AgentTranscriptSpan: Codable, Equatable {
+    public var text: String
+    public var startSeconds: Double
+    public var endSeconds: Double
+
+    public init(text: String, startSeconds: Double, endSeconds: Double) {
+        self.text = text
+        self.startSeconds = startSeconds
+        self.endSeconds = endSeconds
+    }
+}
+
+/// Canonical normalized transcript artifact.
+public struct AgentTranscriptArtifact: Codable, Equatable {
+    public let version: Int
+    public var segments: [AgentTranscriptSpan]
+    public var words: [AgentTranscriptSpan]
+
+    public init(version: Int = 1, segments: [AgentTranscriptSpan], words: [AgentTranscriptSpan]) {
+        self.version = version
+        self.segments = segments
+        self.words = words
+    }
+}
+
+/// Narrative beat used by deterministic Agent Mode planning.
+public enum AgentNarrativeBeat: String, Codable, CaseIterable {
+    case hook
+    case action
+    case payoff
+    case takeaway
+}
+
+/// Timed narrative anchor emitted by Agent Mode analysis.
+public struct AgentBeatAnchor: Codable, Equatable {
+    public var beat: AgentNarrativeBeat
+    public var startSeconds: Double
+    public var endSeconds: Double
+
+    public init(beat: AgentNarrativeBeat, startSeconds: Double, endSeconds: Double) {
+        self.beat = beat
+        self.startSeconds = startSeconds
+        self.endSeconds = endSeconds
+    }
+}
+
+/// Versioned beat-map artifact.
+public struct AgentBeatMapArtifact: Codable, Equatable {
+    public let version: Int
+    public var anchors: [AgentBeatAnchor]
+
+    public init(version: Int = 1, anchors: [AgentBeatAnchor]) {
+        self.version = version
+        self.anchors = anchors
+    }
+}
+
+/// Rational source frame rate retained without rounding fractional broadcast rates.
+public struct AgentFrameRate: Codable, Equatable {
+    public var numerator: Int
+    public var denominator: Int
+
+    public init(numerator: Int, denominator: Int = 1) {
+        self.numerator = numerator
+        self.denominator = denominator
+    }
+
+    public var framesPerSecond: Double {
+        Double(numerator) / Double(denominator)
+    }
+
+    public func seconds(forFrame frame: Int) -> Double {
+        Double(frame) * Double(denominator) / Double(numerator)
+    }
+}
+
+/// End-exclusive frame range selected by a deterministic cut plan.
+public struct AgentCutPlanSegment: Codable, Equatable {
+    public var id: String
+    public var beat: AgentNarrativeBeat
+    public var startFrame: Int
+    public var endFrame: Int
+
+    public init(id: String, beat: AgentNarrativeBeat, startFrame: Int, endFrame: Int) {
+        self.id = id
+        self.beat = beat
+        self.startFrame = startFrame
+        self.endFrame = endFrame
+    }
+}
+
+/// Canonical frame-based Agent Mode cut-plan artifact.
+public struct AgentCutPlanArtifact: Codable, Equatable {
+    public let version: Int
+    public var sourceFps: AgentFrameRate
+    public var sourceFrameCount: Int
+    public var segments: [AgentCutPlanSegment]
+
+    public init(
+        version: Int = 1,
+        sourceFps: AgentFrameRate,
+        sourceFrameCount: Int,
+        segments: [AgentCutPlanSegment]
+    ) {
+        self.version = version
+        self.sourceFps = sourceFps
+        self.sourceFrameCount = sourceFrameCount
+        self.segments = segments
+    }
+
+    public func validated() throws -> AgentCutPlanArtifact {
+        guard version == 1, sourceFps.numerator > 0, sourceFps.denominator > 0,
+              sourceFrameCount > 0, !segments.isEmpty
+        else {
+            throw AgentArtifactError.invalidCutPlan
+        }
+        guard segments.map(\.beat) == AgentNarrativeBeat.allCases,
+              Set(segments.map(\.id)).count == segments.count
+        else { throw AgentArtifactError.invalidCutPlan }
+        var previousEnd = 0
+        for segment in segments {
+            guard !segment.id.isEmpty,
+                  segment.startFrame >= previousEnd,
+                  segment.endFrame > segment.startFrame,
+                  segment.endFrame <= sourceFrameCount
+            else { throw AgentArtifactError.invalidCutPlan }
+            previousEnd = segment.endFrame
+        }
+        return self
+    }
+
+    public func timeline() throws -> TimelineDocument {
+        let validated = try validated()
+        return TimelineDocument(items: validated.segments.map { segment in
+            .clip(TimelineClip(
+                id: segment.id,
+                sourceStartSeconds: validated.sourceFps.seconds(forFrame: segment.startFrame),
+                sourceEndSeconds: validated.sourceFps.seconds(forFrame: segment.endFrame)
+            ))
+        })
+    }
+}
+
+/// Canonical persisted manifest for the latest Agent Mode run in a project.
+public struct AgentRunSummaryArtifact: Codable, Equatable {
+    public let version: Int
+    public var jobId: String
+    public var projectId: UUID
+    public var recordingFileName: String
+    public var recordingRevision: String
+    public var status: AgentJobStatus
+    public var runtimeBudgetMinutes: Int
+    public var qaReport: AgentQAReport
+    public var artifacts: [AgentArtifactReference]
+    public var cutPlan: AgentCutPlanArtifact
+    public var baseTimeline: TimelineDocument
+    public var requiresDestructiveConfirmation: Bool
+    public var createdAt: Date
+    public var updatedAt: Date
+
+    public init(
+        version: Int = 1,
+        jobId: String,
+        projectId: UUID,
+        recordingFileName: String,
+        recordingRevision: String,
+        status: AgentJobStatus,
+        runtimeBudgetMinutes: Int,
+        qaReport: AgentQAReport,
+        artifacts: [AgentArtifactReference],
+        cutPlan: AgentCutPlanArtifact,
+        baseTimeline: TimelineDocument,
+        requiresDestructiveConfirmation: Bool,
+        createdAt: Date,
+        updatedAt: Date
+    ) {
+        self.version = version
+        self.jobId = jobId
+        self.projectId = projectId
+        self.recordingFileName = recordingFileName
+        self.recordingRevision = recordingRevision
+        self.status = status
+        self.runtimeBudgetMinutes = runtimeBudgetMinutes
+        self.qaReport = qaReport
+        self.artifacts = artifacts
+        self.cutPlan = cutPlan
+        self.baseTimeline = baseTimeline
+        self.requiresDestructiveConfirmation = requiresDestructiveConfirmation
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+    }
+}
+
+/// Validation failures for persisted Agent Mode artifacts.
+public enum AgentArtifactError: Error {
+    case invalidTranscript
+    case invalidCutPlan
+    case invalidRunSummary
+    case unsafeArtifactPath
+    case projectMismatch
+}
+
+/// Pure deterministic imported-transcript planner used by Agent Mode.
+public enum ImportedTranscriptAgentPlanner {
+    private struct ImportedTranscript: Decodable {
+        struct Segment: Decodable {
+            let text: String
+            let startSeconds: Double
+            let endSeconds: Double
+        }
+
+        struct Word: Decodable {
+            let word: String
+            let startSeconds: Double
+            let endSeconds: Double
+        }
+
+        let segments: [Segment]?
+        let words: [Word]?
+    }
+
+    public struct Result: Equatable {
+        public var transcript: AgentTranscriptArtifact
+        public var beatMap: AgentBeatMapArtifact
+        public var qaReport: AgentQAReport
+        public var cutPlan: AgentCutPlanArtifact
+    }
+
+    public static func plan(data: Data, sourceDuration: Double, sourceFps: AgentFrameRate) throws -> Result {
+        guard sourceDuration.isFinite, sourceDuration > 0,
+              sourceFps.numerator > 0, sourceFps.denominator > 0,
+              let imported = try? JSONDecoder().decode(ImportedTranscript.self, from: data)
+        else { throw AgentArtifactError.invalidTranscript }
+
+        func normalized(text: String, start: Double, end: Double) -> AgentTranscriptSpan? {
+            let value = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !value.isEmpty, start.isFinite, end.isFinite,
+                  start >= 0, end > start, start < sourceDuration
+            else { return nil }
+            return AgentTranscriptSpan(text: value, startSeconds: start, endSeconds: min(end, sourceDuration))
+        }
+
+        let importedSegments = imported.segments ?? []
+        let importedWords = imported.words ?? []
+        let segments = importedSegments.compactMap {
+            normalized(text: $0.text, start: $0.startSeconds, end: $0.endSeconds)
+        }.sorted { $0.startSeconds < $1.startSeconds }
+        let words = importedWords.compactMap {
+            normalized(text: $0.word, start: $0.startSeconds, end: $0.endSeconds)
+        }.sorted { $0.startSeconds < $1.startSeconds }
+        guard segments.count == importedSegments.count,
+              words.count == importedWords.count,
+              !segments.isEmpty || !words.isEmpty
+        else { throw AgentArtifactError.invalidTranscript }
+
+        let transcript = AgentTranscriptArtifact(segments: segments, words: words)
+        let narrativeUnits = segments.isEmpty ? words : segments
+        let candidates: [AgentNarrativeBeat: Set<String>] = [
+            .hook: ["hook", "intro", "opening"],
+            .action: ["action", "step", "steps", "process"],
+            .payoff: ["payoff", "result", "outcome"],
+            .takeaway: ["takeaway", "lesson", "conclusion"],
+        ]
+        var anchors: [AgentBeatAnchor] = []
+        var searchStart = 0
+        for beat in AgentNarrativeBeat.allCases {
+            guard let accepted = candidates[beat] else { continue }
+            var match: (Int, AgentTranscriptSpan)?
+            for index in searchStart ..< narrativeUnits.count {
+                let tokens = Set(narrativeUnits[index].text.lowercased().split { !$0.isLetter && !$0.isNumber }.map(String.init))
+                if !tokens.isDisjoint(with: accepted) {
+                    match = (index, narrativeUnits[index])
+                    break
+                }
+            }
+            guard let match else { continue }
+            anchors.append(.init(beat: beat, startSeconds: match.1.startSeconds, endSeconds: match.1.endSeconds))
+            searchStart = match.0 + 1
+        }
+
+        let covered = Set(anchors.map(\.beat))
+        let missing = AgentNarrativeBeat.allCases.filter { !covered.contains($0) }
+        let coverage = AgentQACoverage(
+            hook: covered.contains(.hook),
+            action: covered.contains(.action),
+            payoff: covered.contains(.payoff),
+            takeaway: covered.contains(.takeaway)
+        )
+        let qa = AgentQAReport(
+            passed: missing.isEmpty,
+            score: Double(covered.count) / Double(AgentNarrativeBeat.allCases.count),
+            coverage: coverage,
+            missingBeats: missing.map(\.rawValue)
+        )
+        let framesPerSecond = sourceFps.framesPerSecond
+        let sourceFrameCount = max(1, Int(floor(sourceDuration * framesPerSecond)))
+        guard qa.passed else {
+            return Result(
+                transcript: transcript,
+                beatMap: .init(anchors: anchors),
+                qaReport: qa,
+                cutPlan: .init(sourceFps: sourceFps, sourceFrameCount: sourceFrameCount, segments: [])
+            )
+        }
+
+        var plannedSegments: [AgentCutPlanSegment] = []
+        var previousEndFrame = 0
+        for (index, beat) in AgentNarrativeBeat.allCases.enumerated() {
+            let anchor = anchors[index]
+            let startFrame = max(
+                previousEndFrame,
+                max(0, Int(floor(anchor.startSeconds * framesPerSecond)))
+            )
+            let endFrame = min(
+                sourceFrameCount,
+                Int(ceil(anchor.endSeconds * framesPerSecond))
+            )
+            guard endFrame > startFrame else { throw AgentArtifactError.invalidTranscript }
+            plannedSegments.append(AgentCutPlanSegment(
+                id: "agent-\(beat.rawValue)-\(index)",
+                beat: beat,
+                startFrame: startFrame,
+                endFrame: endFrame
+            ))
+            previousEndFrame = endFrame
+        }
+        let cutPlan = try AgentCutPlanArtifact(
+            sourceFps: sourceFps,
+            sourceFrameCount: sourceFrameCount,
+            segments: plannedSegments
+        ).validated()
+        return Result(transcript: transcript, beatMap: .init(anchors: anchors), qaReport: qa, cutPlan: cutPlan)
+    }
+}

--- a/engines/native-foundation/src/agent.rs
+++ b/engines/native-foundation/src/agent.rs
@@ -4,7 +4,8 @@ use crate::wire::{failure, success, EngineCallId, EngineResponse, ProtocolErrorC
 use crate::PREFLIGHT_TOKEN_TTL_SECONDS;
 use serde_json::{json, Value};
 use std::fs;
-use time::OffsetDateTime;
+use time::format_description::well_known::Rfc3339;
+use time::{Duration, OffsetDateTime};
 
 fn decode_params<T>(params: &Value) -> T
 where
@@ -217,38 +218,43 @@ pub(crate) fn agent_preflight(state: &mut State, params: &Value) -> Value {
         None
     };
 
+    let expires_at = token.as_ref().map(|_| {
+        (OffsetDateTime::now_utc() + Duration::seconds(PREFLIGHT_TOKEN_TTL_SECONDS))
+            .format(&Rfc3339)
+            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_string())
+    });
     json!({
         "ready": evaluation.ready,
         "blockingReasons": evaluation.blocking_reasons,
         "canApplyDestructive": state.unsaved_changes,
         "transcriptionProvider": evaluation.provider,
         "preflightToken": token,
+        "preflightTokenExpiresAt": expires_at,
     })
+}
+
+pub(crate) enum PreflightTokenValidationError {
+    Expired,
+    Mismatch,
 }
 
 pub(crate) fn validate_preflight_token(
     state: &mut State,
     token: &str,
     params: &Value,
-) -> Result<(), String> {
+) -> Result<(), PreflightTokenValidationError> {
     if token.is_empty() {
-        return Err(
-            "agent.preflight must be called first. preflightToken is required.".to_string(),
-        );
+        return Err(PreflightTokenValidationError::Expired);
     }
 
     let session = match state.preflight_sessions.get(token) {
         Some(session) => session.clone(),
-        None => {
-            return Err(
-                "preflightToken is missing or expired. Run agent.preflight again.".to_string(),
-            );
-        }
+        None => return Err(PreflightTokenValidationError::Expired),
     };
 
     if now_unix_seconds() - session.created_at_unix_seconds > PREFLIGHT_TOKEN_TTL_SECONDS {
         state.preflight_sessions.remove(token);
-        return Err("preflightToken expired. Run agent.preflight again.".to_string());
+        return Err(PreflightTokenValidationError::Expired);
     }
 
     let evaluation = evaluate_agent_preflight(state, params);
@@ -261,10 +267,7 @@ pub(crate) fn validate_preflight_token(
         && session.recording_url == state.recording_url;
     if !matches {
         state.preflight_sessions.remove(token);
-        return Err(
-            "preflightToken does not match current run parameters. Run agent.preflight again."
-                .to_string(),
-        );
+        return Err(PreflightTokenValidationError::Mismatch);
     }
 
     state.preflight_sessions.remove(token);
@@ -328,8 +331,19 @@ pub(crate) fn build_agent_run(
 pub(crate) fn run(id: &EngineCallId, state: &mut State, params: &Value) -> EngineResponse {
     let agent_params: AgentRunParams = decode_params(params);
     let token = agent_params.preflight_token.as_deref().unwrap_or("");
-    if let Err(message) = validate_preflight_token(state, token, params) {
-        return failure(id, ProtocolErrorCode::InvalidParams, message);
+    if let Err(error) = validate_preflight_token(state, token, params) {
+        return match error {
+            PreflightTokenValidationError::Expired => failure(
+                id,
+                ProtocolErrorCode::PreflightExpired,
+                "preflightToken is missing, expired, or already consumed. Run agent.preflight again.",
+            ),
+            PreflightTokenValidationError::Mismatch => failure(
+                id,
+                ProtocolErrorCode::PreflightMismatch,
+                "preflightToken does not match current run parameters. Run agent.preflight again.",
+            ),
+        };
     }
 
     let runtime_budget_minutes = agent_params.runtime_budget_minutes.unwrap_or(10);
@@ -424,7 +438,7 @@ pub(crate) fn status(id: &EngineCallId, state: &State, params: &Value) -> Engine
         None => {
             return failure(
                 id,
-                ProtocolErrorCode::InvalidParams,
+                ProtocolErrorCode::NotFound,
                 format!("Unknown jobId: {job_id}"),
             )
         }
@@ -454,7 +468,7 @@ pub(crate) fn apply(id: &EngineCallId, state: &mut State, params: &Value) -> Eng
         None => {
             return failure(
                 id,
-                ProtocolErrorCode::InvalidParams,
+                ProtocolErrorCode::NotFound,
                 format!("Unknown jobId: {job_id}"),
             )
         }
@@ -484,7 +498,11 @@ pub(crate) fn apply(id: &EngineCallId, state: &mut State, params: &Value) -> Eng
         id,
         json!({
             "success": true,
-            "message": "Applied cut plan to working timeline.",
+            "message": "Applied foundation-shell Agent state.",
+            "jobId": job_id,
+            "status": "applied",
+            "appliedSegments": 1,
+            "projectHasUnsavedChanges": true,
         }),
     )
 }

--- a/engines/native-foundation/src/export.rs
+++ b/engines/native-foundation/src/export.rs
@@ -137,7 +137,7 @@ pub(crate) fn run_cut_plan(id: &EngineCallId, state: &State, params: &Value) -> 
         None => {
             return failure(
                 id,
-                ProtocolErrorCode::InvalidParams,
+                ProtocolErrorCode::NotFound,
                 format!("Unknown jobId: {job_id}"),
             )
         }

--- a/engines/native-foundation/src/lib.rs
+++ b/engines/native-foundation/src/lib.rs
@@ -491,8 +491,8 @@ mod tests {
                 state,
                 &request("r13", EngineMethod::AgentRun, json!({})),
             );
-            let message = expect_error(response, ProtocolErrorCode::InvalidParams);
-            assert!(message.contains("preflightToken is required"));
+            let message = expect_error(response, ProtocolErrorCode::PreflightExpired);
+            assert!(message.contains("preflightToken"));
         });
     }
 

--- a/engines/native-foundation/src/system.rs
+++ b/engines/native-foundation/src/system.rs
@@ -32,19 +32,24 @@ pub(crate) fn capabilities(id: &EngineCallId, platform: &str) -> EngineResponse 
             },
             "export": {
                 "presets": true,
-                "cutPlan": true,
+                "cutPlan": false,
                 "backgroundFraming": false,
             },
             "project": {
                 "openSave": true,
             },
             "agent": {
-                "preflight": true,
-                "run": true,
-                "status": true,
-                "apply": true,
+                "preflight": false,
+                "run": false,
+                "status": false,
+                "apply": false,
                 "localOnly": true,
                 "runtimeBudgetMinutes": 10,
+                "supportedTranscriptionProviders": [],
+                "maxSourceDurationSeconds": 600,
+                "preflightTokenTtlSeconds": 60,
+                "artifactVersion": 1,
+                "cutPlanVersion": 1,
             }
         }),
     )

--- a/engines/native-foundation/src/transport.rs
+++ b/engines/native-foundation/src/transport.rs
@@ -85,10 +85,6 @@ fn params_from_body<T: Serialize>(body: &T) -> Result<Value, models::EngineBadRe
         .map_err(|error| bad_request("invalid_request", format!("Invalid request body: {error}")))
 }
 
-fn params_with_job_id(job_id: &str) -> Value {
-    json!({ "jobId": job_id })
-}
-
 fn bad_or_runtime(error: models::EngineBadRequestError) -> bool {
     error.code == ProtocolErrorCode::RuntimeError.as_str()
 }
@@ -328,70 +324,77 @@ impl apis::sources::Sources<()> for NativeFoundationApi {
 #[async_trait]
 impl apis::agent::Agent<()> for NativeFoundationApi {
     type Claims = ();
+
     async fn agent_agent_apply(
         &self,
         _: &Method,
         _: &headers::Host,
         _: &axum_extra::extract::CookieJar,
         _: &Self::Claims,
-        path: &models::AgentAgentApplyPathParams,
-        body: &models::AgentApplyPayload,
+        _: &models::AgentAgentApplyPathParams,
+        _: &models::AgentApplyPayload,
     ) -> Result<apis::agent::AgentAgentApplyResponse, ()> {
-        let mut params = params_from_body(body).unwrap_or_else(|_| json!({}));
-        if let Value::Object(ref mut object) = params {
-            object.insert("jobId".to_string(), json!(path.job_id));
-        }
-        map_response!(
-            self.model(EngineMethod::AgentApply, params),
-            apis::agent::AgentAgentApplyResponse::Status200_ActionResult,
-            apis::agent::AgentAgentApplyResponse::Status400_EngineBadRequestErrorResponseBody,
-            apis::agent::AgentAgentApplyResponse::Status500_EngineRuntimeErrorResponseBody
+        Ok(
+            apis::agent::AgentAgentApplyResponse::Status400_EngineBadRequestErrorResponseBody(
+                bad_request(
+                    "unsupported_method",
+                    "Agent Mode is unavailable on foundation shells",
+                ),
+            ),
         )
     }
+
     async fn agent_agent_preflight(
         &self,
         _: &Method,
         _: &headers::Host,
         _: &axum_extra::extract::CookieJar,
         _: &Self::Claims,
-        body: &models::AgentPreflightPayload,
+        _: &models::AgentPreflightPayload,
     ) -> Result<apis::agent::AgentAgentPreflightResponse, ()> {
-        map_response!(
-            params_from_body(body)
-                .and_then(|params| self.model(EngineMethod::AgentPreflight, params)),
-            apis::agent::AgentAgentPreflightResponse::Status200_AgentPreflightResult,
-            apis::agent::AgentAgentPreflightResponse::Status400_EngineBadRequestErrorResponseBody,
-            apis::agent::AgentAgentPreflightResponse::Status500_EngineRuntimeErrorResponseBody
+        Ok(
+            apis::agent::AgentAgentPreflightResponse::Status400_EngineBadRequestErrorResponseBody(
+                bad_request(
+                    "unsupported_method",
+                    "Agent Mode is unavailable on foundation shells",
+                ),
+            ),
         )
     }
+
     async fn agent_agent_run(
         &self,
         _: &Method,
         _: &headers::Host,
         _: &axum_extra::extract::CookieJar,
         _: &Self::Claims,
-        body: &models::AgentRunPayload,
+        _: &models::AgentRunPayload,
     ) -> Result<apis::agent::AgentAgentRunResponse, ()> {
-        map_response!(
-            params_from_body(body).and_then(|params| self.model(EngineMethod::AgentRun, params)),
-            apis::agent::AgentAgentRunResponse::Status200_AgentRunResult,
-            apis::agent::AgentAgentRunResponse::Status400_EngineBadRequestErrorResponseBody,
-            apis::agent::AgentAgentRunResponse::Status500_EngineRuntimeErrorResponseBody
+        Ok(
+            apis::agent::AgentAgentRunResponse::Status400_EngineBadRequestErrorResponseBody(
+                bad_request(
+                    "unsupported_method",
+                    "Agent Mode is unavailable on foundation shells",
+                ),
+            ),
         )
     }
+
     async fn agent_agent_status(
         &self,
         _: &Method,
         _: &headers::Host,
         _: &axum_extra::extract::CookieJar,
         _: &Self::Claims,
-        path: &models::AgentAgentStatusPathParams,
+        _: &models::AgentAgentStatusPathParams,
     ) -> Result<apis::agent::AgentAgentStatusResponse, ()> {
-        map_response!(
-            self.model(EngineMethod::AgentStatus, params_with_job_id(&path.job_id)),
-            apis::agent::AgentAgentStatusResponse::Status200_AgentRunSummary,
-            apis::agent::AgentAgentStatusResponse::Status400_EngineBadRequestErrorResponseBody,
-            apis::agent::AgentAgentStatusResponse::Status500_EngineRuntimeErrorResponseBody
+        Ok(
+            apis::agent::AgentAgentStatusResponse::Status400_EngineBadRequestErrorResponseBody(
+                bad_request(
+                    "unsupported_method",
+                    "Agent Mode is unavailable on foundation shells",
+                ),
+            ),
         )
     }
 }
@@ -460,9 +463,13 @@ impl apis::export::Export<()> for NativeFoundationApi {
         _: &headers::Host,
         _: &axum_extra::extract::CookieJar,
         _: &Self::Claims,
-        body: &models::ExportRunCutPlanPayload,
+        _: &models::ExportRunCutPlanPayload,
     ) -> Result<apis::export::ExportExportRunCutPlanResponse, ()> {
-        map_response!(params_from_body(body).and_then(|params| self.model(EngineMethod::ExportRunCutPlan, params)), apis::export::ExportExportRunCutPlanResponse::Status200_ExportRunCutPlanResult, apis::export::ExportExportRunCutPlanResponse::Status400_EngineBadRequestErrorResponseBody, apis::export::ExportExportRunCutPlanResponse::Status500_EngineRuntimeErrorResponseBody)
+        Ok(
+            apis::export::ExportExportRunCutPlanResponse::Status400_EngineBadRequestErrorResponseBody(
+                bad_request("unsupported_method", "Cut-plan export is unavailable on foundation shells"),
+            ),
+        )
     }
 }
 
@@ -692,14 +699,24 @@ mod tests {
 
     async fn authorized_json(method: &str, uri: &str, body: Body) -> (StatusCode, Value) {
         let response = http_app(config(), "test-token".to_string())
-            .oneshot(request_builder(method, uri).body(body).unwrap())
+            .oneshot(
+                request_builder(method, uri)
+                    .header("content-type", "application/json")
+                    .body(body)
+                    .unwrap(),
+            )
             .await
             .unwrap();
         let status = response.status();
         let bytes = body::to_bytes(response.into_body(), usize::MAX)
             .await
             .unwrap();
-        let json: Value = serde_json::from_slice(&bytes).unwrap();
+        let json: Value = serde_json::from_slice(&bytes).unwrap_or_else(|error| {
+            panic!(
+                "response was not JSON (status {status}, body {:?}): {error}",
+                String::from_utf8_lossy(&bytes)
+            )
+        });
         (status, json)
     }
 
@@ -718,7 +735,51 @@ mod tests {
         assert_eq!(capabilities["phase"], "foundation");
         assert_eq!(capabilities["capture"]["display"], true);
         assert_eq!(capabilities["export"]["backgroundFraming"], false);
+        assert_eq!(capabilities["export"]["cutPlan"], false);
         assert_eq!(capabilities["agent"]["localOnly"], true);
+        for operation in ["preflight", "run", "status", "apply"] {
+            assert_eq!(capabilities["agent"][operation], false, "{operation}");
+        }
+        assert_eq!(
+            capabilities["agent"]["supportedTranscriptionProviders"],
+            json!([])
+        );
+    }
+
+    #[tokio::test]
+    async fn http_transport_rejects_agent_operations_on_foundation_shells() {
+        let (status_code, status) =
+            authorized_json("GET", "/v1/agent/runs/missing", Body::empty()).await;
+        assert_eq!(status_code, StatusCode::BAD_REQUEST);
+        assert_eq!(status["code"], "unsupported_method");
+
+        let (apply_code, apply) =
+            authorized_json("POST", "/v1/agent/runs/missing/apply", Body::from("{}")).await;
+        assert_eq!(apply_code, StatusCode::BAD_REQUEST);
+        assert_eq!(apply["code"], "unsupported_method");
+
+        let (preflight_code, preflight) =
+            authorized_json("POST", "/v1/agent/preflight", Body::from("{}")).await;
+        assert_eq!(preflight_code, StatusCode::BAD_REQUEST);
+        assert_eq!(preflight["code"], "unsupported_method");
+
+        let (run_code, run) = authorized_json(
+            "POST",
+            "/v1/agent/runs",
+            Body::from(r#"{"preflightToken":"token"}"#),
+        )
+        .await;
+        assert_eq!(run_code, StatusCode::BAD_REQUEST);
+        assert_eq!(run["code"], "unsupported_method");
+
+        let (export_code, export) = authorized_json(
+            "POST",
+            "/v1/exports/from-cut-plan",
+            Body::from(r#"{"outputURL":"/tmp/output.mp4","presetId":"1080p","jobId":"missing"}"#),
+        )
+        .await;
+        assert_eq!(export_code, StatusCode::BAD_REQUEST);
+        assert_eq!(export["code"], "unsupported_method");
     }
 
     #[tokio::test]

--- a/engines/native-foundation/src/wire.rs
+++ b/engines/native-foundation/src/wire.rs
@@ -16,6 +16,9 @@ pub(crate) enum ProtocolErrorCode {
     QaFailed,
     MissingLocalModel,
     InvalidCutPlan,
+    PreflightExpired,
+    PreflightMismatch,
+    NotFound,
     RuntimeError,
 }
 
@@ -30,6 +33,9 @@ impl ProtocolErrorCode {
             Self::QaFailed => "qa_failed",
             Self::MissingLocalModel => "missing_local_model",
             Self::InvalidCutPlan => "invalid_cut_plan",
+            Self::PreflightExpired => "preflight_expired",
+            Self::PreflightMismatch => "preflight_mismatch",
+            Self::NotFound => "not_found",
             Self::RuntimeError => "runtime_error",
         }
     }
@@ -77,6 +83,7 @@ pub(crate) struct EngineRequest {
     pub(crate) params: Value,
 }
 
+#[allow(dead_code)] // Legacy internal dispatcher remains testable while unsupported HTTP methods fail truthfully.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum EngineMethod {
     SystemPing,

--- a/engines/protocol-rust/src/apis/agent.rs
+++ b/engines/protocol-rust/src/apis/agent.rs
@@ -12,8 +12,8 @@ use crate::{models, types::*};
 #[must_use]
 #[allow(clippy::large_enum_variant)]
 pub enum AgentAgentApplyResponse {
-    /// ActionResult
-    Status200_ActionResult(models::ActionResult),
+    /// AgentApplyResult
+    Status200_AgentApplyResult(models::AgentApplyResult),
     /// EngineBadRequestError response body.
     Status400_EngineBadRequestErrorResponseBody(models::EngineBadRequestError),
     /// EngineUnauthorizedError response body.
@@ -42,10 +42,6 @@ pub enum AgentAgentPreflightResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -84,6 +80,10 @@ pub enum AgentAgentStatusResponse {
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
     /// EngineNotFoundError response body.
     Status404_EngineNotFoundErrorResponseBody(models::EngineNotFoundError),
+    /// EngineConflictError response body.
+    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
+    /// EngineUnprocessableError response body.
+    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -94,6 +94,8 @@ pub enum AgentAgentStatusResponse {
 pub trait Agent<E: std::fmt::Debug + Send + Sync + 'static = ()>: super::ErrorHandler<E> {
     type Claims;
 
+    /// Apply a verified Agent Mode cut plan.
+    ///
     /// AgentAgentApply - POST /v1/agent/runs/{jobId}/apply
     async fn agent_agent_apply(
         &self,
@@ -106,6 +108,8 @@ pub trait Agent<E: std::fmt::Debug + Send + Sync + 'static = ()>: super::ErrorHa
         body: &models::AgentApplyPayload,
     ) -> Result<AgentAgentApplyResponse, E>;
 
+    /// Validate Agent Mode prerequisites.
+    ///
     /// AgentAgentPreflight - POST /v1/agent/preflight
     async fn agent_agent_preflight(
         &self,
@@ -117,6 +121,8 @@ pub trait Agent<E: std::fmt::Debug + Send + Sync + 'static = ()>: super::ErrorHa
         body: &models::AgentPreflightPayload,
     ) -> Result<AgentAgentPreflightResponse, E>;
 
+    /// Create a deterministic Agent Mode run.
+    ///
     /// AgentAgentRun - POST /v1/agent/runs
     async fn agent_agent_run(
         &self,
@@ -128,6 +134,8 @@ pub trait Agent<E: std::fmt::Debug + Send + Sync + 'static = ()>: super::ErrorHa
         body: &models::AgentRunPayload,
     ) -> Result<AgentAgentRunResponse, E>;
 
+    /// Inspect Agent Mode run status.
+    ///
     /// AgentAgentStatus - GET /v1/agent/runs/{jobId}
     async fn agent_agent_status(
         &self,

--- a/engines/protocol-rust/src/apis/capture.rs
+++ b/engines/protocol-rust/src/apis/capture.rs
@@ -36,10 +36,6 @@ pub enum CaptureCaptureStartCurrentWindowResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -56,10 +52,6 @@ pub enum CaptureCaptureStartDisplayResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -76,10 +68,6 @@ pub enum CaptureCaptureStartWindowResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -112,10 +100,6 @@ pub enum CaptureCaptureStopResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }

--- a/engines/protocol-rust/src/apis/export.rs
+++ b/engines/protocol-rust/src/apis/export.rs
@@ -54,10 +54,6 @@ pub enum ExportExportRunResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -74,6 +70,8 @@ pub enum ExportExportRunCutPlanResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
+    /// EngineNotFoundError response body.
+    Status404_EngineNotFoundErrorResponseBody(models::EngineNotFoundError),
     /// EngineConflictError response body.
     Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
     /// EngineUnprocessableError response body.
@@ -120,6 +118,8 @@ pub trait Export<E: std::fmt::Debug + Send + Sync + 'static = ()>: super::ErrorH
         body: &models::ExportRunPayload,
     ) -> Result<ExportExportRunResponse, E>;
 
+    /// Export a verified Agent Mode cut plan.
+    ///
     /// ExportExportRunCutPlan - POST /v1/exports/from-cut-plan
     async fn export_export_run_cut_plan(
         &self,

--- a/engines/protocol-rust/src/apis/permissions.rs
+++ b/engines/protocol-rust/src/apis/permissions.rs
@@ -36,10 +36,6 @@ pub enum PermissionsPermissionsOpenInputMonitoringSettingsResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -56,10 +52,6 @@ pub enum PermissionsPermissionsRequestInputMonitoringResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -76,10 +68,6 @@ pub enum PermissionsPermissionsRequestMicrophoneResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -96,10 +84,6 @@ pub enum PermissionsPermissionsRequestScreenRecordingResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }

--- a/engines/protocol-rust/src/apis/project.rs
+++ b/engines/protocol-rust/src/apis/project.rs
@@ -36,10 +36,6 @@ pub enum ProjectProjectOpenResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -72,10 +68,6 @@ pub enum ProjectProjectSaveResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }

--- a/engines/protocol-rust/src/apis/recording.rs
+++ b/engines/protocol-rust/src/apis/recording.rs
@@ -20,10 +20,6 @@ pub enum RecordingRecordingStartResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }
@@ -40,10 +36,6 @@ pub enum RecordingRecordingStopResponse {
     Status401_EngineUnauthorizedErrorResponseBody(models::AgentAgentPreflight401Response),
     /// EngineForbiddenError response body.
     Status403_EngineForbiddenErrorResponseBody(models::EngineForbiddenError),
-    /// EngineConflictError response body.
-    Status409_EngineConflictErrorResponseBody(models::EngineConflictError),
-    /// EngineUnprocessableError response body.
-    Status422_EngineUnprocessableErrorResponseBody(models::EngineUnprocessableError),
     /// EngineRuntimeError response body.
     Status500_EngineRuntimeErrorResponseBody(models::EngineRuntimeError),
 }

--- a/engines/protocol-rust/src/models.rs
+++ b/engines/protocol-rust/src/models.rs
@@ -412,6 +412,2034 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentApplyPa
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentApplyResult {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "success")]
+    pub success: bool,
+
+    #[serde(rename = "message")]
+    #[validate(custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub message: Option<String>,
+
+    #[serde(rename = "jobId")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub job_id: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "status")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub status: String,
+
+    #[serde(rename = "appliedSegments")]
+    pub applied_segments: i32,
+
+    #[serde(rename = "projectHasUnsavedChanges")]
+    pub project_has_unsaved_changes: bool,
+}
+
+impl AgentApplyResult {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(
+        success: bool,
+        job_id: String,
+        status: String,
+        applied_segments: i32,
+        project_has_unsaved_changes: bool,
+    ) -> AgentApplyResult {
+        AgentApplyResult {
+            success,
+            message: None,
+            job_id,
+            status,
+            applied_segments,
+            project_has_unsaved_changes,
+        }
+    }
+}
+
+/// Converts the AgentApplyResult value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentApplyResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("success".to_string()),
+            Some(self.success.to_string()),
+            self.message
+                .as_ref()
+                .map(|message| ["message".to_string(), message.to_string()].join(",")),
+            Some("jobId".to_string()),
+            Some(self.job_id.to_string()),
+            Some("status".to_string()),
+            Some(self.status.to_string()),
+            Some("appliedSegments".to_string()),
+            Some(self.applied_segments.to_string()),
+            Some("projectHasUnsavedChanges".to_string()),
+            Some(self.project_has_unsaved_changes.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentApplyResult value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentApplyResult {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub success: Vec<bool>,
+            pub message: Vec<String>,
+            pub job_id: Vec<String>,
+            pub status: Vec<String>,
+            pub applied_segments: Vec<i32>,
+            pub project_has_unsaved_changes: Vec<bool>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentApplyResult".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "success" => intermediate_rep.success.push(
+                        <bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "message" => intermediate_rep.message.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "jobId" => intermediate_rep.job_id.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "status" => intermediate_rep.status.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "appliedSegments" => intermediate_rep.applied_segments.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "projectHasUnsavedChanges" => {
+                        intermediate_rep.project_has_unsaved_changes.push(
+                            <bool as std::str::FromStr>::from_str(val)
+                                .map_err(|x| x.to_string())?,
+                        )
+                    }
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentApplyResult".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentApplyResult {
+            success: intermediate_rep
+                .success
+                .into_iter()
+                .next()
+                .ok_or_else(|| "success missing in AgentApplyResult".to_string())?,
+            message: intermediate_rep.message.into_iter().next(),
+            job_id: intermediate_rep
+                .job_id
+                .into_iter()
+                .next()
+                .ok_or_else(|| "jobId missing in AgentApplyResult".to_string())?,
+            status: intermediate_rep
+                .status
+                .into_iter()
+                .next()
+                .ok_or_else(|| "status missing in AgentApplyResult".to_string())?,
+            applied_segments: intermediate_rep
+                .applied_segments
+                .into_iter()
+                .next()
+                .ok_or_else(|| "appliedSegments missing in AgentApplyResult".to_string())?,
+            project_has_unsaved_changes: intermediate_rep
+                .project_has_unsaved_changes
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "projectHasUnsavedChanges missing in AgentApplyResult".to_string()
+                })?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentApplyResult> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentApplyResult>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentApplyResult>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentApplyResult - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentApplyResult> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentApplyResult as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentApplyResult - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+#[allow(non_camel_case_types, clippy::large_enum_variant)]
+pub enum AgentArtifactReference {
+    AgentArtifactReferenceAnyOf(models::AgentArtifactReferenceAnyOf),
+    AgentArtifactReferenceAnyOf1(models::AgentArtifactReferenceAnyOf1),
+    AgentArtifactReferenceAnyOf2(models::AgentArtifactReferenceAnyOf2),
+    AgentArtifactReferenceAnyOf3(models::AgentArtifactReferenceAnyOf3),
+    AgentArtifactReferenceAnyOf4(models::AgentArtifactReferenceAnyOf4),
+    AgentArtifactReferenceAnyOf5(models::AgentArtifactReferenceAnyOf5),
+}
+
+impl validator::Validate for AgentArtifactReference {
+    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+        match self {
+            Self::AgentArtifactReferenceAnyOf(v) => v.validate(),
+            Self::AgentArtifactReferenceAnyOf1(v) => v.validate(),
+            Self::AgentArtifactReferenceAnyOf2(v) => v.validate(),
+            Self::AgentArtifactReferenceAnyOf3(v) => v.validate(),
+            Self::AgentArtifactReferenceAnyOf4(v) => v.validate(),
+            Self::AgentArtifactReferenceAnyOf5(v) => v.validate(),
+        }
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentArtifactReference value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentArtifactReference {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl From<models::AgentArtifactReferenceAnyOf> for AgentArtifactReference {
+    fn from(value: models::AgentArtifactReferenceAnyOf) -> Self {
+        Self::AgentArtifactReferenceAnyOf(value)
+    }
+}
+impl From<models::AgentArtifactReferenceAnyOf1> for AgentArtifactReference {
+    fn from(value: models::AgentArtifactReferenceAnyOf1) -> Self {
+        Self::AgentArtifactReferenceAnyOf1(value)
+    }
+}
+impl From<models::AgentArtifactReferenceAnyOf2> for AgentArtifactReference {
+    fn from(value: models::AgentArtifactReferenceAnyOf2) -> Self {
+        Self::AgentArtifactReferenceAnyOf2(value)
+    }
+}
+impl From<models::AgentArtifactReferenceAnyOf3> for AgentArtifactReference {
+    fn from(value: models::AgentArtifactReferenceAnyOf3) -> Self {
+        Self::AgentArtifactReferenceAnyOf3(value)
+    }
+}
+impl From<models::AgentArtifactReferenceAnyOf4> for AgentArtifactReference {
+    fn from(value: models::AgentArtifactReferenceAnyOf4) -> Self {
+        Self::AgentArtifactReferenceAnyOf4(value)
+    }
+}
+impl From<models::AgentArtifactReferenceAnyOf5> for AgentArtifactReference {
+    fn from(value: models::AgentArtifactReferenceAnyOf5) -> Self {
+        Self::AgentArtifactReferenceAnyOf5(value)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentArtifactReferenceAnyOf {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "kind")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub kind: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "path")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub path: String,
+
+    #[serde(rename = "sha256")]
+    #[validate(custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+impl AgentArtifactReferenceAnyOf {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(kind: String, path: String) -> AgentArtifactReferenceAnyOf {
+        AgentArtifactReferenceAnyOf {
+            kind,
+            path,
+            sha256: None,
+        }
+    }
+}
+
+/// Converts the AgentArtifactReferenceAnyOf value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentArtifactReferenceAnyOf {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("kind".to_string()),
+            Some(self.kind.to_string()),
+            Some("path".to_string()),
+            Some(self.path.to_string()),
+            self.sha256
+                .as_ref()
+                .map(|sha256| ["sha256".to_string(), sha256.to_string()].join(",")),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentArtifactReferenceAnyOf value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentArtifactReferenceAnyOf {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub kind: Vec<String>,
+            pub path: Vec<String>,
+            pub sha256: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentArtifactReferenceAnyOf".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "kind" => intermediate_rep.kind.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "path" => intermediate_rep.path.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "sha256" => intermediate_rep.sha256.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentArtifactReferenceAnyOf".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentArtifactReferenceAnyOf {
+            kind: intermediate_rep
+                .kind
+                .into_iter()
+                .next()
+                .ok_or_else(|| "kind missing in AgentArtifactReferenceAnyOf".to_string())?,
+            path: intermediate_rep
+                .path
+                .into_iter()
+                .next()
+                .ok_or_else(|| "path missing in AgentArtifactReferenceAnyOf".to_string())?,
+            sha256: intermediate_rep.sha256.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentArtifactReferenceAnyOf> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentArtifactReferenceAnyOf>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentArtifactReferenceAnyOf>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentArtifactReferenceAnyOf - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentArtifactReferenceAnyOf> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentArtifactReferenceAnyOf as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentArtifactReferenceAnyOf - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentArtifactReferenceAnyOf1 {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "kind")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub kind: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "path")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub path: String,
+
+    #[serde(rename = "sha256")]
+    #[validate(custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+impl AgentArtifactReferenceAnyOf1 {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(kind: String, path: String) -> AgentArtifactReferenceAnyOf1 {
+        AgentArtifactReferenceAnyOf1 {
+            kind,
+            path,
+            sha256: None,
+        }
+    }
+}
+
+/// Converts the AgentArtifactReferenceAnyOf1 value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentArtifactReferenceAnyOf1 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("kind".to_string()),
+            Some(self.kind.to_string()),
+            Some("path".to_string()),
+            Some(self.path.to_string()),
+            self.sha256
+                .as_ref()
+                .map(|sha256| ["sha256".to_string(), sha256.to_string()].join(",")),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentArtifactReferenceAnyOf1 value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentArtifactReferenceAnyOf1 {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub kind: Vec<String>,
+            pub path: Vec<String>,
+            pub sha256: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentArtifactReferenceAnyOf1".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "kind" => intermediate_rep.kind.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "path" => intermediate_rep.path.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "sha256" => intermediate_rep.sha256.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentArtifactReferenceAnyOf1".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentArtifactReferenceAnyOf1 {
+            kind: intermediate_rep
+                .kind
+                .into_iter()
+                .next()
+                .ok_or_else(|| "kind missing in AgentArtifactReferenceAnyOf1".to_string())?,
+            path: intermediate_rep
+                .path
+                .into_iter()
+                .next()
+                .ok_or_else(|| "path missing in AgentArtifactReferenceAnyOf1".to_string())?,
+            sha256: intermediate_rep.sha256.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentArtifactReferenceAnyOf1> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentArtifactReferenceAnyOf1>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentArtifactReferenceAnyOf1>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentArtifactReferenceAnyOf1 - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentArtifactReferenceAnyOf1> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentArtifactReferenceAnyOf1 as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentArtifactReferenceAnyOf1 - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentArtifactReferenceAnyOf2 {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "kind")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub kind: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "path")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub path: String,
+
+    #[serde(rename = "sha256")]
+    #[validate(custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+impl AgentArtifactReferenceAnyOf2 {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(kind: String, path: String) -> AgentArtifactReferenceAnyOf2 {
+        AgentArtifactReferenceAnyOf2 {
+            kind,
+            path,
+            sha256: None,
+        }
+    }
+}
+
+/// Converts the AgentArtifactReferenceAnyOf2 value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentArtifactReferenceAnyOf2 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("kind".to_string()),
+            Some(self.kind.to_string()),
+            Some("path".to_string()),
+            Some(self.path.to_string()),
+            self.sha256
+                .as_ref()
+                .map(|sha256| ["sha256".to_string(), sha256.to_string()].join(",")),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentArtifactReferenceAnyOf2 value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentArtifactReferenceAnyOf2 {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub kind: Vec<String>,
+            pub path: Vec<String>,
+            pub sha256: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentArtifactReferenceAnyOf2".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "kind" => intermediate_rep.kind.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "path" => intermediate_rep.path.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "sha256" => intermediate_rep.sha256.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentArtifactReferenceAnyOf2".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentArtifactReferenceAnyOf2 {
+            kind: intermediate_rep
+                .kind
+                .into_iter()
+                .next()
+                .ok_or_else(|| "kind missing in AgentArtifactReferenceAnyOf2".to_string())?,
+            path: intermediate_rep
+                .path
+                .into_iter()
+                .next()
+                .ok_or_else(|| "path missing in AgentArtifactReferenceAnyOf2".to_string())?,
+            sha256: intermediate_rep.sha256.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentArtifactReferenceAnyOf2> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentArtifactReferenceAnyOf2>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentArtifactReferenceAnyOf2>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentArtifactReferenceAnyOf2 - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentArtifactReferenceAnyOf2> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentArtifactReferenceAnyOf2 as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentArtifactReferenceAnyOf2 - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentArtifactReferenceAnyOf3 {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "kind")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub kind: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "path")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub path: String,
+
+    #[serde(rename = "sha256")]
+    #[validate(custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+impl AgentArtifactReferenceAnyOf3 {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(kind: String, path: String) -> AgentArtifactReferenceAnyOf3 {
+        AgentArtifactReferenceAnyOf3 {
+            kind,
+            path,
+            sha256: None,
+        }
+    }
+}
+
+/// Converts the AgentArtifactReferenceAnyOf3 value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentArtifactReferenceAnyOf3 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("kind".to_string()),
+            Some(self.kind.to_string()),
+            Some("path".to_string()),
+            Some(self.path.to_string()),
+            self.sha256
+                .as_ref()
+                .map(|sha256| ["sha256".to_string(), sha256.to_string()].join(",")),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentArtifactReferenceAnyOf3 value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentArtifactReferenceAnyOf3 {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub kind: Vec<String>,
+            pub path: Vec<String>,
+            pub sha256: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentArtifactReferenceAnyOf3".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "kind" => intermediate_rep.kind.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "path" => intermediate_rep.path.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "sha256" => intermediate_rep.sha256.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentArtifactReferenceAnyOf3".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentArtifactReferenceAnyOf3 {
+            kind: intermediate_rep
+                .kind
+                .into_iter()
+                .next()
+                .ok_or_else(|| "kind missing in AgentArtifactReferenceAnyOf3".to_string())?,
+            path: intermediate_rep
+                .path
+                .into_iter()
+                .next()
+                .ok_or_else(|| "path missing in AgentArtifactReferenceAnyOf3".to_string())?,
+            sha256: intermediate_rep.sha256.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentArtifactReferenceAnyOf3> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentArtifactReferenceAnyOf3>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentArtifactReferenceAnyOf3>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentArtifactReferenceAnyOf3 - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentArtifactReferenceAnyOf3> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentArtifactReferenceAnyOf3 as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentArtifactReferenceAnyOf3 - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentArtifactReferenceAnyOf4 {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "kind")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub kind: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "path")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub path: String,
+
+    #[serde(rename = "sha256")]
+    #[validate(custom(function = "check_xss_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sha256: Option<String>,
+}
+
+impl AgentArtifactReferenceAnyOf4 {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(kind: String, path: String) -> AgentArtifactReferenceAnyOf4 {
+        AgentArtifactReferenceAnyOf4 {
+            kind,
+            path,
+            sha256: None,
+        }
+    }
+}
+
+/// Converts the AgentArtifactReferenceAnyOf4 value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentArtifactReferenceAnyOf4 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("kind".to_string()),
+            Some(self.kind.to_string()),
+            Some("path".to_string()),
+            Some(self.path.to_string()),
+            self.sha256
+                .as_ref()
+                .map(|sha256| ["sha256".to_string(), sha256.to_string()].join(",")),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentArtifactReferenceAnyOf4 value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentArtifactReferenceAnyOf4 {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub kind: Vec<String>,
+            pub path: Vec<String>,
+            pub sha256: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentArtifactReferenceAnyOf4".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "kind" => intermediate_rep.kind.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "path" => intermediate_rep.path.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "sha256" => intermediate_rep.sha256.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentArtifactReferenceAnyOf4".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentArtifactReferenceAnyOf4 {
+            kind: intermediate_rep
+                .kind
+                .into_iter()
+                .next()
+                .ok_or_else(|| "kind missing in AgentArtifactReferenceAnyOf4".to_string())?,
+            path: intermediate_rep
+                .path
+                .into_iter()
+                .next()
+                .ok_or_else(|| "path missing in AgentArtifactReferenceAnyOf4".to_string())?,
+            sha256: intermediate_rep.sha256.into_iter().next(),
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentArtifactReferenceAnyOf4> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentArtifactReferenceAnyOf4>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentArtifactReferenceAnyOf4>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentArtifactReferenceAnyOf4 - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentArtifactReferenceAnyOf4> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentArtifactReferenceAnyOf4 as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentArtifactReferenceAnyOf4 - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentArtifactReferenceAnyOf5 {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "kind")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub kind: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "path")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub path: String,
+}
+
+impl AgentArtifactReferenceAnyOf5 {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(kind: String, path: String) -> AgentArtifactReferenceAnyOf5 {
+        AgentArtifactReferenceAnyOf5 { kind, path }
+    }
+}
+
+/// Converts the AgentArtifactReferenceAnyOf5 value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentArtifactReferenceAnyOf5 {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("kind".to_string()),
+            Some(self.kind.to_string()),
+            Some("path".to_string()),
+            Some(self.path.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentArtifactReferenceAnyOf5 value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentArtifactReferenceAnyOf5 {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub kind: Vec<String>,
+            pub path: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentArtifactReferenceAnyOf5".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "kind" => intermediate_rep.kind.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "path" => intermediate_rep.path.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentArtifactReferenceAnyOf5".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentArtifactReferenceAnyOf5 {
+            kind: intermediate_rep
+                .kind
+                .into_iter()
+                .next()
+                .ok_or_else(|| "kind missing in AgentArtifactReferenceAnyOf5".to_string())?,
+            path: intermediate_rep
+                .path
+                .into_iter()
+                .next()
+                .ok_or_else(|| "path missing in AgentArtifactReferenceAnyOf5".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentArtifactReferenceAnyOf5> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentArtifactReferenceAnyOf5>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentArtifactReferenceAnyOf5>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentArtifactReferenceAnyOf5 - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentArtifactReferenceAnyOf5> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentArtifactReferenceAnyOf5 as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentArtifactReferenceAnyOf5 - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentCutPlanSegment {
+    #[serde(rename = "id")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub id: String,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "beat")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub beat: String,
+
+    #[serde(rename = "startFrame")]
+    pub start_frame: i32,
+
+    #[serde(rename = "endFrame")]
+    pub end_frame: i32,
+}
+
+impl AgentCutPlanSegment {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(id: String, beat: String, start_frame: i32, end_frame: i32) -> AgentCutPlanSegment {
+        AgentCutPlanSegment {
+            id,
+            beat,
+            start_frame,
+            end_frame,
+        }
+    }
+}
+
+/// Converts the AgentCutPlanSegment value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentCutPlanSegment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("id".to_string()),
+            Some(self.id.to_string()),
+            Some("beat".to_string()),
+            Some(self.beat.to_string()),
+            Some("startFrame".to_string()),
+            Some(self.start_frame.to_string()),
+            Some("endFrame".to_string()),
+            Some(self.end_frame.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentCutPlanSegment value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentCutPlanSegment {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub id: Vec<String>,
+            pub beat: Vec<String>,
+            pub start_frame: Vec<i32>,
+            pub end_frame: Vec<i32>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentCutPlanSegment".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "id" => intermediate_rep.id.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "beat" => intermediate_rep.beat.push(
+                        <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "startFrame" => intermediate_rep.start_frame.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "endFrame" => intermediate_rep.end_frame.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentCutPlanSegment".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentCutPlanSegment {
+            id: intermediate_rep
+                .id
+                .into_iter()
+                .next()
+                .ok_or_else(|| "id missing in AgentCutPlanSegment".to_string())?,
+            beat: intermediate_rep
+                .beat
+                .into_iter()
+                .next()
+                .ok_or_else(|| "beat missing in AgentCutPlanSegment".to_string())?,
+            start_frame: intermediate_rep
+                .start_frame
+                .into_iter()
+                .next()
+                .ok_or_else(|| "startFrame missing in AgentCutPlanSegment".to_string())?,
+            end_frame: intermediate_rep
+                .end_frame
+                .into_iter()
+                .next()
+                .ok_or_else(|| "endFrame missing in AgentCutPlanSegment".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentCutPlanSegment> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentCutPlanSegment>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentCutPlanSegment>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentCutPlanSegment - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentCutPlanSegment> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentCutPlanSegment as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentCutPlanSegment - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentCutPlanSummary {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "version")]
+    pub version: f64,
+
+    #[serde(rename = "sourceFps")]
+    #[validate(nested)]
+    pub source_fps: models::AgentFrameRate,
+
+    #[serde(rename = "sourceFrameCount")]
+    pub source_frame_count: i32,
+
+    #[serde(rename = "segments")]
+    #[validate(nested)]
+    pub segments: Vec<models::AgentCutPlanSegment>,
+}
+
+impl AgentCutPlanSummary {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(
+        version: f64,
+        source_fps: models::AgentFrameRate,
+        source_frame_count: i32,
+        segments: Vec<models::AgentCutPlanSegment>,
+    ) -> AgentCutPlanSummary {
+        AgentCutPlanSummary {
+            version,
+            source_fps,
+            source_frame_count,
+            segments,
+        }
+    }
+}
+
+/// Converts the AgentCutPlanSummary value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentCutPlanSummary {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("version".to_string()),
+            Some(self.version.to_string()),
+            // Skipping sourceFps in query parameter serialization
+            Some("sourceFrameCount".to_string()),
+            Some(self.source_frame_count.to_string()),
+            // Skipping segments in query parameter serialization
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentCutPlanSummary value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentCutPlanSummary {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub version: Vec<f64>,
+            pub source_fps: Vec<models::AgentFrameRate>,
+            pub source_frame_count: Vec<i32>,
+            pub segments: Vec<Vec<models::AgentCutPlanSegment>>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentCutPlanSummary".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "version" => intermediate_rep.version.push(
+                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "sourceFps" => intermediate_rep.source_fps.push(
+                        <models::AgentFrameRate as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "sourceFrameCount" => intermediate_rep.source_frame_count.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    "segments" => return std::result::Result::Err(
+                        "Parsing a container in this style is not supported in AgentCutPlanSummary"
+                            .to_string(),
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentCutPlanSummary".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentCutPlanSummary {
+            version: intermediate_rep
+                .version
+                .into_iter()
+                .next()
+                .ok_or_else(|| "version missing in AgentCutPlanSummary".to_string())?,
+            source_fps: intermediate_rep
+                .source_fps
+                .into_iter()
+                .next()
+                .ok_or_else(|| "sourceFps missing in AgentCutPlanSummary".to_string())?,
+            source_frame_count: intermediate_rep
+                .source_frame_count
+                .into_iter()
+                .next()
+                .ok_or_else(|| "sourceFrameCount missing in AgentCutPlanSummary".to_string())?,
+            segments: intermediate_rep
+                .segments
+                .into_iter()
+                .next()
+                .ok_or_else(|| "segments missing in AgentCutPlanSummary".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentCutPlanSummary> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentCutPlanSummary>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentCutPlanSummary>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentCutPlanSummary - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentCutPlanSummary> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentCutPlanSummary as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentCutPlanSummary - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentFrameRate {
+    #[serde(rename = "numerator")]
+    pub numerator: i32,
+
+    #[serde(rename = "denominator")]
+    pub denominator: i32,
+}
+
+impl AgentFrameRate {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(numerator: i32, denominator: i32) -> AgentFrameRate {
+        AgentFrameRate {
+            numerator,
+            denominator,
+        }
+    }
+}
+
+/// Converts the AgentFrameRate value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentFrameRate {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("numerator".to_string()),
+            Some(self.numerator.to_string()),
+            Some("denominator".to_string()),
+            Some(self.denominator.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentFrameRate value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentFrameRate {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub numerator: Vec<i32>,
+            pub denominator: Vec<i32>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentFrameRate".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "numerator" => intermediate_rep.numerator.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "denominator" => intermediate_rep.denominator.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    _ => {
+                        return std::result::Result::Err(
+                            "Unexpected key while parsing AgentFrameRate".to_string(),
+                        );
+                    }
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentFrameRate {
+            numerator: intermediate_rep
+                .numerator
+                .into_iter()
+                .next()
+                .ok_or_else(|| "numerator missing in AgentFrameRate".to_string())?,
+            denominator: intermediate_rep
+                .denominator
+                .into_iter()
+                .next()
+                .ok_or_else(|| "denominator missing in AgentFrameRate".to_string())?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentFrameRate> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentFrameRate>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentFrameRate>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentFrameRate - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentFrameRate> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentFrameRate as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentFrameRate - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
+pub struct AgentPreflightBlockedResult {
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "ready")]
+    pub ready: bool,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "blockingReasons")]
+    #[validate(length(min = 1), custom(function = "check_xss_vec_string"))]
+    pub blocking_reasons: Vec<String>,
+
+    #[serde(rename = "canApplyDestructive")]
+    pub can_apply_destructive: bool,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "transcriptionProvider")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub transcription_provider: String,
+}
+
+impl AgentPreflightBlockedResult {
+    #[allow(clippy::new_without_default, clippy::too_many_arguments)]
+    pub fn new(
+        ready: bool,
+        blocking_reasons: Vec<String>,
+        can_apply_destructive: bool,
+        transcription_provider: String,
+    ) -> AgentPreflightBlockedResult {
+        AgentPreflightBlockedResult {
+            ready,
+            blocking_reasons,
+            can_apply_destructive,
+            transcription_provider,
+        }
+    }
+}
+
+/// Converts the AgentPreflightBlockedResult value to the Query Parameters representation (style=form, explode=false)
+/// specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde serializer
+impl std::fmt::Display for AgentPreflightBlockedResult {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let params: Vec<Option<String>> = vec![
+            Some("ready".to_string()),
+            Some(self.ready.to_string()),
+            Some("blockingReasons".to_string()),
+            Some(
+                self.blocking_reasons
+                    .iter()
+                    .map(|x| x.to_string())
+                    .collect::<Vec<_>>()
+                    .join(","),
+            ),
+            Some("canApplyDestructive".to_string()),
+            Some(self.can_apply_destructive.to_string()),
+            Some("transcriptionProvider".to_string()),
+            Some(self.transcription_provider.to_string()),
+        ];
+
+        write!(
+            f,
+            "{}",
+            params.into_iter().flatten().collect::<Vec<_>>().join(",")
+        )
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentPreflightBlockedResult value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentPreflightBlockedResult {
+    type Err = String;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        /// An intermediate representation of the struct to use for parsing.
+        #[derive(Default)]
+        #[allow(dead_code)]
+        struct IntermediateRep {
+            pub ready: Vec<bool>,
+            pub blocking_reasons: Vec<Vec<String>>,
+            pub can_apply_destructive: Vec<bool>,
+            pub transcription_provider: Vec<String>,
+        }
+
+        let mut intermediate_rep = IntermediateRep::default();
+
+        // Parse into intermediate representation
+        let mut string_iter = s.split(',');
+        let mut key_result = string_iter.next();
+
+        while key_result.is_some() {
+            let val = match string_iter.next() {
+                Some(x) => x,
+                None => {
+                    return std::result::Result::Err(
+                        "Missing value while parsing AgentPreflightBlockedResult".to_string(),
+                    );
+                }
+            };
+
+            if let Some(key) = key_result {
+                #[allow(clippy::match_single_binding)]
+                match key {
+                    #[allow(clippy::redundant_clone)]
+                    "ready" => intermediate_rep.ready.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    "blockingReasons" => return std::result::Result::Err("Parsing a container in this style is not supported in AgentPreflightBlockedResult".to_string()),
+                    #[allow(clippy::redundant_clone)]
+                    "canApplyDestructive" => intermediate_rep.can_apply_destructive.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    #[allow(clippy::redundant_clone)]
+                    "transcriptionProvider" => intermediate_rep.transcription_provider.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing AgentPreflightBlockedResult".to_string())
+                }
+            }
+
+            // Get the next key
+            key_result = string_iter.next();
+        }
+
+        // Use the intermediate representation to return the struct
+        std::result::Result::Ok(AgentPreflightBlockedResult {
+            ready: intermediate_rep
+                .ready
+                .into_iter()
+                .next()
+                .ok_or_else(|| "ready missing in AgentPreflightBlockedResult".to_string())?,
+            blocking_reasons: intermediate_rep
+                .blocking_reasons
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "blockingReasons missing in AgentPreflightBlockedResult".to_string()
+                })?,
+            can_apply_destructive: intermediate_rep
+                .can_apply_destructive
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "canApplyDestructive missing in AgentPreflightBlockedResult".to_string()
+                })?,
+            transcription_provider: intermediate_rep
+                .transcription_provider
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "transcriptionProvider missing in AgentPreflightBlockedResult".to_string()
+                })?,
+        })
+    }
+}
+
+// Methods for converting between header::IntoHeaderValue<AgentPreflightBlockedResult> and HeaderValue
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentPreflightBlockedResult>> for HeaderValue {
+    type Error = String;
+
+    fn try_from(
+        hdr_value: header::IntoHeaderValue<AgentPreflightBlockedResult>,
+    ) -> std::result::Result<Self, Self::Error> {
+        let hdr_value = hdr_value.to_string();
+        match HeaderValue::from_str(&hdr_value) {
+            std::result::Result::Ok(value) => std::result::Result::Ok(value),
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Invalid header value for AgentPreflightBlockedResult - value: {hdr_value} is invalid {e}"#
+            )),
+        }
+    }
+}
+
+#[cfg(feature = "server")]
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentPreflightBlockedResult> {
+    type Error = String;
+
+    fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
+        match hdr_value.to_str() {
+            std::result::Result::Ok(value) => {
+                match <AgentPreflightBlockedResult as std::str::FromStr>::from_str(value) {
+                    std::result::Result::Ok(value) => {
+                        std::result::Result::Ok(header::IntoHeaderValue(value))
+                    }
+                    std::result::Result::Err(err) => std::result::Result::Err(format!(
+                        r#"Unable to convert header value '{value}' into AgentPreflightBlockedResult - {err}"#
+                    )),
+                }
+            }
+            std::result::Result::Err(e) => std::result::Result::Err(format!(
+                r#"Unable to convert header: {hdr_value:?} to string: {e}"#
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
+#[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AgentPreflightPayload {
     #[serde(rename = "runtimeBudgetMinutes")]
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -595,7 +2623,8 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentPreflig
 
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
-pub struct AgentPreflightResult {
+pub struct AgentPreflightReadyResult {
+    /// Note: inline enums are not fully supported by openapi-generator
     #[serde(rename = "ready")]
     pub ready: bool,
 
@@ -614,32 +2643,38 @@ pub struct AgentPreflightResult {
 
     #[serde(rename = "preflightToken")]
     #[validate(custom(function = "check_xss_string"))]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub preflight_token: Option<String>,
+    pub preflight_token: String,
+
+    #[serde(rename = "preflightTokenExpiresAt")]
+    #[validate(custom(function = "check_xss_string"))]
+    pub preflight_token_expires_at: String,
 }
 
-impl AgentPreflightResult {
+impl AgentPreflightReadyResult {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
     pub fn new(
         ready: bool,
         blocking_reasons: Vec<String>,
         can_apply_destructive: bool,
         transcription_provider: String,
-    ) -> AgentPreflightResult {
-        AgentPreflightResult {
+        preflight_token: String,
+        preflight_token_expires_at: String,
+    ) -> AgentPreflightReadyResult {
+        AgentPreflightReadyResult {
             ready,
             blocking_reasons,
             can_apply_destructive,
             transcription_provider,
-            preflight_token: None,
+            preflight_token,
+            preflight_token_expires_at,
         }
     }
 }
 
-/// Converts the AgentPreflightResult value to the Query Parameters representation (style=form, explode=false)
+/// Converts the AgentPreflightReadyResult value to the Query Parameters representation (style=form, explode=false)
 /// specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde serializer
-impl std::fmt::Display for AgentPreflightResult {
+impl std::fmt::Display for AgentPreflightReadyResult {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let params: Vec<Option<String>> = vec![
             Some("ready".to_string()),
@@ -656,9 +2691,10 @@ impl std::fmt::Display for AgentPreflightResult {
             Some(self.can_apply_destructive.to_string()),
             Some("transcriptionProvider".to_string()),
             Some(self.transcription_provider.to_string()),
-            self.preflight_token.as_ref().map(|preflight_token| {
-                ["preflightToken".to_string(), preflight_token.to_string()].join(",")
-            }),
+            Some("preflightToken".to_string()),
+            Some(self.preflight_token.to_string()),
+            Some("preflightTokenExpiresAt".to_string()),
+            Some(self.preflight_token_expires_at.to_string()),
         ];
 
         write!(
@@ -669,10 +2705,10 @@ impl std::fmt::Display for AgentPreflightResult {
     }
 }
 
-/// Converts Query Parameters representation (style=form, explode=false) to a AgentPreflightResult value
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentPreflightReadyResult value
 /// as specified in https://swagger.io/docs/specification/serialization/
 /// Should be implemented in a serde deserializer
-impl std::str::FromStr for AgentPreflightResult {
+impl std::str::FromStr for AgentPreflightReadyResult {
     type Err = String;
 
     fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
@@ -685,6 +2721,7 @@ impl std::str::FromStr for AgentPreflightResult {
             pub can_apply_destructive: Vec<bool>,
             pub transcription_provider: Vec<String>,
             pub preflight_token: Vec<String>,
+            pub preflight_token_expires_at: Vec<String>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -698,7 +2735,7 @@ impl std::str::FromStr for AgentPreflightResult {
                 Some(x) => x,
                 None => {
                     return std::result::Result::Err(
-                        "Missing value while parsing AgentPreflightResult".to_string(),
+                        "Missing value while parsing AgentPreflightReadyResult".to_string(),
                     );
                 }
             };
@@ -708,14 +2745,16 @@ impl std::str::FromStr for AgentPreflightResult {
                 match key {
                     #[allow(clippy::redundant_clone)]
                     "ready" => intermediate_rep.ready.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
-                    "blockingReasons" => return std::result::Result::Err("Parsing a container in this style is not supported in AgentPreflightResult".to_string()),
+                    "blockingReasons" => return std::result::Result::Err("Parsing a container in this style is not supported in AgentPreflightReadyResult".to_string()),
                     #[allow(clippy::redundant_clone)]
                     "canApplyDestructive" => intermediate_rep.can_apply_destructive.push(<bool as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
                     "transcriptionProvider" => intermediate_rep.transcription_provider.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
                     #[allow(clippy::redundant_clone)]
                     "preflightToken" => intermediate_rep.preflight_token.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
-                    _ => return std::result::Result::Err("Unexpected key while parsing AgentPreflightResult".to_string())
+                    #[allow(clippy::redundant_clone)]
+                    "preflightTokenExpiresAt" => intermediate_rep.preflight_token_expires_at.push(<String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?),
+                    _ => return std::result::Result::Err("Unexpected key while parsing AgentPreflightReadyResult".to_string())
                 }
             }
 
@@ -724,66 +2763,81 @@ impl std::str::FromStr for AgentPreflightResult {
         }
 
         // Use the intermediate representation to return the struct
-        std::result::Result::Ok(AgentPreflightResult {
+        std::result::Result::Ok(AgentPreflightReadyResult {
             ready: intermediate_rep
                 .ready
                 .into_iter()
                 .next()
-                .ok_or_else(|| "ready missing in AgentPreflightResult".to_string())?,
+                .ok_or_else(|| "ready missing in AgentPreflightReadyResult".to_string())?,
             blocking_reasons: intermediate_rep
                 .blocking_reasons
                 .into_iter()
                 .next()
-                .ok_or_else(|| "blockingReasons missing in AgentPreflightResult".to_string())?,
+                .ok_or_else(|| {
+                    "blockingReasons missing in AgentPreflightReadyResult".to_string()
+                })?,
             can_apply_destructive: intermediate_rep
                 .can_apply_destructive
                 .into_iter()
                 .next()
-                .ok_or_else(|| "canApplyDestructive missing in AgentPreflightResult".to_string())?,
+                .ok_or_else(|| {
+                    "canApplyDestructive missing in AgentPreflightReadyResult".to_string()
+                })?,
             transcription_provider: intermediate_rep
                 .transcription_provider
                 .into_iter()
                 .next()
                 .ok_or_else(|| {
-                    "transcriptionProvider missing in AgentPreflightResult".to_string()
+                    "transcriptionProvider missing in AgentPreflightReadyResult".to_string()
                 })?,
-            preflight_token: intermediate_rep.preflight_token.into_iter().next(),
+            preflight_token: intermediate_rep
+                .preflight_token
+                .into_iter()
+                .next()
+                .ok_or_else(|| "preflightToken missing in AgentPreflightReadyResult".to_string())?,
+            preflight_token_expires_at: intermediate_rep
+                .preflight_token_expires_at
+                .into_iter()
+                .next()
+                .ok_or_else(|| {
+                    "preflightTokenExpiresAt missing in AgentPreflightReadyResult".to_string()
+                })?,
         })
     }
 }
 
-// Methods for converting between header::IntoHeaderValue<AgentPreflightResult> and HeaderValue
+// Methods for converting between header::IntoHeaderValue<AgentPreflightReadyResult> and HeaderValue
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<header::IntoHeaderValue<AgentPreflightResult>> for HeaderValue {
+impl std::convert::TryFrom<header::IntoHeaderValue<AgentPreflightReadyResult>> for HeaderValue {
     type Error = String;
 
     fn try_from(
-        hdr_value: header::IntoHeaderValue<AgentPreflightResult>,
+        hdr_value: header::IntoHeaderValue<AgentPreflightReadyResult>,
     ) -> std::result::Result<Self, Self::Error> {
         let hdr_value = hdr_value.to_string();
         match HeaderValue::from_str(&hdr_value) {
             std::result::Result::Ok(value) => std::result::Result::Ok(value),
             std::result::Result::Err(e) => std::result::Result::Err(format!(
-                r#"Invalid header value for AgentPreflightResult - value: {hdr_value} is invalid {e}"#
+                r#"Invalid header value for AgentPreflightReadyResult - value: {hdr_value} is invalid {e}"#
             )),
         }
     }
 }
 
 #[cfg(feature = "server")]
-impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentPreflightResult> {
+impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentPreflightReadyResult> {
     type Error = String;
 
     fn try_from(hdr_value: HeaderValue) -> std::result::Result<Self, Self::Error> {
         match hdr_value.to_str() {
             std::result::Result::Ok(value) => {
-                match <AgentPreflightResult as std::str::FromStr>::from_str(value) {
+                match <AgentPreflightReadyResult as std::str::FromStr>::from_str(value) {
                     std::result::Result::Ok(value) => {
                         std::result::Result::Ok(header::IntoHeaderValue(value))
                     }
                     std::result::Result::Err(err) => std::result::Result::Err(format!(
-                        r#"Unable to convert header value '{value}' into AgentPreflightResult - {err}"#
+                        r#"Unable to convert header value '{value}' into AgentPreflightReadyResult - {err}"#
                     )),
                 }
             }
@@ -794,6 +2848,45 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentPreflig
     }
 }
 
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+#[allow(non_camel_case_types, clippy::large_enum_variant)]
+pub enum AgentPreflightResult {
+    AgentPreflightReadyResult(models::AgentPreflightReadyResult),
+    AgentPreflightBlockedResult(models::AgentPreflightBlockedResult),
+}
+
+impl validator::Validate for AgentPreflightResult {
+    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
+        match self {
+            Self::AgentPreflightReadyResult(v) => v.validate(),
+            Self::AgentPreflightBlockedResult(v) => v.validate(),
+        }
+    }
+}
+
+/// Converts Query Parameters representation (style=form, explode=false) to a AgentPreflightResult value
+/// as specified in https://swagger.io/docs/specification/serialization/
+/// Should be implemented in a serde deserializer
+impl std::str::FromStr for AgentPreflightResult {
+    type Err = serde_json::Error;
+
+    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
+        serde_json::from_str(s)
+    }
+}
+
+impl From<models::AgentPreflightReadyResult> for AgentPreflightResult {
+    fn from(value: models::AgentPreflightReadyResult) -> Self {
+        Self::AgentPreflightReadyResult(value)
+    }
+}
+impl From<models::AgentPreflightBlockedResult> for AgentPreflightResult {
+    fn from(value: models::AgentPreflightBlockedResult) -> Self {
+        Self::AgentPreflightBlockedResult(value)
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize, validator::Validate)]
 #[cfg_attr(feature = "conversion", derive(frunk::LabelledGeneric))]
 pub struct AgentQaReport {
@@ -801,8 +2894,7 @@ pub struct AgentQaReport {
     pub passed: bool,
 
     #[serde(rename = "score")]
-    #[validate(nested)]
-    pub score: models::AgentQaReportScore,
+    pub score: f64,
 
     #[serde(rename = "coverage")]
     #[validate(nested)]
@@ -817,11 +2909,7 @@ pub struct AgentQaReport {
 
 impl AgentQaReport {
     #[allow(clippy::new_without_default, clippy::too_many_arguments)]
-    pub fn new(
-        passed: bool,
-        score: models::AgentQaReportScore,
-        coverage: models::AgentQaReportCoverage,
-    ) -> AgentQaReport {
+    pub fn new(passed: bool, score: f64, coverage: models::AgentQaReportCoverage) -> AgentQaReport {
         AgentQaReport {
             passed,
             score,
@@ -839,8 +2927,8 @@ impl std::fmt::Display for AgentQaReport {
         let params: Vec<Option<String>> = vec![
             Some("passed".to_string()),
             Some(self.passed.to_string()),
-            // Skipping score in query parameter serialization
-
+            Some("score".to_string()),
+            Some(self.score.to_string()),
             // Skipping coverage in query parameter serialization
             self.missing_beats.as_ref().map(|missing_beats| {
                 [
@@ -875,7 +2963,7 @@ impl std::str::FromStr for AgentQaReport {
         #[allow(dead_code)]
         struct IntermediateRep {
             pub passed: Vec<bool>,
-            pub score: Vec<models::AgentQaReportScore>,
+            pub score: Vec<f64>,
             pub coverage: Vec<models::AgentQaReportCoverage>,
             pub missing_beats: Vec<Vec<String>>,
         }
@@ -905,8 +2993,7 @@ impl std::str::FromStr for AgentQaReport {
                     ),
                     #[allow(clippy::redundant_clone)]
                     "score" => intermediate_rep.score.push(
-                        <models::AgentQaReportScore as std::str::FromStr>::from_str(val)
-                            .map_err(|x| x.to_string())?,
+                        <f64 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
                     #[allow(clippy::redundant_clone)]
                     "coverage" => intermediate_rep.coverage.push(
@@ -1176,83 +3263,6 @@ impl std::convert::TryFrom<HeaderValue> for header::IntoHeaderValue<AgentQaRepor
                 r#"Unable to convert header: {hdr_value:?} to string: {e}"#
             )),
         }
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
-#[allow(non_camel_case_types, clippy::large_enum_variant)]
-pub enum AgentQaReportScore {
-    AgentQaReportScoreAnyOf(models::AgentQaReportScoreAnyOf),
-    String(String),
-}
-
-impl validator::Validate for AgentQaReportScore {
-    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
-        match self {
-            Self::AgentQaReportScoreAnyOf(v) => v.validate(),
-            Self::String(_) => std::result::Result::Ok(()),
-        }
-    }
-}
-
-/// Converts Query Parameters representation (style=form, explode=false) to a AgentQaReportScore value
-/// as specified in https://swagger.io/docs/specification/serialization/
-/// Should be implemented in a serde deserializer
-impl std::str::FromStr for AgentQaReportScore {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        serde_json::from_str(s)
-    }
-}
-
-impl From<models::AgentQaReportScoreAnyOf> for AgentQaReportScore {
-    fn from(value: models::AgentQaReportScoreAnyOf) -> Self {
-        Self::AgentQaReportScoreAnyOf(value)
-    }
-}
-impl From<String> for AgentQaReportScore {
-    fn from(value: String) -> Self {
-        Self::String(value)
-    }
-}
-
-#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
-#[serde(untagged)]
-#[allow(non_camel_case_types, clippy::large_enum_variant)]
-pub enum AgentQaReportScoreAnyOf {
-    F64(f64),
-    String(String),
-    String1(String),
-    String2(String),
-}
-
-impl validator::Validate for AgentQaReportScoreAnyOf {
-    fn validate(&self) -> std::result::Result<(), validator::ValidationErrors> {
-        match self {
-            Self::F64(_) => std::result::Result::Ok(()),
-            Self::String(_) => std::result::Result::Ok(()),
-            Self::String1(_) => std::result::Result::Ok(()),
-            Self::String2(_) => std::result::Result::Ok(()),
-        }
-    }
-}
-
-/// Converts Query Parameters representation (style=form, explode=false) to a AgentQaReportScoreAnyOf value
-/// as specified in https://swagger.io/docs/specification/serialization/
-/// Should be implemented in a serde deserializer
-impl std::str::FromStr for AgentQaReportScoreAnyOf {
-    type Err = serde_json::Error;
-
-    fn from_str(s: &str) -> std::result::Result<Self, Self::Err> {
-        serde_json::from_str(s)
-    }
-}
-
-impl From<f64> for AgentQaReportScoreAnyOf {
-    fn from(value: f64) -> Self {
-        Self::F64(value)
     }
 }
 
@@ -1648,6 +3658,16 @@ pub struct AgentRunSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub blocking_reason: Option<String>,
 
+    #[serde(rename = "artifacts")]
+    #[validate(nested)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifacts: Option<Vec<models::AgentArtifactReference>>,
+
+    #[serde(rename = "cutPlan")]
+    #[validate(nested)]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cut_plan: Option<models::AgentCutPlanSummary>,
+
     #[serde(rename = "updatedAt")]
     #[validate(custom(function = "check_xss_string"))]
     pub updated_at: String,
@@ -1667,6 +3687,8 @@ impl AgentRunSummary {
             runtime_budget_minutes,
             qa_report: None,
             blocking_reason: None,
+            artifacts: None,
+            cut_plan: None,
             updated_at,
         }
     }
@@ -1688,6 +3710,9 @@ impl std::fmt::Display for AgentRunSummary {
             self.blocking_reason.as_ref().map(|blocking_reason| {
                 ["blockingReason".to_string(), blocking_reason.to_string()].join(",")
             }),
+            // Skipping artifacts in query parameter serialization
+
+            // Skipping cutPlan in query parameter serialization
             Some("updatedAt".to_string()),
             Some(self.updated_at.to_string()),
         ];
@@ -1716,6 +3741,8 @@ impl std::str::FromStr for AgentRunSummary {
             pub runtime_budget_minutes: Vec<i32>,
             pub qa_report: Vec<models::AgentQaReport>,
             pub blocking_reason: Vec<String>,
+            pub artifacts: Vec<Vec<models::AgentArtifactReference>>,
+            pub cut_plan: Vec<models::AgentCutPlanSummary>,
             pub updated_at: Vec<String>,
         }
 
@@ -1759,6 +3786,17 @@ impl std::str::FromStr for AgentRunSummary {
                     "blockingReason" => intermediate_rep.blocking_reason.push(
                         <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
+                    "artifacts" => {
+                        return std::result::Result::Err(
+                            "Parsing a container in this style is not supported in AgentRunSummary"
+                                .to_string(),
+                        );
+                    }
+                    #[allow(clippy::redundant_clone)]
+                    "cutPlan" => intermediate_rep.cut_plan.push(
+                        <models::AgentCutPlanSummary as std::str::FromStr>::from_str(val)
+                            .map_err(|x| x.to_string())?,
+                    ),
                     #[allow(clippy::redundant_clone)]
                     "updatedAt" => intermediate_rep.updated_at.push(
                         <String as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
@@ -1794,6 +3832,8 @@ impl std::str::FromStr for AgentRunSummary {
                 .ok_or_else(|| "runtimeBudgetMinutes missing in AgentRunSummary".to_string())?,
             qa_report: intermediate_rep.qa_report.into_iter().next(),
             blocking_reason: intermediate_rep.blocking_reason.into_iter().next(),
+            artifacts: intermediate_rep.artifacts.into_iter().next(),
+            cut_plan: intermediate_rep.cut_plan.into_iter().next(),
             updated_at: intermediate_rep
                 .updated_at
                 .into_iter()
@@ -2272,6 +4312,28 @@ pub struct CapabilitiesAgent {
     #[serde(rename = "runtimeBudgetMinutes")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub runtime_budget_minutes: Option<i32>,
+
+    /// Note: inline enums are not fully supported by openapi-generator
+    #[serde(rename = "supportedTranscriptionProviders")]
+    #[validate(custom(function = "check_xss_vec_string"))]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub supported_transcription_providers: Option<Vec<String>>,
+
+    #[serde(rename = "maxSourceDurationSeconds")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_source_duration_seconds: Option<i32>,
+
+    #[serde(rename = "preflightTokenTtlSeconds")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub preflight_token_ttl_seconds: Option<i32>,
+
+    #[serde(rename = "artifactVersion")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub artifact_version: Option<i32>,
+
+    #[serde(rename = "cutPlanVersion")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cut_plan_version: Option<i32>,
 }
 
 impl CapabilitiesAgent {
@@ -2284,6 +4346,11 @@ impl CapabilitiesAgent {
             apply,
             local_only: None,
             runtime_budget_minutes: None,
+            supported_transcription_providers: None,
+            max_source_duration_seconds: None,
+            preflight_token_ttl_seconds: None,
+            artifact_version: None,
+            cut_plan_version: None,
         }
     }
 }
@@ -2314,6 +4381,43 @@ impl std::fmt::Display for CapabilitiesAgent {
                     ]
                     .join(",")
                 }),
+            self.supported_transcription_providers.as_ref().map(
+                |supported_transcription_providers| {
+                    [
+                        "supportedTranscriptionProviders".to_string(),
+                        supported_transcription_providers
+                            .iter()
+                            .map(|x| x.to_string())
+                            .collect::<Vec<_>>()
+                            .join(","),
+                    ]
+                    .join(",")
+                },
+            ),
+            self.max_source_duration_seconds
+                .as_ref()
+                .map(|max_source_duration_seconds| {
+                    [
+                        "maxSourceDurationSeconds".to_string(),
+                        max_source_duration_seconds.to_string(),
+                    ]
+                    .join(",")
+                }),
+            self.preflight_token_ttl_seconds
+                .as_ref()
+                .map(|preflight_token_ttl_seconds| {
+                    [
+                        "preflightTokenTtlSeconds".to_string(),
+                        preflight_token_ttl_seconds.to_string(),
+                    ]
+                    .join(",")
+                }),
+            self.artifact_version.as_ref().map(|artifact_version| {
+                ["artifactVersion".to_string(), artifact_version.to_string()].join(",")
+            }),
+            self.cut_plan_version.as_ref().map(|cut_plan_version| {
+                ["cutPlanVersion".to_string(), cut_plan_version.to_string()].join(",")
+            }),
         ];
 
         write!(
@@ -2341,6 +4445,11 @@ impl std::str::FromStr for CapabilitiesAgent {
             pub apply: Vec<bool>,
             pub local_only: Vec<bool>,
             pub runtime_budget_minutes: Vec<i32>,
+            pub supported_transcription_providers: Vec<Vec<String>>,
+            pub max_source_duration_seconds: Vec<i32>,
+            pub preflight_token_ttl_seconds: Vec<i32>,
+            pub artifact_version: Vec<i32>,
+            pub cut_plan_version: Vec<i32>,
         }
 
         let mut intermediate_rep = IntermediateRep::default();
@@ -2386,6 +4495,30 @@ impl std::str::FromStr for CapabilitiesAgent {
                     "runtimeBudgetMinutes" => intermediate_rep.runtime_budget_minutes.push(
                         <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
                     ),
+                    "supportedTranscriptionProviders" => return std::result::Result::Err(
+                        "Parsing a container in this style is not supported in CapabilitiesAgent"
+                            .to_string(),
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "maxSourceDurationSeconds" => {
+                        intermediate_rep.max_source_duration_seconds.push(
+                            <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                        )
+                    }
+                    #[allow(clippy::redundant_clone)]
+                    "preflightTokenTtlSeconds" => {
+                        intermediate_rep.preflight_token_ttl_seconds.push(
+                            <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                        )
+                    }
+                    #[allow(clippy::redundant_clone)]
+                    "artifactVersion" => intermediate_rep.artifact_version.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
+                    #[allow(clippy::redundant_clone)]
+                    "cutPlanVersion" => intermediate_rep.cut_plan_version.push(
+                        <i32 as std::str::FromStr>::from_str(val).map_err(|x| x.to_string())?,
+                    ),
                     _ => {
                         return std::result::Result::Err(
                             "Unexpected key while parsing CapabilitiesAgent".to_string(),
@@ -2422,6 +4555,20 @@ impl std::str::FromStr for CapabilitiesAgent {
                 .ok_or_else(|| "apply missing in CapabilitiesAgent".to_string())?,
             local_only: intermediate_rep.local_only.into_iter().next(),
             runtime_budget_minutes: intermediate_rep.runtime_budget_minutes.into_iter().next(),
+            supported_transcription_providers: intermediate_rep
+                .supported_transcription_providers
+                .into_iter()
+                .next(),
+            max_source_duration_seconds: intermediate_rep
+                .max_source_duration_seconds
+                .into_iter()
+                .next(),
+            preflight_token_ttl_seconds: intermediate_rep
+                .preflight_token_ttl_seconds
+                .into_iter()
+                .next(),
+            artifact_version: intermediate_rep.artifact_version.into_iter().next(),
+            cut_plan_version: intermediate_rep.cut_plan_version.into_iter().next(),
         })
     }
 }

--- a/engines/protocol-rust/src/server/mod.rs
+++ b/engines/protocol-rust/src/server/mod.rs
@@ -198,7 +198,7 @@ where
 
     let resp = match result {
                                             Ok(rsp) => match rsp {
-                                                apis::agent::AgentAgentApplyResponse::Status200_ActionResult
+                                                apis::agent::AgentAgentApplyResponse::Status200_AgentApplyResult
                                                     (body)
                                                 => {
                                                   let mut response = response.status(200);
@@ -476,42 +476,6 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::agent::AgentAgentPreflightResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::agent::AgentAgentPreflightResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(
@@ -916,6 +880,42 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
+                                                apis::agent::AgentAgentStatusResponse::Status409_EngineConflictErrorResponseBody
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(409);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::agent::AgentAgentStatusResponse::Status422_EngineUnprocessableErrorResponseBody
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(422);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
                                                 apis::agent::AgentAgentStatusResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -1237,42 +1237,6 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
-                                                apis::capture::CaptureCaptureStartCurrentWindowResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::capture::CaptureCaptureStartCurrentWindowResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
                                                 apis::capture::CaptureCaptureStartCurrentWindowResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -1440,42 +1404,6 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
-                                                apis::capture::CaptureCaptureStartDisplayResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::capture::CaptureCaptureStartDisplayResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
                                                 apis::capture::CaptureCaptureStartDisplayResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -1629,42 +1557,6 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::capture::CaptureCaptureStartWindowResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::capture::CaptureCaptureStartWindowResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(
@@ -1971,42 +1863,6 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::capture::CaptureCaptureStopResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::capture::CaptureCaptureStopResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(
@@ -2516,42 +2372,6 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
-                                                apis::export::ExportExportRunResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::export::ExportExportRunResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
                                                 apis::export::ExportExportRunResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -2705,6 +2525,24 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
+                                                  {
+                                                    let mut response_headers = response.headers_mut().unwrap();
+                                                    response_headers.insert(
+                                                        CONTENT_TYPE,
+                                                        HeaderValue::from_static("application/json"));
+                                                  }
+
+                                                  let body_content =  tokio::task::spawn_blocking(move ||
+                                                      serde_json::to_vec(&body).map_err(|e| {
+                                                        error!(error = ?e);
+                                                        StatusCode::INTERNAL_SERVER_ERROR
+                                                      })).await.unwrap()?;
+                                                  response.body(Body::from(body_content))
+                                                },
+                                                apis::export::ExportExportRunCutPlanResponse::Status404_EngineNotFoundErrorResponseBody
+                                                    (body)
+                                                => {
+                                                  let mut response = response.status(404);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(
@@ -3064,42 +2902,6 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
-                                                apis::permissions::PermissionsPermissionsOpenInputMonitoringSettingsResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::permissions::PermissionsPermissionsOpenInputMonitoringSettingsResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
                                                 apis::permissions::PermissionsPermissionsOpenInputMonitoringSettingsResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -3242,42 +3044,6 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::permissions::PermissionsPermissionsRequestInputMonitoringResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::permissions::PermissionsPermissionsRequestInputMonitoringResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(
@@ -3448,42 +3214,6 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
-                                                apis::permissions::PermissionsPermissionsRequestMicrophoneResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::permissions::PermissionsPermissionsRequestMicrophoneResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
                                                 apis::permissions::PermissionsPermissionsRequestMicrophoneResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -3626,42 +3356,6 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::permissions::PermissionsPermissionsRequestScreenRecordingResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::permissions::PermissionsPermissionsRequestScreenRecordingResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(
@@ -3981,42 +3675,6 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::project::ProjectProjectOpenResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::project::ProjectProjectOpenResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(
@@ -4356,42 +4014,6 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
-                                                apis::project::ProjectProjectSaveResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::project::ProjectProjectSaveResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
                                                 apis::project::ProjectProjectSaveResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -4559,42 +4181,6 @@ where
                                                       })).await.unwrap()?;
                                                   response.body(Body::from(body_content))
                                                 },
-                                                apis::recording::RecordingRecordingStartResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::recording::RecordingRecordingStartResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
                                                 apis::recording::RecordingRecordingStartResponse::Status500_EngineRuntimeErrorResponseBody
                                                     (body)
                                                 => {
@@ -4734,42 +4320,6 @@ where
                                                     (body)
                                                 => {
                                                   let mut response = response.status(403);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::recording::RecordingRecordingStopResponse::Status409_EngineConflictErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(409);
-                                                  {
-                                                    let mut response_headers = response.headers_mut().unwrap();
-                                                    response_headers.insert(
-                                                        CONTENT_TYPE,
-                                                        HeaderValue::from_static("application/json"));
-                                                  }
-
-                                                  let body_content =  tokio::task::spawn_blocking(move ||
-                                                      serde_json::to_vec(&body).map_err(|e| {
-                                                        error!(error = ?e);
-                                                        StatusCode::INTERNAL_SERVER_ERROR
-                                                      })).await.unwrap()?;
-                                                  response.body(Body::from(body_content))
-                                                },
-                                                apis::recording::RecordingRecordingStopResponse::Status422_EngineUnprocessableErrorResponseBody
-                                                    (body)
-                                                => {
-                                                  let mut response = response.status(422);
                                                   {
                                                     let mut response_headers = response.headers_mut().unwrap();
                                                     response_headers.insert(

--- a/engines/protocol-swift/Sources/EngineProtocol/openapi.json
+++ b/engines/protocol-swift/Sources/EngineProtocol/openapi.json
@@ -157,26 +157,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -188,6 +168,8 @@
             }
           }
         },
+        "description": "Checks the active project, recording, transcript provider, and runtime limits before issuing a short-lived token bound to those inputs.",
+        "summary": "Validate Agent Mode prerequisites",
         "requestBody": {
           "content": {
             "application/json": {
@@ -291,6 +273,8 @@
             }
           }
         },
+        "description": "Consumes a valid preflight token and creates project-bound QA, artifact, and cut-plan state.",
+        "summary": "Create a deterministic Agent Mode run",
         "requestBody": {
           "content": {
             "application/json": {
@@ -387,6 +371,26 @@
               }
             }
           },
+          "409": {
+            "description": "EngineConflictError response body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EngineConflictError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "EngineUnprocessableError response body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EngineUnprocessableError"
+                }
+              }
+            }
+          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -397,7 +401,9 @@
               }
             }
           }
-        }
+        },
+        "description": "Returns terminal status, narrative QA, persisted artifact references, and a reviewable cut-plan summary for one project-bound run.",
+        "summary": "Inspect Agent Mode run status"
       }
     },
     "/v1/agent/runs/{jobId}/apply": {
@@ -428,11 +434,11 @@
         ],
         "responses": {
           "200": {
-            "description": "ActionResult",
+            "description": "AgentApplyResult",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
+                  "$ref": "#/components/schemas/AgentApplyResult"
                 }
               }
             }
@@ -515,6 +521,8 @@
             }
           }
         },
+        "description": "Applies the exact persisted cut plan to the working timeline after QA, project binding, and destructive-confirmation checks.",
+        "summary": "Apply a verified Agent Mode cut plan",
         "requestBody": {
           "content": {
             "application/json": {
@@ -660,26 +668,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -749,26 +737,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -846,26 +814,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -935,26 +883,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1105,26 +1033,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -1204,26 +1112,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1311,26 +1199,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -1410,26 +1278,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1653,26 +1501,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -1752,26 +1580,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1922,26 +1730,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -2025,6 +1813,16 @@
               }
             }
           },
+          "404": {
+            "description": "EngineNotFoundError response body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EngineNotFoundError"
+                }
+              }
+            }
+          },
           "409": {
             "description": "EngineConflictError response body.",
             "content": {
@@ -2056,6 +1854,8 @@
             }
           }
         },
+        "description": "Resolves the supplied Agent Mode job, enforces project binding and narrative QA, and exports the exact persisted frame-based cut plan.",
+        "summary": "Export a verified Agent Mode cut plan",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2298,26 +2098,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -2397,26 +2177,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -2661,6 +2421,48 @@
                 "minimum": 1
               }
             ]
+          },
+          "supportedTranscriptionProviders": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "none",
+                "imported_transcript"
+              ]
+            }
+          },
+          "maxSourceDurationSeconds": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "preflightTokenTtlSeconds": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "artifactVersion": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "cutPlanVersion": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
           }
         },
         "required": [
@@ -2789,7 +2591,7 @@
                 "minimum": 1
               },
               {
-                "maximum": 60
+                "maximum": 10
               }
             ]
           },
@@ -2811,14 +2613,107 @@
         },
         "additionalProperties": false
       },
-      "AgentPreflightResult": {
+      "AgentPreflightReadyResult": {
         "type": "object",
         "properties": {
           "ready": {
-            "type": "boolean"
+            "type": "boolean",
+            "enum": [
+              true
+            ]
           },
           "blockingReasons": {
             "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "missing_project",
+                "missing_recording",
+                "invalid_runtime_budget",
+                "source_too_long",
+                "source_duration_invalid",
+                "missing_local_model",
+                "missing_imported_transcript",
+                "invalid_imported_transcript",
+                "no_audio_track",
+                "silent_audio"
+              ]
+            },
+            "allOf": [
+              {
+                "minItems": 0
+              },
+              {
+                "maxItems": 0
+              }
+            ]
+          },
+          "canApplyDestructive": {
+            "type": "boolean"
+          },
+          "transcriptionProvider": {
+            "type": "string",
+            "enum": [
+              "none",
+              "imported_transcript"
+            ]
+          },
+          "preflightToken": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "preflightTokenExpiresAt": {
+            "type": "string",
+            "allOf": [
+              {
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+              }
+            ]
+          }
+        },
+        "required": [
+          "ready",
+          "blockingReasons",
+          "canApplyDestructive",
+          "transcriptionProvider",
+          "preflightToken",
+          "preflightTokenExpiresAt"
+        ],
+        "additionalProperties": false
+      },
+      "AgentPreflightBlockedResult": {
+        "type": "object",
+        "properties": {
+          "ready": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          },
+          "blockingReasons": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "type": "string",
+                "enum": [
+                  "missing_project",
+                  "missing_recording",
+                  "invalid_runtime_budget",
+                  "source_too_long",
+                  "source_duration_invalid",
+                  "missing_local_model",
+                  "missing_imported_transcript",
+                  "invalid_imported_transcript",
+                  "no_audio_track",
+                  "silent_audio"
+                ]
+              }
+            ],
+            "minItems": 1,
             "items": {
               "type": "string",
               "enum": [
@@ -2844,14 +2739,6 @@
               "none",
               "imported_transcript"
             ]
-          },
-          "preflightToken": {
-            "type": "string",
-            "allOf": [
-              {
-                "minLength": 1
-              }
-            ]
           }
         },
         "required": [
@@ -2862,6 +2749,16 @@
         ],
         "additionalProperties": false
       },
+      "AgentPreflightResult": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/AgentPreflightReadyResult"
+          },
+          {
+            "$ref": "#/components/schemas/AgentPreflightBlockedResult"
+          }
+        ]
+      },
       "EngineBadRequestError": {
         "type": "object",
         "properties": {
@@ -2870,7 +2767,9 @@
             "enum": [
               "invalid_request",
               "invalid_params",
-              "unsupported_method"
+              "unsupported_method",
+              "preflight_expired",
+              "preflight_mismatch"
             ]
           },
           "message": {
@@ -2918,62 +2817,6 @@
         "additionalProperties": false,
         "description": "EngineForbiddenError response body."
       },
-      "EngineConflictError": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "needs_confirmation"
-                ]
-              }
-            ]
-          },
-          "message": {
-            "type": "string",
-            "allOf": [
-              {
-                "minLength": 1
-              }
-            ]
-          }
-        },
-        "required": [
-          "code",
-          "message"
-        ],
-        "additionalProperties": false,
-        "description": "EngineConflictError response body."
-      },
-      "EngineUnprocessableError": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "enum": [
-              "qa_failed",
-              "missing_local_model",
-              "invalid_cut_plan"
-            ]
-          },
-          "message": {
-            "type": "string",
-            "allOf": [
-              {
-                "minLength": 1
-              }
-            ]
-          }
-        },
-        "required": [
-          "code",
-          "message"
-        ],
-        "additionalProperties": false,
-        "description": "EngineUnprocessableError response body."
-      },
       "AgentRunPayload": {
         "type": "object",
         "properties": {
@@ -2992,7 +2835,7 @@
                 "minimum": 1
               },
               {
-                "maximum": 60
+                "maximum": 10
               }
             ]
           },
@@ -3049,6 +2892,59 @@
         ],
         "additionalProperties": false
       },
+      "EngineConflictError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "needs_confirmation",
+              "project_mismatch"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "EngineConflictError response body."
+      },
+      "EngineUnprocessableError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "qa_failed",
+              "missing_local_model",
+              "invalid_cut_plan"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "EngineUnprocessableError response body."
+      },
       "AgentQAReport": {
         "type": "object",
         "properties": {
@@ -3056,39 +2952,11 @@
             "type": "boolean"
           },
           "score": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "NaN"
-                    ]
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "Infinity"
-                    ]
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "-Infinity"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "Infinity",
-                  "-Infinity",
-                  "NaN"
-                ]
+                "minimum": 0,
+                "maximum": 1
               }
             ]
           },
@@ -3133,6 +3001,288 @@
           "passed",
           "score",
           "coverage"
+        ],
+        "additionalProperties": false
+      },
+      "AgentArtifactReference": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "transcript.full.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/transcript.full.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "transcript.words.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/transcript.words.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "beat-map.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/beat-map.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "qa-report.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/qa-report.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "cut-plan.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/cut-plan.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "run-summary.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/run-summary.v1.json"
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "AgentFrameRate": {
+        "type": "object",
+        "properties": {
+          "numerator": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "denominator": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "numerator",
+          "denominator"
+        ],
+        "additionalProperties": false
+      },
+      "AgentCutPlanSegment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "beat": {
+            "type": "string",
+            "enum": [
+              "hook",
+              "action",
+              "payoff",
+              "takeaway"
+            ]
+          },
+          "startFrame": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          },
+          "endFrame": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "beat",
+          "startFrame",
+          "endFrame"
+        ],
+        "additionalProperties": false
+      },
+      "AgentCutPlanSummary": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "number",
+            "enum": [
+              1
+            ]
+          },
+          "sourceFps": {
+            "$ref": "#/components/schemas/AgentFrameRate"
+          },
+          "sourceFrameCount": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentCutPlanSegment"
+            }
+          }
+        },
+        "required": [
+          "version",
+          "sourceFps",
+          "sourceFrameCount",
+          "segments"
         ],
         "additionalProperties": false
       },
@@ -3185,6 +3335,15 @@
               "empty_transcript",
               "weak_narrative_structure"
             ]
+          },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentArtifactReference"
+            }
+          },
+          "cutPlan": {
+            "$ref": "#/components/schemas/AgentCutPlanSummary"
           },
           "updatedAt": {
             "type": "string",
@@ -3241,18 +3400,55 @@
         },
         "additionalProperties": false
       },
-      "ActionResult": {
+      "AgentApplyResult": {
         "type": "object",
         "properties": {
           "success": {
-            "type": "boolean"
+            "type": "boolean",
+            "enum": [
+              true
+            ]
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "jobId": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "applied"
+            ]
+          },
+          "appliedSegments": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "projectHasUnsavedChanges": {
+            "type": "boolean"
           }
         },
         "required": [
-          "success"
+          "success",
+          "jobId",
+          "status",
+          "appliedSegments",
+          "projectHasUnsavedChanges"
         ],
         "additionalProperties": false
       },
@@ -3278,6 +3474,21 @@
           "screenRecordingGranted",
           "microphoneGranted",
           "inputMonitoring"
+        ],
+        "additionalProperties": false
+      },
+      "ActionResult": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success"
         ],
         "additionalProperties": false
       },
@@ -4772,7 +4983,8 @@
       "name": "system"
     },
     {
-      "name": "agent"
+      "name": "agent",
+      "description": "Project-scoped local Agent Mode planning and apply workflow."
     },
     {
       "name": "permissions"

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "protocol:rust:test": "cargo test --manifest-path engines/protocol-rust/Cargo.toml",
     "swift:build": "swift build",
     "swift:test": "swift test",
+    "agent:smoke:macos": "bun ./Scripts/agent_mode_smoke.ts",
     "swift:format": "swiftformat .",
     "swift:lint": "swiftlint",
     "capture:benchmark": "bun ./Scripts/capture_benchmark.ts",

--- a/packages/engine-client/README.md
+++ b/packages/engine-client/README.md
@@ -1,0 +1,55 @@
+# Engine client
+
+Effect-native client and scoped process launcher for the authenticated local Guerilla Glass engine HTTP API.
+
+## Ownership
+
+- Wire schemas and endpoints: `packages/engine-contract`
+- Generated OpenAPI: `packages/engine-contract/generated/engine.openapi.json`
+- Native process launch/readiness/authentication: this package
+- Agent Mode operational workflow: `docs/AGENT_MODE_RUNBOOK.md`
+
+Do not construct raw HTTP clients in desktop application services. Use `layerEngineClientBun` at a composition root and consume the domain services or `EngineClient` tag.
+
+## Scoped launch example
+
+```ts
+import { EngineClient, layerEngineClientBun } from "@guerillaglass/engine-client/service";
+import { Effect } from "effect";
+
+const program = Effect.gen(function* () {
+  const engine = yield* EngineClient;
+  const capabilities = yield* engine.engineCapabilities;
+  return capabilities;
+});
+
+const capabilities = await Effect.runPromise(
+  Effect.scoped(
+    program.pipe(
+      Effect.provide(
+        layerEngineClientBun({
+          enginePath: "/absolute/path/to/guerillaglass-engine",
+        }),
+      ),
+    ),
+  ),
+);
+```
+
+The scoped layer:
+
+1. generates a redacted per-process bearer token;
+2. launches the engine with loopback HTTP transport;
+3. parses the readiness envelope;
+4. decorates generated `HttpApi` requests with bearer authentication; and
+5. terminates the native process when its Effect scope closes.
+
+Before invoking optional behavior, read `engineCapabilities`. Windows/Linux foundation shells intentionally do not advertise production Agent Mode or cut-plan export parity merely because generated endpoints compile.
+
+## Checks
+
+```bash
+cd packages/engine-client
+bun run typecheck
+bun run test
+```

--- a/packages/engine-client/src/service.ts
+++ b/packages/engine-client/src/service.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentApplyResult,
   AgentPreflightResult,
   AgentRunResult,
   AgentStatusResult,
@@ -138,7 +139,7 @@ export type EngineClientService = {
   readonly agentApply: (
     jobId: AgentJobId,
     request: AgentApplyRequest,
-  ) => Effect.Effect<ActionResult, EngineClientError>;
+  ) => Effect.Effect<AgentApplyResult, EngineClientError>;
   /**
    * Calls `GET /v1/permissions`.
    */

--- a/packages/engine-client/src/services/AgentService.ts
+++ b/packages/engine-client/src/services/AgentService.ts
@@ -1,9 +1,9 @@
 import type {
+  AgentApplyResult,
   AgentPreflightResult,
   AgentRunResult,
   AgentStatusResult,
 } from "@guerillaglass/engine-contract/domains/agent";
-import type { ActionResult } from "@guerillaglass/engine-contract/domains/permissions";
 import type { AgentJobId } from "@guerillaglass/engine-contract/schema-primitives";
 import { Context, Effect, Layer } from "effect";
 import type { EngineClientError } from "../errors";
@@ -38,7 +38,7 @@ export type AgentServiceShape = {
   readonly apply: (
     jobId: AgentJobId,
     request: AgentApplyRequest,
-  ) => Effect.Effect<ActionResult, EngineClientError>;
+  ) => Effect.Effect<AgentApplyResult, EngineClientError>;
 };
 
 /**

--- a/packages/engine-contract/generated/engine.openapi.json
+++ b/packages/engine-contract/generated/engine.openapi.json
@@ -157,26 +157,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -188,6 +168,8 @@
             }
           }
         },
+        "description": "Checks the active project, recording, transcript provider, and runtime limits before issuing a short-lived token bound to those inputs.",
+        "summary": "Validate Agent Mode prerequisites",
         "requestBody": {
           "content": {
             "application/json": {
@@ -291,6 +273,8 @@
             }
           }
         },
+        "description": "Consumes a valid preflight token and creates project-bound QA, artifact, and cut-plan state.",
+        "summary": "Create a deterministic Agent Mode run",
         "requestBody": {
           "content": {
             "application/json": {
@@ -387,6 +371,26 @@
               }
             }
           },
+          "409": {
+            "description": "EngineConflictError response body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EngineConflictError"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "EngineUnprocessableError response body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EngineUnprocessableError"
+                }
+              }
+            }
+          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -397,7 +401,9 @@
               }
             }
           }
-        }
+        },
+        "description": "Returns terminal status, narrative QA, persisted artifact references, and a reviewable cut-plan summary for one project-bound run.",
+        "summary": "Inspect Agent Mode run status"
       }
     },
     "/v1/agent/runs/{jobId}/apply": {
@@ -428,11 +434,11 @@
         ],
         "responses": {
           "200": {
-            "description": "ActionResult",
+            "description": "AgentApplyResult",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ActionResult"
+                  "$ref": "#/components/schemas/AgentApplyResult"
                 }
               }
             }
@@ -515,6 +521,8 @@
             }
           }
         },
+        "description": "Applies the exact persisted cut plan to the working timeline after QA, project binding, and destructive-confirmation checks.",
+        "summary": "Apply a verified Agent Mode cut plan",
         "requestBody": {
           "content": {
             "application/json": {
@@ -660,26 +668,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -749,26 +737,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -846,26 +814,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -935,26 +883,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1105,26 +1033,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -1204,26 +1112,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1311,26 +1199,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -1410,26 +1278,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1653,26 +1501,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -1752,26 +1580,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -1922,26 +1730,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -2025,6 +1813,16 @@
               }
             }
           },
+          "404": {
+            "description": "EngineNotFoundError response body.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EngineNotFoundError"
+                }
+              }
+            }
+          },
           "409": {
             "description": "EngineConflictError response body.",
             "content": {
@@ -2056,6 +1854,8 @@
             }
           }
         },
+        "description": "Resolves the supplied Agent Mode job, enforces project binding and narrative QA, and exports the exact persisted frame-based cut plan.",
+        "summary": "Export a verified Agent Mode cut plan",
         "requestBody": {
           "content": {
             "application/json": {
@@ -2298,26 +2098,6 @@
               }
             }
           },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
-                }
-              }
-            }
-          },
           "500": {
             "description": "EngineRuntimeError response body.",
             "content": {
@@ -2397,26 +2177,6 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/EngineForbiddenError"
-                }
-              }
-            }
-          },
-          "409": {
-            "description": "EngineConflictError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineConflictError"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "EngineUnprocessableError response body.",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/EngineUnprocessableError"
                 }
               }
             }
@@ -2661,6 +2421,48 @@
                 "minimum": 1
               }
             ]
+          },
+          "supportedTranscriptionProviders": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "none",
+                "imported_transcript"
+              ]
+            }
+          },
+          "maxSourceDurationSeconds": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "preflightTokenTtlSeconds": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "artifactVersion": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "cutPlanVersion": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
           }
         },
         "required": [
@@ -2789,7 +2591,7 @@
                 "minimum": 1
               },
               {
-                "maximum": 60
+                "maximum": 10
               }
             ]
           },
@@ -2811,14 +2613,107 @@
         },
         "additionalProperties": false
       },
-      "AgentPreflightResult": {
+      "AgentPreflightReadyResult": {
         "type": "object",
         "properties": {
           "ready": {
-            "type": "boolean"
+            "type": "boolean",
+            "enum": [
+              true
+            ]
           },
           "blockingReasons": {
             "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "missing_project",
+                "missing_recording",
+                "invalid_runtime_budget",
+                "source_too_long",
+                "source_duration_invalid",
+                "missing_local_model",
+                "missing_imported_transcript",
+                "invalid_imported_transcript",
+                "no_audio_track",
+                "silent_audio"
+              ]
+            },
+            "allOf": [
+              {
+                "minItems": 0
+              },
+              {
+                "maxItems": 0
+              }
+            ]
+          },
+          "canApplyDestructive": {
+            "type": "boolean"
+          },
+          "transcriptionProvider": {
+            "type": "string",
+            "enum": [
+              "none",
+              "imported_transcript"
+            ]
+          },
+          "preflightToken": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "preflightTokenExpiresAt": {
+            "type": "string",
+            "allOf": [
+              {
+                "pattern": "^\\d{4}-\\d{2}-\\d{2}T"
+              }
+            ]
+          }
+        },
+        "required": [
+          "ready",
+          "blockingReasons",
+          "canApplyDestructive",
+          "transcriptionProvider",
+          "preflightToken",
+          "preflightTokenExpiresAt"
+        ],
+        "additionalProperties": false
+      },
+      "AgentPreflightBlockedResult": {
+        "type": "object",
+        "properties": {
+          "ready": {
+            "type": "boolean",
+            "enum": [
+              false
+            ]
+          },
+          "blockingReasons": {
+            "type": "array",
+            "prefixItems": [
+              {
+                "type": "string",
+                "enum": [
+                  "missing_project",
+                  "missing_recording",
+                  "invalid_runtime_budget",
+                  "source_too_long",
+                  "source_duration_invalid",
+                  "missing_local_model",
+                  "missing_imported_transcript",
+                  "invalid_imported_transcript",
+                  "no_audio_track",
+                  "silent_audio"
+                ]
+              }
+            ],
+            "minItems": 1,
             "items": {
               "type": "string",
               "enum": [
@@ -2844,14 +2739,6 @@
               "none",
               "imported_transcript"
             ]
-          },
-          "preflightToken": {
-            "type": "string",
-            "allOf": [
-              {
-                "minLength": 1
-              }
-            ]
           }
         },
         "required": [
@@ -2862,6 +2749,16 @@
         ],
         "additionalProperties": false
       },
+      "AgentPreflightResult": {
+        "anyOf": [
+          {
+            "$ref": "#/components/schemas/AgentPreflightReadyResult"
+          },
+          {
+            "$ref": "#/components/schemas/AgentPreflightBlockedResult"
+          }
+        ]
+      },
       "EngineBadRequestError": {
         "type": "object",
         "properties": {
@@ -2870,7 +2767,9 @@
             "enum": [
               "invalid_request",
               "invalid_params",
-              "unsupported_method"
+              "unsupported_method",
+              "preflight_expired",
+              "preflight_mismatch"
             ]
           },
           "message": {
@@ -2918,62 +2817,6 @@
         "additionalProperties": false,
         "description": "EngineForbiddenError response body."
       },
-      "EngineConflictError": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "anyOf": [
-              {
-                "type": "string",
-                "enum": [
-                  "needs_confirmation"
-                ]
-              }
-            ]
-          },
-          "message": {
-            "type": "string",
-            "allOf": [
-              {
-                "minLength": 1
-              }
-            ]
-          }
-        },
-        "required": [
-          "code",
-          "message"
-        ],
-        "additionalProperties": false,
-        "description": "EngineConflictError response body."
-      },
-      "EngineUnprocessableError": {
-        "type": "object",
-        "properties": {
-          "code": {
-            "type": "string",
-            "enum": [
-              "qa_failed",
-              "missing_local_model",
-              "invalid_cut_plan"
-            ]
-          },
-          "message": {
-            "type": "string",
-            "allOf": [
-              {
-                "minLength": 1
-              }
-            ]
-          }
-        },
-        "required": [
-          "code",
-          "message"
-        ],
-        "additionalProperties": false,
-        "description": "EngineUnprocessableError response body."
-      },
       "AgentRunPayload": {
         "type": "object",
         "properties": {
@@ -2992,7 +2835,7 @@
                 "minimum": 1
               },
               {
-                "maximum": 60
+                "maximum": 10
               }
             ]
           },
@@ -3049,6 +2892,59 @@
         ],
         "additionalProperties": false
       },
+      "EngineConflictError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "needs_confirmation",
+              "project_mismatch"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "EngineConflictError response body."
+      },
+      "EngineUnprocessableError": {
+        "type": "object",
+        "properties": {
+          "code": {
+            "type": "string",
+            "enum": [
+              "qa_failed",
+              "missing_local_model",
+              "invalid_cut_plan"
+            ]
+          },
+          "message": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "code",
+          "message"
+        ],
+        "additionalProperties": false,
+        "description": "EngineUnprocessableError response body."
+      },
       "AgentQAReport": {
         "type": "object",
         "properties": {
@@ -3056,39 +2952,11 @@
             "type": "boolean"
           },
           "score": {
-            "anyOf": [
+            "type": "number",
+            "allOf": [
               {
-                "anyOf": [
-                  {
-                    "type": "number"
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "NaN"
-                    ]
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "Infinity"
-                    ]
-                  },
-                  {
-                    "type": "string",
-                    "enum": [
-                      "-Infinity"
-                    ]
-                  }
-                ]
-              },
-              {
-                "type": "string",
-                "enum": [
-                  "Infinity",
-                  "-Infinity",
-                  "NaN"
-                ]
+                "minimum": 0,
+                "maximum": 1
               }
             ]
           },
@@ -3133,6 +3001,288 @@
           "passed",
           "score",
           "coverage"
+        ],
+        "additionalProperties": false
+      },
+      "AgentArtifactReference": {
+        "anyOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "transcript.full.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/transcript.full.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "transcript.words.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/transcript.words.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "beat-map.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/beat-map.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "qa-report.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/qa-report.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "cut-plan.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/cut-plan.v1.json"
+                ]
+              },
+              "sha256": {
+                "type": "string",
+                "allOf": [
+                  {
+                    "pattern": "^[a-f0-9]{64}$"
+                  }
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "enum": [
+                  "run-summary.v1"
+                ]
+              },
+              "path": {
+                "type": "string",
+                "enum": [
+                  "analysis/run-summary.v1.json"
+                ]
+              }
+            },
+            "required": [
+              "kind",
+              "path"
+            ],
+            "additionalProperties": false
+          }
+        ]
+      },
+      "AgentFrameRate": {
+        "type": "object",
+        "properties": {
+          "numerator": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "denominator": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "numerator",
+          "denominator"
+        ],
+        "additionalProperties": false
+      },
+      "AgentCutPlanSegment": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "beat": {
+            "type": "string",
+            "enum": [
+              "hook",
+              "action",
+              "payoff",
+              "takeaway"
+            ]
+          },
+          "startFrame": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 0
+              }
+            ]
+          },
+          "endFrame": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          }
+        },
+        "required": [
+          "id",
+          "beat",
+          "startFrame",
+          "endFrame"
+        ],
+        "additionalProperties": false
+      },
+      "AgentCutPlanSummary": {
+        "type": "object",
+        "properties": {
+          "version": {
+            "type": "number",
+            "enum": [
+              1
+            ]
+          },
+          "sourceFps": {
+            "$ref": "#/components/schemas/AgentFrameRate"
+          },
+          "sourceFrameCount": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "segments": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentCutPlanSegment"
+            }
+          }
+        },
+        "required": [
+          "version",
+          "sourceFps",
+          "sourceFrameCount",
+          "segments"
         ],
         "additionalProperties": false
       },
@@ -3185,6 +3335,15 @@
               "empty_transcript",
               "weak_narrative_structure"
             ]
+          },
+          "artifacts": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/AgentArtifactReference"
+            }
+          },
+          "cutPlan": {
+            "$ref": "#/components/schemas/AgentCutPlanSummary"
           },
           "updatedAt": {
             "type": "string",
@@ -3241,18 +3400,55 @@
         },
         "additionalProperties": false
       },
-      "ActionResult": {
+      "AgentApplyResult": {
         "type": "object",
         "properties": {
           "success": {
-            "type": "boolean"
+            "type": "boolean",
+            "enum": [
+              true
+            ]
           },
           "message": {
-            "type": "string"
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "jobId": {
+            "type": "string",
+            "allOf": [
+              {
+                "minLength": 1
+              }
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "applied"
+            ]
+          },
+          "appliedSegments": {
+            "type": "integer",
+            "allOf": [
+              {
+                "minimum": 1
+              }
+            ]
+          },
+          "projectHasUnsavedChanges": {
+            "type": "boolean"
           }
         },
         "required": [
-          "success"
+          "success",
+          "jobId",
+          "status",
+          "appliedSegments",
+          "projectHasUnsavedChanges"
         ],
         "additionalProperties": false
       },
@@ -3278,6 +3474,21 @@
           "screenRecordingGranted",
           "microphoneGranted",
           "inputMonitoring"
+        ],
+        "additionalProperties": false
+      },
+      "ActionResult": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean"
+          },
+          "message": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "success"
         ],
         "additionalProperties": false
       },
@@ -4772,7 +4983,8 @@
       "name": "system"
     },
     {
-      "name": "agent"
+      "name": "agent",
+      "description": "Project-scoped local Agent Mode planning and apply workflow."
     },
     {
       "name": "permissions"

--- a/packages/engine-contract/src/domains/agent.ts
+++ b/packages/engine-contract/src/domains/agent.ts
@@ -2,11 +2,12 @@ import { Schema } from "effect";
 import {
   IsoDateTime,
   NonEmptyString,
+  NonNegativeInt,
   NonNegativeNumber,
   PositiveInt,
   between,
 } from "../shared/helpers";
-import { agentJobIdSchema } from "../schema-primitives";
+import { agentJobIdSchema, agentPreflightTokenSchema } from "../schema-primitives";
 
 /**
  * Lifecycle states for asynchronous Agent Mode jobs.
@@ -24,6 +25,125 @@ export const agentJobStatusSchema = Schema.Literals([
  * Transcript source selected for Agent Mode analysis.
  */
 export const transcriptionProviderSchema = Schema.Literals(["none", "imported_transcript"]);
+
+/**
+ * Versioned Agent Mode artifacts persisted inside the active project package.
+ */
+export const agentArtifactKindSchema = Schema.Literals([
+  "transcript.full.v1",
+  "transcript.words.v1",
+  "beat-map.v1",
+  "qa-report.v1",
+  "cut-plan.v1",
+  "run-summary.v1",
+]);
+
+/**
+ * Canonical narrative beats used by deterministic Agent Mode planning.
+ */
+export const agentNarrativeBeatSchema = Schema.Literals(["hook", "action", "payoff", "takeaway"]);
+
+/**
+ * Project-relative artifact reference with each kind bound to its canonical path.
+ */
+export const agentArtifactReferenceSchema = Schema.Union([
+  Schema.Struct({
+    kind: Schema.Literal("transcript.full.v1"),
+    path: Schema.Literal("analysis/transcript.full.v1.json"),
+    sha256: Schema.optionalKey(Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("transcript.words.v1"),
+    path: Schema.Literal("analysis/transcript.words.v1.json"),
+    sha256: Schema.optionalKey(Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("beat-map.v1"),
+    path: Schema.Literal("analysis/beat-map.v1.json"),
+    sha256: Schema.optionalKey(Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("qa-report.v1"),
+    path: Schema.Literal("analysis/qa-report.v1.json"),
+    sha256: Schema.optionalKey(Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("cut-plan.v1"),
+    path: Schema.Literal("analysis/cut-plan.v1.json"),
+    sha256: Schema.optionalKey(Schema.String.check(Schema.isPattern(/^[a-f0-9]{64}$/))),
+  }),
+  Schema.Struct({
+    kind: Schema.Literal("run-summary.v1"),
+    path: Schema.Literal("analysis/run-summary.v1.json"),
+  }),
+]).annotate({ identifier: "AgentArtifactReference" });
+
+/**
+ * Rational source frame rate retained without rounding rates such as 30000/1001.
+ */
+export const agentFrameRateSchema = Schema.Struct({
+  numerator: PositiveInt,
+  denominator: PositiveInt,
+}).annotate({ identifier: "AgentFrameRate" });
+
+/**
+ * End-exclusive frame range selected by a deterministic Agent Mode cut plan.
+ */
+const agentCutPlanSegmentWireSchema = Schema.Struct({
+  id: NonEmptyString,
+  beat: agentNarrativeBeatSchema,
+  startFrame: NonNegativeInt,
+  endFrame: PositiveInt,
+});
+export const agentCutPlanSegmentSchema = agentCutPlanSegmentWireSchema
+  .pipe(
+    Schema.decodeTo(
+      agentCutPlanSegmentWireSchema.check(
+        Schema.makeFilter((segment) =>
+          segment.endFrame > segment.startFrame
+            ? undefined
+            : "endFrame must be greater than startFrame",
+        ),
+      ),
+    ),
+  )
+  .annotate({ identifier: "AgentCutPlanSegment" });
+
+/**
+ * Compact, reviewable representation of the cut plan produced by a run.
+ */
+const agentCutPlanSummaryWireSchema = Schema.Struct({
+  version: Schema.Literal(1),
+  sourceFps: agentFrameRateSchema,
+  sourceFrameCount: PositiveInt,
+  segments: Schema.Array(agentCutPlanSegmentSchema),
+});
+const canonicalBeatOrder = ["hook", "action", "payoff", "takeaway"] as const;
+export const agentCutPlanSummarySchema = agentCutPlanSummaryWireSchema
+  .pipe(
+    Schema.decodeTo(
+      agentCutPlanSummaryWireSchema.check(
+        Schema.makeFilter((plan) => {
+          if (
+            plan.segments.length !== canonicalBeatOrder.length ||
+            plan.segments.some((segment, index) => segment.beat !== canonicalBeatOrder[index]) ||
+            new Set(plan.segments.map((segment) => segment.id)).size !== plan.segments.length
+          ) {
+            return "segments must have unique IDs and canonical hook/action/payoff/takeaway order";
+          }
+          let previousEndFrame = 0;
+          for (const segment of plan.segments) {
+            if (segment.startFrame < previousEndFrame || segment.endFrame > plan.sourceFrameCount) {
+              return "segments must be ordered, non-overlapping, and within sourceFrameCount";
+            }
+            previousEndFrame = segment.endFrame;
+          }
+          return undefined;
+        }),
+      ),
+    ),
+  )
+  .annotate({ identifier: "AgentCutPlanSummary" });
 
 /**
  * Reasons that prevent an Agent Mode run from being started.
@@ -64,7 +184,7 @@ export const agentRunBlockingReasonSchema = Schema.Literals([
  */
 export const agentQAReportSchema = Schema.Struct({
   passed: Schema.Boolean,
-  score: Schema.Number.pipe(between(0, 1)),
+  score: Schema.Finite.pipe(between(0, 1)),
   coverage: Schema.Struct({
     hook: Schema.Boolean,
     action: Schema.Boolean,
@@ -85,19 +205,36 @@ export const agentRunSummarySchema = Schema.Struct({
   runtimeBudgetMinutes: PositiveInt,
   qaReport: Schema.optionalKey(agentQAReportSchema),
   blockingReason: Schema.optionalKey(agentRunBlockingReasonSchema),
+  artifacts: Schema.optionalKey(Schema.Array(agentArtifactReferenceSchema)),
+  cutPlan: Schema.optionalKey(agentCutPlanSummarySchema),
   updatedAt: IsoDateTime,
 }).annotate({ identifier: "AgentRunSummary" });
 
 /**
  * Result of validating whether the current project can run Agent Mode.
  */
-export const agentPreflightResultSchema = Schema.Struct({
-  ready: Schema.Boolean,
-  blockingReasons: Schema.Array(agentPreflightBlockingReasonSchema),
+const agentPreflightReadyResultSchema = Schema.Struct({
+  ready: Schema.Literal(true),
+  blockingReasons: Schema.Array(agentPreflightBlockingReasonSchema).check(
+    Schema.isLengthBetween(0, 0),
+  ),
   canApplyDestructive: Schema.Boolean,
   transcriptionProvider: transcriptionProviderSchema,
-  preflightToken: Schema.optionalKey(NonEmptyString),
-}).annotate({ identifier: "AgentPreflightResult" });
+  preflightToken: agentPreflightTokenSchema,
+  preflightTokenExpiresAt: IsoDateTime,
+}).annotate({ identifier: "AgentPreflightReadyResult" });
+
+const agentPreflightBlockedResultSchema = Schema.Struct({
+  ready: Schema.Literal(false),
+  blockingReasons: Schema.NonEmptyArray(agentPreflightBlockingReasonSchema),
+  canApplyDestructive: Schema.Boolean,
+  transcriptionProvider: transcriptionProviderSchema,
+}).annotate({ identifier: "AgentPreflightBlockedResult" });
+
+export const agentPreflightResultSchema = Schema.Union([
+  agentPreflightReadyResultSchema,
+  agentPreflightBlockedResultSchema,
+]).annotate({ identifier: "AgentPreflightResult" });
 
 /**
  * Initial response returned after enqueuing an Agent Mode run.
@@ -111,6 +248,18 @@ export const agentRunResultSchema = Schema.Struct({
  * Polling response for Agent Mode job status.
  */
 export const agentStatusResultSchema = agentRunSummarySchema;
+
+/**
+ * Verifiable result of applying one Agent Mode cut plan to the working timeline.
+ */
+export const agentApplyResultSchema = Schema.Struct({
+  success: Schema.Literal(true),
+  message: Schema.optionalKey(NonEmptyString),
+  jobId: agentJobIdSchema,
+  status: Schema.Literal("applied"),
+  appliedSegments: PositiveInt,
+  projectHasUnsavedChanges: Schema.Boolean,
+}).annotate({ identifier: "AgentApplyResult" });
 
 /**
  * Imported transcript segment with text and time bounds in seconds.
@@ -152,6 +301,11 @@ export type TranscriptionProvider = Schema.Schema.Type<typeof transcriptionProvi
  * Runtime TypeScript type for Agent Mode preflight responses.
  */
 export type AgentPreflightResult = Schema.Schema.Type<typeof agentPreflightResultSchema>;
+
+/**
+ * Runtime TypeScript type for successful Agent Mode apply responses.
+ */
+export type AgentApplyResult = Schema.Schema.Type<typeof agentApplyResultSchema>;
 
 /**
  * Runtime TypeScript type for Agent Mode run enqueue responses.

--- a/packages/engine-contract/src/domains/system.ts
+++ b/packages/engine-contract/src/domains/system.ts
@@ -1,5 +1,6 @@
 import { Schema } from "effect";
 import { NonEmptyString, PositiveInt } from "../shared/helpers";
+import { transcriptionProviderSchema } from "./agent";
 
 /**
  * Health-check response containing engine identity and protocol information.
@@ -18,6 +19,11 @@ const capabilitiesAgentSchema = Schema.Struct({
   apply: Schema.Boolean,
   localOnly: Schema.optionalKey(Schema.Boolean),
   runtimeBudgetMinutes: Schema.optionalKey(PositiveInt),
+  supportedTranscriptionProviders: Schema.optionalKey(Schema.Array(transcriptionProviderSchema)),
+  maxSourceDurationSeconds: Schema.optionalKey(PositiveInt),
+  preflightTokenTtlSeconds: Schema.optionalKey(PositiveInt),
+  artifactVersion: Schema.optionalKey(PositiveInt),
+  cutPlanVersion: Schema.optionalKey(PositiveInt),
 }).annotate({ identifier: "CapabilitiesAgent" });
 
 /**

--- a/packages/engine-contract/src/errors.ts
+++ b/packages/engine-contract/src/errors.ts
@@ -19,6 +19,9 @@ export const engineErrorCodeSchema = Schema.Literals([
   "qa_failed",
   "missing_local_model",
   "invalid_cut_plan",
+  "preflight_expired",
+  "preflight_mismatch",
+  "project_mismatch",
   "not_found",
   "runtime_error",
 ]);
@@ -42,6 +45,8 @@ export const EngineBadRequestError = makeEngineError("EngineBadRequestError", 40
   "invalid_request",
   "invalid_params",
   "unsupported_method",
+  "preflight_expired",
+  "preflight_mismatch",
 ]);
 
 /**
@@ -68,6 +73,7 @@ export const EngineNotFoundError = makeEngineError("EngineNotFoundError", 404, [
  */
 export const EngineConflictError = makeEngineError("EngineConflictError", 409, [
   "needs_confirmation",
+  "project_mismatch",
 ]);
 
 /**
@@ -101,8 +107,6 @@ export const EngineMutationErrors = [
   EngineBadRequestError,
   EngineUnauthorizedError,
   EngineForbiddenError,
-  EngineConflictError,
-  EngineUnprocessableError,
   EngineRuntimeError,
 ] as const;
 

--- a/packages/engine-contract/src/httpApi.ts
+++ b/packages/engine-contract/src/httpApi.ts
@@ -1,4 +1,4 @@
-import { HttpApi, HttpApiEndpoint, HttpApiGroup } from "effect/unstable/httpapi";
+import { HttpApi, HttpApiEndpoint, HttpApiGroup, OpenApi } from "effect/unstable/httpapi";
 import { Schema } from "effect";
 import {
   agentJobIdSchema,
@@ -21,6 +21,7 @@ import {
   timelineDocumentSchema,
 } from "./shared/valueObjects";
 import {
+  agentApplyResultSchema,
   agentPreflightResultSchema,
   agentRunResultSchema,
   agentStatusResultSchema,
@@ -39,9 +40,11 @@ import { capabilitiesResultSchema, pingResultSchema } from "./domains/system";
 import {
   EngineAuthMiddleware,
   EngineCommonErrors,
+  EngineConflictError,
   EngineMutationErrors,
   EngineNotFoundError,
   EngineRuntimeError,
+  EngineUnprocessableError,
 } from "./errors";
 
 export const agentPreflightPayloadSchema = Schema.Struct({
@@ -124,29 +127,61 @@ const SystemGroup = HttpApiGroup.make("system").add(
   }),
 );
 
-const AgentGroup = HttpApiGroup.make("agent").add(
-  HttpApiEndpoint.post("agentPreflight", "/v1/agent/preflight", {
-    payload: agentPreflightPayloadSchema,
-    success: agentPreflightResultSchema,
-    error: EngineMutationErrors,
-  }),
-  HttpApiEndpoint.post("agentRun", "/v1/agent/runs", {
-    payload: agentRunPayloadSchema,
-    success: agentRunResultSchema,
-    error: EngineMutationErrors,
-  }),
-  HttpApiEndpoint.get("agentStatus", "/v1/agent/runs/:jobId", {
-    params: { jobId: agentJobIdSchema },
-    success: agentStatusResultSchema,
-    error: [...EngineCommonErrors, EngineNotFoundError],
-  }),
-  HttpApiEndpoint.post("agentApply", "/v1/agent/runs/:jobId/apply", {
-    params: { jobId: agentJobIdSchema },
-    payload: agentApplyPayloadSchema,
-    success: actionResultSchema,
-    error: [...EngineMutationErrors, EngineNotFoundError],
-  }),
-);
+const AgentGroup = HttpApiGroup.make("agent")
+  .annotate(OpenApi.Description, "Project-scoped local Agent Mode planning and apply workflow.")
+  .add(
+    HttpApiEndpoint.post("agentPreflight", "/v1/agent/preflight", {
+      payload: agentPreflightPayloadSchema,
+      success: agentPreflightResultSchema,
+      error: EngineMutationErrors,
+    })
+      .annotate(OpenApi.Summary, "Validate Agent Mode prerequisites")
+      .annotate(
+        OpenApi.Description,
+        "Checks the active project, recording, transcript provider, and runtime limits before issuing a short-lived token bound to those inputs.",
+      ),
+    HttpApiEndpoint.post("agentRun", "/v1/agent/runs", {
+      payload: agentRunPayloadSchema,
+      success: agentRunResultSchema,
+      error: [...EngineMutationErrors, EngineConflictError, EngineUnprocessableError],
+    })
+      .annotate(OpenApi.Summary, "Create a deterministic Agent Mode run")
+      .annotate(
+        OpenApi.Description,
+        "Consumes a valid preflight token and creates project-bound QA, artifact, and cut-plan state.",
+      ),
+    HttpApiEndpoint.get("agentStatus", "/v1/agent/runs/:jobId", {
+      params: { jobId: agentJobIdSchema },
+      success: agentStatusResultSchema,
+      error: [
+        ...EngineCommonErrors,
+        EngineNotFoundError,
+        EngineConflictError,
+        EngineUnprocessableError,
+      ],
+    })
+      .annotate(OpenApi.Summary, "Inspect Agent Mode run status")
+      .annotate(
+        OpenApi.Description,
+        "Returns terminal status, narrative QA, persisted artifact references, and a reviewable cut-plan summary for one project-bound run.",
+      ),
+    HttpApiEndpoint.post("agentApply", "/v1/agent/runs/:jobId/apply", {
+      params: { jobId: agentJobIdSchema },
+      payload: agentApplyPayloadSchema,
+      success: agentApplyResultSchema,
+      error: [
+        ...EngineMutationErrors,
+        EngineNotFoundError,
+        EngineConflictError,
+        EngineUnprocessableError,
+      ],
+    })
+      .annotate(OpenApi.Summary, "Apply a verified Agent Mode cut plan")
+      .annotate(
+        OpenApi.Description,
+        "Applies the exact persisted cut plan to the working timeline after QA, project binding, and destructive-confirmation checks.",
+      ),
+  );
 
 const PermissionsGroup = HttpApiGroup.make("permissions").add(
   HttpApiEndpoint.get("permissionsGet", "/v1/permissions", {
@@ -245,8 +280,18 @@ const ExportGroup = HttpApiGroup.make("export").add(
   HttpApiEndpoint.post("exportRunCutPlan", "/v1/exports/from-cut-plan", {
     payload: exportRunCutPlanPayloadSchema,
     success: exportRunCutPlanResultSchema,
-    error: EngineMutationErrors,
-  }),
+    error: [
+      ...EngineMutationErrors,
+      EngineNotFoundError,
+      EngineConflictError,
+      EngineUnprocessableError,
+    ],
+  })
+    .annotate(OpenApi.Summary, "Export a verified Agent Mode cut plan")
+    .annotate(
+      OpenApi.Description,
+      "Resolves the supplied Agent Mode job, enforces project binding and narrative QA, and exports the exact persisted frame-based cut plan.",
+    ),
   HttpApiEndpoint.get("exportGet", "/v1/exports/:jobId", {
     params: { jobId: exportJobIdSchema },
     success: exportRunResultSchema,

--- a/packages/engine-contract/src/shared/helpers.ts
+++ b/packages/engine-contract/src/shared/helpers.ts
@@ -40,7 +40,7 @@ export const ProjectRecentsLimitSchema = PositiveInt.pipe(lessThanOrEqualTo(100)
 /**
  * Agent runtime budget in minutes, capped to supported local-engine limits.
  */
-export const RuntimeBudgetMinutesSchema = PositiveInt.pipe(lessThanOrEqualTo(60));
+export const RuntimeBudgetMinutesSchema = PositiveInt.pipe(lessThanOrEqualTo(10));
 
 /**
  * Builds a reusable numeric schema check for inclusive lower bounds.

--- a/packages/engine-contract/tests/agent-discoverability.test.ts
+++ b/packages/engine-contract/tests/agent-discoverability.test.ts
@@ -1,0 +1,171 @@
+import { Schema } from "effect";
+import { describe, expect, it } from "vitest";
+import {
+  agentApplyResultSchema,
+  agentCutPlanSummarySchema,
+  agentPreflightResultSchema,
+  agentStatusResultSchema,
+} from "../src/domains/agent";
+import { agentPreflightPayloadSchema } from "../src/httpApi";
+import { EngineOpenApi } from "../src/openApi";
+
+const qaReport = {
+  passed: true,
+  score: 1,
+  coverage: { hook: true, action: true, payoff: true, takeaway: true },
+  missingBeats: [],
+};
+
+describe("Agent Mode discoverability contract", () => {
+  it("matches the native runtime budget limit", () => {
+    expect(
+      Schema.decodeUnknownSync(agentPreflightPayloadSchema)({ runtimeBudgetMinutes: 10 }),
+    ).toEqual({ runtimeBudgetMinutes: 10 });
+    expect(() =>
+      Schema.decodeUnknownSync(agentPreflightPayloadSchema)({ runtimeBudgetMinutes: 11 }),
+    ).toThrow();
+  });
+
+  it("exposes token expiry only with a ready preflight response", () => {
+    const ready = Schema.decodeUnknownSync(agentPreflightResultSchema)({
+      ready: true,
+      blockingReasons: [],
+      canApplyDestructive: false,
+      transcriptionProvider: "imported_transcript",
+      preflightToken: "token",
+      preflightTokenExpiresAt: "2026-07-25T12:00:00Z",
+    });
+    expect("preflightToken" in ready && ready.preflightToken).toBe("token");
+
+    const blocked = Schema.decodeUnknownSync(agentPreflightResultSchema)({
+      ready: false,
+      blockingReasons: ["missing_project"],
+      canApplyDestructive: false,
+      transcriptionProvider: "none",
+    });
+    expect("preflightToken" in blocked).toBe(false);
+    expect(() =>
+      Schema.decodeUnknownSync(agentPreflightResultSchema)({
+        ready: true,
+        blockingReasons: [],
+        canApplyDestructive: false,
+        transcriptionProvider: "imported_transcript",
+      }),
+    ).toThrow();
+  });
+
+  it("returns reviewable artifacts and an end-exclusive cut plan", () => {
+    const result = Schema.decodeUnknownSync(agentStatusResultSchema)({
+      jobId: "agent-1",
+      status: "completed",
+      runtimeBudgetMinutes: 10,
+      qaReport,
+      artifacts: [
+        { kind: "cut-plan.v1", path: "analysis/cut-plan.v1.json" },
+        { kind: "run-summary.v1", path: "analysis/run-summary.v1.json" },
+      ],
+      cutPlan: {
+        version: 1,
+        sourceFps: { numerator: 30_000, denominator: 1001 },
+        sourceFrameCount: 300,
+        segments: [
+          { id: "agent-hook-0", beat: "hook", startFrame: 0, endFrame: 30 },
+          { id: "agent-action-1", beat: "action", startFrame: 30, endFrame: 60 },
+          { id: "agent-payoff-2", beat: "payoff", startFrame: 60, endFrame: 90 },
+          { id: "agent-takeaway-3", beat: "takeaway", startFrame: 90, endFrame: 120 },
+        ],
+      },
+      updatedAt: "2026-07-25T12:00:00Z",
+    });
+    expect(result.cutPlan?.segments[0]).toMatchObject({ startFrame: 0, endFrame: 30 });
+    expect(() =>
+      Schema.decodeUnknownSync(agentStatusResultSchema)({
+        jobId: "agent-1",
+        status: "completed",
+        runtimeBudgetMinutes: 10,
+        artifacts: [{ kind: "cut-plan.v1", path: "/tmp/cut-plan.v1.json" }],
+        updatedAt: "2026-07-25T12:00:00Z",
+      }),
+    ).toThrow();
+  });
+
+  it("rejects non-canonical or overlapping cut plans", () => {
+    const base = {
+      version: 1,
+      sourceFps: { numerator: 30, denominator: 1 },
+      sourceFrameCount: 120,
+      segments: [
+        { id: "hook", beat: "hook", startFrame: 0, endFrame: 30 },
+        { id: "action", beat: "action", startFrame: 30, endFrame: 60 },
+        { id: "payoff", beat: "payoff", startFrame: 60, endFrame: 90 },
+        { id: "takeaway", beat: "takeaway", startFrame: 90, endFrame: 120 },
+      ],
+    } as const;
+    expect(Schema.decodeUnknownSync(agentCutPlanSummarySchema)(base).segments).toHaveLength(4);
+    expect(() =>
+      Schema.decodeUnknownSync(agentCutPlanSummarySchema)({
+        ...base,
+        segments: base.segments.map((segment, index) =>
+          index === 1 ? { ...segment, startFrame: 20 } : segment,
+        ),
+      }),
+    ).toThrow();
+    expect(() =>
+      Schema.decodeUnknownSync(agentCutPlanSummarySchema)({
+        ...base,
+        segments: base.segments.map((segment, index) =>
+          index === 3 ? { ...segment, id: "payoff", beat: "payoff" } : segment,
+        ),
+      }),
+    ).toThrow();
+  });
+
+  it("requires a verifiable successful apply result", () => {
+    expect(
+      Schema.decodeUnknownSync(agentApplyResultSchema)({
+        success: true,
+        jobId: "agent-1",
+        status: "applied",
+        appliedSegments: 4,
+        projectHasUnsavedChanges: true,
+      }),
+    ).toMatchObject({ appliedSegments: 4, status: "applied" });
+    expect(() =>
+      Schema.decodeUnknownSync(agentApplyResultSchema)({
+        success: true,
+        jobId: "agent-1",
+        status: "applied",
+        appliedSegments: 0,
+        projectHasUnsavedChanges: true,
+      }),
+    ).toThrow();
+  });
+
+  it("documents Agent workflow semantics and exact error statuses in OpenAPI", () => {
+    const document = EngineOpenApi as {
+      paths: Record<
+        string,
+        Record<string, { summary?: string; description?: string; responses: object }>
+      >;
+    };
+    const preflight = document.paths["/v1/agent/preflight"]?.post;
+    const run = document.paths["/v1/agent/runs"]?.post;
+    const apply = document.paths["/v1/agent/runs/{jobId}/apply"]?.post;
+    const cutPlanExport = document.paths["/v1/exports/from-cut-plan"]?.post;
+
+    expect(preflight?.summary).toBe("Validate Agent Mode prerequisites");
+    expect(preflight?.description).toContain("short-lived token");
+    expect(Object.keys(preflight?.responses ?? {})).not.toEqual(
+      expect.arrayContaining(["409", "422"]),
+    );
+    expect(Object.keys(run?.responses ?? {})).toEqual(
+      expect.arrayContaining(["200", "400", "409", "422"]),
+    );
+    expect(Object.keys(apply?.responses ?? {})).toEqual(
+      expect.arrayContaining(["404", "409", "422"]),
+    );
+    expect(JSON.stringify(EngineOpenApi)).toContain("project_mismatch");
+    expect(JSON.stringify(EngineOpenApi)).toContain("preflight_expired");
+    expect(Object.keys(cutPlanExport?.responses ?? {})).toContain("404");
+  });
+});


### PR DESCRIPTION
# Summary

- make the supported macOS imported-transcript Agent Mode workflow discoverable through truthful capabilities, focused runbook/audit documentation, and typed OpenAPI semantics
- persist deterministic project-bound QA, transcript, beat-map, cut-plan, and run-summary artifacts with descriptor-anchored atomic generation swaps, SHA-256 binding, rational frame plans, and restart recovery
- bind preflight, run, apply, and export to the active project and full recording revision; export from a verified immutable recording snapshot and consume the same canonical plan for apply/export parity
- add executable macOS golden-path verification covering artifact review, exact apply timeline, ordered rendered content, decoded duration, independent/pre/post-restart export, stale recording, malformed/symlinked transcripts, failed QA, confirmation, token reuse, and cross-project rejection
- advertise Agent Mode and cut-plan export as unavailable on Linux/Windows foundation shells and return typed `unsupported_method` responses from every generated Agent route
- keep renderer transcript paths unavailable until a host-minted file grant exists; direct authenticated engine clients remain the supported automation surface

> **Merge hold:** this PR is being used to test Patchplane. Do not merge until explicit approval is given.

## UI screenshots

N/A — no rendered UI behavior changed.

# Checklist

- [x] Read and applied `AGENTS.md`, the nearest nested agent guide, and `REVIEW.md`
- [x] Kept the change scoped to one roadmap slice or maintenance purpose
- [x] Ran `bun run repo:check`
- [x] Ran `bun run gate`
- [x] Regenerated derived artifacts and verified determinism when changing contracts
- [x] Updated roadmap/docs when architecture, workflow, or tracked status changed
- [x] Added both `en-US` and `de-DE` messages for user-visible UI, or N/A — no user-visible UI added
- [x] Ran `bun run desktop:acceptance`, or N/A — no rendered desktop workflow changed; authenticated native runtime is covered by the Agent smoke
- [x] Used Peekaboo against the packaged app, or N/A — no rendered UI behavior changed
- [x] Attached rendered screenshots, or no visual/interaction behavior changed
- [x] Addressed every review comment and ran `bun run pr:check-review-threads -- 128` with zero unresolved threads

# Validation evidence

- `bun run gate`
- `bun run gate:typescript`
- `swift test`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace --all-targets`
- `bun run agent:smoke:macos`
- `bun run protocol:check-determinism`
- `bun run repo:check`
- `bun run docs:check`
- `git diff --check`
- independent TypeScript/Rust and Swift/security reviews through the `tsci` and `swiftci` Herdr panes

All hosted CI and Greptile checks pass. PatchPlane verification passed; maintainer approval remains intentionally pending.

# Cross-boundary review

- [x] Preview, persistence, and export remain aligned for editor-model changes, or N/A — apply and native export consume the exact persisted frame plan; no preview UI was added
- [x] Hosted services remain optional for local capture/edit/export
- [x] New native capabilities are advertised only on implemented targets

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a discoverable, project-bound macOS Agent Mode workflow.
- Persists deterministic QA, transcript, beat-map, cut-plan, and run-summary artifacts with restart recovery.
- Binds preflight, apply, and export operations to the active project and recording revision.
- Adds typed cross-platform capability reporting, generated protocol bindings, documentation, and macOS golden-path verification.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge from the reviewed code paths.

No blocking failure remains; the Save As rollback preserves destination Agent artifacts when the project write fails, and a subsequent recents-index failure no longer reports the committed save as failed.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| engines/macos-swift/EngineService+Project.swift | Save As now quarantines destination analysis artifacts, restores them when the project write fails, and treats a later recents-index failure as non-fatal after the save commits. |
| engines/macos-swift/EngineService+Agent.swift | Implements project-bound Agent preflight, run, status, and apply operations with typed validation and persisted recovery. |
| engines/macos-swift/modules/project/AgentArtifactStore.swift | Adds descriptor-anchored atomic artifact generation, integrity validation, quarantine, restoration, and recovery. |
| engines/macos-swift/EngineService+Export.swift | Adds cut-plan export from a verified recording revision using the persisted canonical frame plan. |
| Scripts/agent_mode_smoke.ts | Exercises the supported macOS Agent Mode workflow, including recovery, content verification, stale inputs, confirmation, and cross-project rejection. |
| packages/engine-contract/src/domains/agent.ts | Defines the typed Agent Mode API contract and discoverability semantics. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    P[Open project] --> F[Agent preflight]
    F --> R[Generate deterministic run]
    R --> A[Persist project-bound artifacts]
    A --> V[Review cut plan and QA]
    V -->|Apply| T[Update project timeline]
    V -->|Export| E[Render immutable recording snapshot]
    A --> X[Recover run after restart]
```

<sub>Reviews (3): Last reviewed commit: ["fix(project): keep committed saves succe..."](https://github.com/okikesolutions/guerillaglass/commit/24107cffe0413e55b34c8ec49bceb22532cd841f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47235113)</sub>

<!-- /greptile_comment -->
