### PR TITLE
test: prove native bounded SDK disposal

### DIFF
--- a/patchplane-linux-acceptance-138.md
+++ b/patchplane-linux-acceptance-138.md
@@ -1,0 +1,3 @@
+# PatchPlane hosted Linux acceptance 138
+
+Candidate with native bounded SDK disposal.


### PR DESCRIPTION
Temporary acceptance candidate. Do not merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a short Markdown marker identifying PatchPlane hosted Linux acceptance candidate 138 and noting native bounded SDK disposal.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the documentation-only marker introduces no actionable repository failure.

The new Markdown file is not consumed by repository automation, contains no links, and does not alter runtime, build, test, or security behavior.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patchplane-linux-acceptance-138.md | Adds a standalone three-line acceptance-candidate marker with no repository automation or documented contract affected. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: prove native bounded SDK disposal"](https://github.com/okikesolutions/guerillaglass/commit/5bb7149f5c9265419a0b7b6718da7913440ef509) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48115736)</sub>

<!-- /greptile_comment -->