### PR TITLE
test: PatchPlane hosted trust-loop fixture

### DIFF
--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -9,3 +9,5 @@ Revocation retry marker.
 Bounded response retry marker.
 
 Post-deploy observation marker.
+
+Error classification marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -37,3 +37,5 @@ Captured publication marker.
 Publication cleanup retry marker.
 
 Publication status marker.
+
+Long publication observation marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -3,3 +3,5 @@
 This temporary file exercises exact-head candidate capture and protected verification.
 
 Live retry marker.
+
+Revocation retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -21,3 +21,5 @@ No-cancel cleanup marker.
 Detailed cleanup marker.
 
 Manual redirect retry marker.
+
+User-agent retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -27,3 +27,5 @@ User-agent retry marker.
 Passing command marker.
 
 Report-producing retry marker.
+
+Canonical publication marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -17,3 +17,5 @@ Final response retry marker.
 Direct cleanup retry marker.
 
 No-cancel cleanup marker.
+
+Detailed cleanup marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -11,3 +11,5 @@ Bounded response retry marker.
 Post-deploy observation marker.
 
 Error classification marker.
+
+Final response retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -25,3 +25,5 @@ Manual redirect retry marker.
 User-agent retry marker.
 
 Passing command marker.
+
+Report-producing retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -15,3 +15,5 @@ Error classification marker.
 Final response retry marker.
 
 Direct cleanup retry marker.
+
+No-cancel cleanup marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -1,0 +1,3 @@
+# PatchPlane hosted trust-loop fixture
+
+This temporary file exercises exact-head candidate capture and protected verification.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -29,3 +29,5 @@ Passing command marker.
 Report-producing retry marker.
 
 Canonical publication marker.
+
+Publication debug marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -1,3 +1,5 @@
 # PatchPlane hosted trust-loop fixture
 
 This temporary file exercises exact-head candidate capture and protected verification.
+
+Live retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -39,3 +39,5 @@ Publication cleanup retry marker.
 Publication status marker.
 
 Long publication observation marker.
+
+Publication detail marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -5,3 +5,5 @@ This temporary file exercises exact-head candidate capture and protected verific
 Live retry marker.
 
 Revocation retry marker.
+
+Bounded response retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -35,3 +35,5 @@ Publication debug marker.
 Captured publication marker.
 
 Publication cleanup retry marker.
+
+Publication status marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -41,3 +41,5 @@ Publication status marker.
 Long publication observation marker.
 
 Publication detail marker.
+
+Idempotent publication marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -31,3 +31,5 @@ Report-producing retry marker.
 Canonical publication marker.
 
 Publication debug marker.
+
+Captured publication marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -23,3 +23,5 @@ Detailed cleanup marker.
 Manual redirect retry marker.
 
 User-agent retry marker.
+
+Passing command marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -33,3 +33,5 @@ Canonical publication marker.
 Publication debug marker.
 
 Captured publication marker.
+
+Publication cleanup retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -7,3 +7,5 @@ Live retry marker.
 Revocation retry marker.
 
 Bounded response retry marker.
+
+Post-deploy observation marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -43,3 +43,5 @@ Long publication observation marker.
 Publication detail marker.
 
 Idempotent publication marker.
+
+Final publication detail marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -19,3 +19,5 @@ Direct cleanup retry marker.
 No-cancel cleanup marker.
 
 Detailed cleanup marker.
+
+Manual redirect retry marker.

--- a/patchplane-trust-loop-fixture.md
+++ b/patchplane-trust-loop-fixture.md
@@ -13,3 +13,5 @@ Post-deploy observation marker.
 Error classification marker.
 
 Final response retry marker.
+
+Direct cleanup retry marker.


### PR DESCRIPTION
Temporary maintainer-controlled fixture for the PatchPlane hosted trust-loop smoke. It will be removed after acceptance evidence is collected.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a temporary maintainer-controlled Markdown fixture for PatchPlane hosted trust-loop acceptance testing.
- Introduces markers covering retry, cleanup, observation, reporting, and publication scenarios.
- Contains no application logic, configuration, links, or structured data.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| patchplane-trust-loop-fixture.md | Adds the temporary trust-loop smoke-test marker fixture described by the PR, with no actionable issue identified. |

</details>

<sub>Reviews (22): Last reviewed commit: ["test: capture final publication detail"](https://github.com/okikesolutions/guerillaglass/commit/b780267836e3c89ad6aef8516b70aaec58a9027a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49292596)</sub>

<!-- /greptile_comment -->