### PR TITLE
test: bound terminal persistence

### DIFF
--- a/patchplane-linux-acceptance-143.md
+++ b/patchplane-linux-acceptance-143.md
@@ -1,0 +1,3 @@
+# PatchPlane hosted Linux acceptance 143
+
+Bounded Convex terminal persistence candidate.


### PR DESCRIPTION
Temporary diagnostic candidate. Do not merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a short Markdown file identifying a temporary bounded terminal-persistence diagnostic candidate.

<h3>Confidence Score: 5/5</h3>

The documentation-only change appears safe to merge, although the PR description explicitly marks it as temporary and says not to merge.

The PR only adds an isolated Markdown diagnostic marker and introduces no executable behavior or concrete defect.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patchplane-linux-acceptance-143.md | Adds a three-line diagnostic marker document with no runtime, build, or security impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: bound terminal persistence"](https://github.com/okikesolutions/guerillaglass/commit/9099b8c3f2296697750578aef137c3c0e7e4ce76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48139085)</sub>

<!-- /greptile_comment -->