### PR TITLE
test: PatchPlane Linux verification acceptance

### DIFF
--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Rerun: trusted environment readback, candidate-bound logs, and confirmed deletion.
+Final rerun: fresh exact candidate with trusted Linux evidence.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -1,0 +1,3 @@
+# PatchPlane Linux acceptance
+
+This file is the candidate for the PatchPlane ephemeral Linux verification smoke.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Acceptance: exact candidate, fresh Linux group, bounded evidence, and confirmed deletion.
+Provider-backed acceptance candidate after lifecycle readback remediation.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Acceptance: terminal queued execution with durable environment and cleanup evidence.
+Acceptance: bounded deletion request plus structured not-found confirmation.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Acceptance: base-bound mutation digest, queue execution, evidence, and confirmed deletion.
+Diagnostic: capture durable queued executor response.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Diagnostic acceptance: queued executor completion and durable result.
+Acceptance: base-bound mutation digest, queue execution, evidence, and confirmed deletion.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Acceptance: queue-owned execution, fresh sandbox, bounded evidence, and confirmed deletion.
+Diagnostic acceptance: queued executor completion and durable result.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Diagnostic: capture durable queued executor response.
+Acceptance: terminal queued execution with durable environment and cleanup evidence.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Provider-backed acceptance candidate after lifecycle readback remediation.
+Acceptance: bounded Node runtime probe and candidate-bound evidence.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Acceptance: bounded Node runtime probe and candidate-bound evidence.
+Acceptance: durable queue dispatch, fresh sandbox, bounded evidence, and confirmed deletion.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Rerun: effective environment and delete-to-not-found readback.
+Rerun: trusted environment readback, candidate-bound logs, and confirmed deletion.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -1,3 +1,5 @@
 # PatchPlane Linux acceptance
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
+
+Rerun: effective environment and delete-to-not-found readback.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Final rerun: fresh exact candidate with trusted Linux evidence.
+Acceptance: exact candidate, fresh Linux group, bounded evidence, and confirmed deletion.

--- a/.patchplane-linux-acceptance.md
+++ b/.patchplane-linux-acceptance.md
@@ -2,4 +2,4 @@
 
 This file is the candidate for the PatchPlane ephemeral Linux verification smoke.
 
-Acceptance: durable queue dispatch, fresh sandbox, bounded evidence, and confirmed deletion.
+Acceptance: queue-owned execution, fresh sandbox, bounded evidence, and confirmed deletion.


### PR DESCRIPTION
Docs-only candidate for the PatchPlane supported-Linux acceptance run. No macOS, Windows, browser, GUI, or production-credential verification is required.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a root-level PatchPlane Linux acceptance marker documenting the ephemeral verification smoke and its bounded-deletion acceptance criterion.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .patchplane-linux-acceptance.md | Adds the Linux verification candidate and acceptance criterion without changing executable code or runtime behavior. |

</details>

<sub>Reviews (13): Last reviewed commit: ["test: confirm queued Linux cleanup"](https://github.com/okikesolutions/guerillaglass/commit/d5b1feb72b3d49cfccc0f68396acfac29881f011) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47923868)</sub>

<!-- /greptile_comment -->