### PR TITLE
test: prove drained queue bounded provider

### DIFF
--- a/patchplane-linux-acceptance-147.md
+++ b/patchplane-linux-acceptance-147.md
@@ -1,0 +1,3 @@
+# PatchPlane hosted Linux acceptance 147
+
+Drained-queue fully bounded provider candidate.


### PR DESCRIPTION
Temporary acceptance candidate. Do not merge.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a temporary Markdown acceptance-candidate marker for the drained-queue bounded-provider test.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge from a code-quality perspective because it only adds an inert Markdown note.

The added document is not consumed by builds, tests, workflows, or repository validation, and no actionable defect was identified.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patchplane-linux-acceptance-147.md | Adds a standalone three-line acceptance-candidate note with no executable behavior or repository contract impact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: prove drained queue bounded provid..."](https://github.com/okikesolutions/guerillaglass/commit/5fe3f0ccc485480c7256173a9716bfca3060e9b4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48157894)</sub>

<!-- /greptile_comment -->